### PR TITLE
nix mingw issues for x86/amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,10 @@ CUSTOM_CFLAGS?=-Wall -ggdb3 -O3 -std=gnu99 -frename-registers -pthread -Wsign-co
 
 
 ifdef WIN
-	SYS_CFLAGS?=
+	# XXX printf %z all over the place annoys GNU cc -sh 20141003
+	SYS_CFLAGS?=-Wno-format
 	SYS_LDFLAGS?=-pthread
-	SYS_LIBS?=-lm -lws2_32 -lregex
+	SYS_LIBS?=-lm -lws2_32
 else
 ifdef MAC
 	SYS_CFLAGS?=-DNO_THREAD_LOCAL

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@
 # 	make MAC=1 DOUBLE=1
 
 
-# Do you compile on Windows instead of Linux? Please note that the
-# performance may not be optimal.
+# Do you compile on Windows instead of Linux?
 # (XXX: For now, only the mingw target is supported on Windows.
 # Patches for others are welcome!)
 

--- a/chat.c
+++ b/chat.c
@@ -2,8 +2,13 @@
 #include <math.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include <regex.h>
 #include <stdint.h>
+
+#if defined(__MINGW32__)
+#   include "regex-stubs.h"
+#else
+#   include <regex.h>
+#endif
 
 #define DEBUG
 

--- a/distributed/distributed.c
+++ b/distributed/distributed.c
@@ -200,12 +200,12 @@ distributed_notify(struct engine *e, struct board *b, int id, char *cmd, char *a
  * include contributions from other slaves. To avoid 32-bit overflow on
  * large configurations with many slaves we must average the playouts. */
 struct large_stats {
-	long playouts; // # of playouts
+	integral_s playouts; // # of playouts
 	floating_t value; // BLACK wins/playouts
 };
 
 static void
-large_stats_add_result(struct large_stats *s, floating_t result, long playouts)
+large_stats_add_result(struct large_stats *s, floating_t result, integral_s playouts)
 {
 	s->playouts += playouts;
 	s->value += (result - s->value) * playouts / s->playouts;
@@ -231,7 +231,7 @@ select_best_move(struct board *b, struct large_stats *stats, int *played,
 	memset(stats-2, 0, (board_size2(b)+2) * sizeof(*stats));
 
 	coord_t best_move = pass;
-	long best_playouts = 0;
+	integral_s best_playouts = 0;
 	*played = 0;
 	*total_playouts = 0;
 	*total_threads = 0;
@@ -254,7 +254,7 @@ select_best_move(struct board *b, struct large_stats *stats, int *played,
 			coord_t c = str2scoord(move, board_size(b));
 			assert (c >= resign && c < board_size2(b) && s.playouts >= 0);
 
-			large_stats_add_result(&stats[c], s.value, (long)s.playouts);
+			large_stats_add_result(&stats[c], s.value, s.playouts);
 
 			if (stats[c].playouts > best_playouts) {
 				best_playouts = stats[c].playouts;

--- a/distributed/distributed.c
+++ b/distributed/distributed.c
@@ -76,6 +76,8 @@
 
 #define DEBUG
 
+#include "distributed/protocol.h"
+
 #include "engine.h"
 #include "move.h"
 #include "timeinfo.h"

--- a/distributed/distributed.h
+++ b/distributed/distributed.h
@@ -27,10 +27,10 @@ typedef int64_t path_t;
 
 /* For debugging only */
 struct hash_counts {
-	long lookups;
-	long collisions;
-	long inserts;
-	long occupied;
+	integral_s lookups;
+	integral_s collisions;
+	integral_s inserts;
+	integral_s occupied;
 };
 
 /* Find a hash table entry given its coord path from root.

--- a/distributed/merge.c
+++ b/distributed/merge.c
@@ -11,9 +11,10 @@
 #define DEBUG
 
 #include "debug.h"
-#include "timeinfo.h"
+#include "distributed/protocol.h"
 #include "distributed/distributed.h"
 #include "distributed/merge.h"
+#include "timeinfo.h"
 
 /* We merge together debug stats for all hash tables. */
 static struct hash_counts h_counts;

--- a/distributed/protocol.c
+++ b/distributed/protocol.c
@@ -119,10 +119,10 @@ logline(struct in_addr *client, char *prefix, char *s)
 
 /* Thread opening a connection on the given socket and copying input
  * from there to stderr. */
-static void *
+static void * __attribute__((noreturn))
 proxy_thread(void *arg)
 {
-	int proxy_sock = (long)arg;
+	int proxy_sock = (int)(intptr_t)arg;
 	assert(proxy_sock >= 0);
 	for (;;) {
 		struct in_addr client;
@@ -500,11 +500,11 @@ is_pachi_slave(FILE *f, struct in_addr *client)
  * connection, to avoid wasting memory if max_slaves is too large.
  * We do not invalidate the received buffers if a slave disconnects;
  * they are still useful for other slaves. */
-static void *
+static void * __attribute__((noreturn))
 slave_thread(void *arg)
 {
 	struct slave_state sstate = default_sstate;
-	sstate.thread_id = (long)arg;
+	sstate.thread_id = (intptr_t)arg;
 
 	assert(sstate.slave_sock >= 0);
 	char reply_buf[CMDS_SIZE];
@@ -669,13 +669,13 @@ protocol_init(char *slave_port, char *proxy_port, int max_slaves)
 
 	pthread_t thread;
 	for (int id = 0; id < max_slaves; id++) {
-		pthread_create(&thread, NULL, slave_thread, (void *)(long)id);
+		pthread_create(&thread, NULL, slave_thread, (void *)(intptr_t)id);
 	}
 
 	if (proxy_port) {
 		int proxy_sock = port_listen(proxy_port, max_slaves);
 		for (int id = 0; id < max_slaves; id++) {
-			pthread_create(&thread, NULL, proxy_thread, (void *)(long)proxy_sock);
+			pthread_create(&thread, NULL, proxy_thread, (void *)(intptr_t)proxy_sock);
 		}
 	}
 }

--- a/distributed/protocol.c
+++ b/distributed/protocol.c
@@ -18,13 +18,13 @@
 
 #define DEBUG
 
+#include "distributed/protocol.h"
 #include "random.h"
 #include "timeinfo.h"
 #include "playout.h"
 #include "network.h"
 #include "debug.h"
 #include "distributed/distributed.h"
-#include "distributed/protocol.h"
 
 /* All gtp commands for current game separated by \n */
 static char gtp_cmds[CMDS_SIZE];

--- a/distributed/protocol.h
+++ b/distributed/protocol.h
@@ -36,7 +36,7 @@ struct buf_state {
 
 struct slave_state {
 	int max_buf_size;
-	int thread_id;
+	intptr_t thread_id;
 	struct in_addr client; // for debugging only
 	state_alloc_hook alloc_hook;
 	buffer_hook insert_hook;

--- a/network.c
+++ b/network.c
@@ -53,7 +53,7 @@ port_listen(char *port, int max_connections)
 	server_addr.sin_addr.s_addr = INADDR_ANY; 
 
 	const int val = 1;
-	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)))
+	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*) &val, sizeof(val)))
 		die("setsockopt");
 	if (bind(sock, (struct sockaddr *)&server_addr, sizeof(struct sockaddr)) == -1)
 		die("bind");

--- a/pachi.c
+++ b/pachi.c
@@ -191,6 +191,11 @@ int main(int argc, char *argv[])
 	char *e_arg = NULL;
 	if (optind < argc)
 		e_arg = argv[optind];
+        if (optind + 1 < argc)
+            fprintf(stderr,
+                    "warning: too many args, %d expected; first needless is %s\n"
+                    "info: separate engine params by commas, hyphen-prefixed ones go before\n",
+                    optind + 1, argv[optind+1]);
 	struct engine *e = init_engine(engine, e_arg, b);
 
 	if (testfile) {

--- a/pachi.c
+++ b/pachi.c
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
 		while (fgets(buf, 4096, stdin)) {
 			if (DEBUGL(1))
 				fprintf(stderr, "IN: %s", buf);
-
+			/* XXX uct assumes no genmove after game finished -sh 20141003 */
 			enum parse_code c = gtp_parse(b, e, ti, buf);
 			if (c == P_ENGINE_RESET) {
 				ti[S_BLACK] = ti_default;

--- a/pachi.c
+++ b/pachi.c
@@ -7,6 +7,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "network.h"
 #include "board.h"
 #include "debug.h"
 #include "engine.h"
@@ -24,7 +25,6 @@
 #include "timeinfo.h"
 #include "random.h"
 #include "version.h"
-#include "network.h"
 
 int debug_level = 3;
 bool debug_boardprint = true;

--- a/patternsp.c
+++ b/patternsp.c
@@ -359,7 +359,7 @@ spatial_dict_hashstats(struct spatial_dict *dict)
 	 * -e patternscan), since it will insert a pattern multiple times,
 	 * multiplying the reported number of collisions. */
 
-	unsigned long buckets = (sizeof(dict->hash) / sizeof(dict->hash[0]));
+	integral_u buckets = (sizeof(dict->hash) / sizeof(dict->hash[0]));
 	fprintf(stderr, "\t(Spatial dictionary hash: %d collisions (incl. repetitions), %.2f%% (%d/%lu) fill rate).\n",
 			dict->collisions,
 			(double) dict->fills * 100 / buckets,

--- a/regex-stubs.h
+++ b/regex-stubs.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <stdint.h> /* for size_t */
+
+typedef struct {} regex_t;
+typedef struct {} regmatch_t;
+
+#define REG_ESPACE (-((1 << 9) + 42))
+
+static inline int regcomp(regex_t *preg, const char *regex, int cflags)
+{
+    return REG_ESPACE;
+}
+
+static inline int regexec(const regex_t *preg, const char *string, size_t nmatch, regmatch_t pmatch[], int eflags)
+{
+    return REG_ESPACE;
+}
+
+#include <string.h>
+static inline size_t regerror(int errcode, const regex_t *preg, char *errbuf, size_t errbuf_size)
+{
+    if (errbuf_size)
+    {
+        errbuf[errbuf_size-1] = '\0';
+        strncpy(errbuf, "no regex support on this platform", errbuf_size-1);
+    }
+    return errbuf_size;
+}
+
+static inline void regfree(regex_t *preg) {}
+
+#   define REG_EXTENDED (-1)
+#   define REG_ICASE (-1)

--- a/tactics/selfatari.c
+++ b/tactics/selfatari.c
@@ -530,6 +530,7 @@ selfatari_cousin(struct board *b, enum stone color, coord_t coord, group_t *bygr
 				fprintf(stderr, "%s(%s) ", coord2sstr(c, b), stone2str(s));
 		}
 	});
+	assert(groups_n <= 4);
 	if (DEBUGL(6))
 		fprintf(stderr, "\n");
 

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -51,9 +51,9 @@ struct uct {
 	int force_seed;
 	bool no_tbook;
 	bool fast_alloc;
-	unsigned long max_tree_size;
-	unsigned long max_pruned_size;
-	unsigned long pruning_threshold;
+	integral_u max_tree_size;
+	integral_u max_pruned_size;
+	integral_u pruning_threshold;
 	int mercymin;
 	int significant_threshold;
 

--- a/uct/search.c
+++ b/uct/search.c
@@ -273,7 +273,7 @@ uct_search_progress(struct uct *u, struct board *b, enum stone color,
 		uct_progress_status(u, ctx->t, color, s->last_print, NULL);
 	}
 
-	if (!s->fullmem && ctx->t->nodes_size > u->max_tree_size) {
+	if (!s->fullmem && ctx->t->nodes_size > (integral_u)u->max_tree_size) {
 		if (UDEBUGL(2))
 			fprintf(stderr, "memory limit hit (%lu > %lu)\n",
 				ctx->t->nodes_size, u->max_tree_size);

--- a/uct/slave.c
+++ b/uct/slave.c
@@ -51,9 +51,9 @@
 
 /* For debugging only. */
 static struct hash_counts h_counts;
-static long parent_not_found = 0;
-static long parent_leaf = 0;
-static long node_not_found = 0;
+static integral_s parent_not_found = 0;
+static integral_s parent_leaf = 0;
+static integral_s node_not_found = 0;
 
 /* Hash table entry mapping path to node. */
 struct tree_hash {

--- a/uct/tree.h
+++ b/uct/tree.h
@@ -142,16 +142,16 @@ struct tree {
 
 	// Statistics
 	int max_depth;
-	volatile unsigned long nodes_size; // byte size of all allocated nodes
-	unsigned long max_tree_size; // maximum byte size for entire tree, > 0 only for fast_alloc
-	unsigned long max_pruned_size;
-	unsigned long pruning_threshold;
+	volatile integral_u nodes_size; // byte size of all allocated nodes
+	integral_u max_tree_size; // maximum byte size for entire tree, > 0 only for fast_alloc
+	integral_u max_pruned_size;
+	integral_u pruning_threshold;
 	void *nodes; // nodes buffer, only for fast_alloc
 };
 
 /* Warning: all functions below except tree_expand_node & tree_leaf_node are THREAD-UNSAFE! */
-struct tree *tree_init(struct board *board, enum stone color, unsigned long max_tree_size,
-		       unsigned long max_pruned_size, unsigned long pruning_threshold, floating_t ltree_aging, int hbits);
+struct tree *tree_init(struct board *board, enum stone color, integral_u max_tree_size,
+		       integral_u max_pruned_size, integral_u pruning_threshold, floating_t ltree_aging, int hbits);
 void tree_done(struct tree *tree);
 void tree_dump(struct tree *tree, double thres);
 void tree_save(struct tree *tree, struct board *b, int thres);

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -676,7 +676,7 @@ uct_state_init(char *arg, struct board *b)
 			if (optval) *optval++ = 0;
 
 			/** Basic options */
-
+			/* XXX make an offsetof+funptr table outta these -sh 20141003 */
 			if (!strcasecmp(optname, "debug")) {
 				if (optval)
 					u->debug_level = atoi(optval);

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -913,7 +913,7 @@ uct_state_init(char *arg, struct board *b)
 				/* Maximum amount of memory [MiB] consumed by the move tree.
 				 * For fast_alloc it includes the temp tree used for pruning.
 				 * Default is 3072 (3 GiB). */
-				u->max_tree_size = atol(optval) * 1048576;
+				u->max_tree_size = atol(optval) * (1ULL << 20);
 			} else if (!strcasecmp(optname, "fast_alloc")) {
 				u->fast_alloc = !optval || atoi(optval);
 			} else if (!strcasecmp(optname, "pruning_threshold") && optval) {

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -669,7 +669,7 @@ uct_state_init(char *arg, struct board *b)
 		while (*next) {
 			optspec = next;
 			next += strcspn(next, ",");
-			if (*next) { *next++ = 0; } else { *next = 0; }
+			if (*next) { *next++ = 0; }
 
 			char *optname = optspec;
 			char *optval = strchr(optspec, '=');

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -520,7 +520,7 @@ uct_playout(struct uct *u, struct board *b, enum stone player_color, struct tree
 		 * The size test must be before the test&set not after, to allow
 		 * expansion of the node later if enough nodes have been freed. */
 		if (tree_leaf_node(n)
-		    && n->u.playouts - u->virtual_loss >= u->expand_p && t->nodes_size < u->max_tree_size
+		    && n->u.playouts - u->virtual_loss >= u->expand_p && t->nodes_size < (integral_u)u->max_tree_size
 		    && !__sync_lock_test_and_set(&n->is_expanded, 1))
 			tree_expand_node(t, n, &b2, next_color, u, -parity);
 	}

--- a/util.h
+++ b/util.h
@@ -37,6 +37,11 @@ more_hay:;
 
 /* Misc. definitions. */
 
+/* used for value ranges that can overflow */
+#include <inttypes.h>
+typedef uintmax_t integral_u;
+typedef intmax_t integral_s;
+
 /* Use make DOUBLE=1 in large configurations with counts > 1M
  * where 24 bits of floating_t mantissa become insufficient. */
 #ifdef DOUBLE

--- a/util.h
+++ b/util.h
@@ -9,8 +9,10 @@
 #include <windows.h>
 
 #define sleep(seconds) Sleep((seconds) * 1000)
-#define __sync_fetch_and_add(ap, b) InterlockedExchangeAdd((LONG volatile *) (ap), (b));
-#define __sync_fetch_and_sub(ap, b) InterlockedExchangeAdd((LONG volatile *) (ap), -(b));
+#ifndef __GNUC__
+#   define __sync_fetch_and_add(ap, b) InterlockedExchangeAdd((LONG volatile *) (ap), (b));
+#   define __sync_fetch_and_sub(ap, b) InterlockedExchangeAdd((LONG volatile *) (ap), -(b));
+#endif
 
 /* MinGW gcc, no function prototype for built-in function stpcpy() */ 
 char *stpcpy (char *dest, const char *src);


### PR DESCRIPTION
Only lightly tested, as only output binary copied to target system, no units ran.

Sanity-checked as follows % { echo boardsize 19; while :; do echo genmove b; echo genmove w; done; } | nice -n 20 ./pachi-x86-64.exe -t 60 threads=8

note, despite messing with max tree size and time argument, couldn't get it to to consume more than 1.1 gigs worth of ram.