### PR TITLE
Improved random number generator for integers

### DIFF
--- a/random.c
+++ b/random.c
@@ -24,12 +24,9 @@ fast_getseed(void)
 uint16_t
 fast_random(unsigned int max)
 {
-	unsigned long hi, lo;
-	lo = 16807 * (pmseed & 0xffff);
-	hi = 16807 * (pmseed >> 16);
-	lo += (hi & 0x7fff) << 16;
-	lo += hi >> 15;
-	pmseed = (lo & 0x7fffffff) + (lo >> 31);
+	if(max < 2)
+		return 0;
+	pmseed = ((pmseed * 1103515245) + 12345) & 0x7fffffff;
 	return ((pmseed & 0xffff) * max) >> 16;
 }
 
@@ -74,13 +71,10 @@ fast_getseed(void)
 uint16_t
 fast_random(unsigned int max)
 {
-	unsigned long pmseed = (unsigned long)pthread_getspecific(seed_key);
-	unsigned long hi, lo;
-	lo = 16807 * (pmseed & 0xffff);
-	hi = 16807 * (pmseed >> 16);
-	lo += (hi & 0x7fff) << 16;
-	lo += hi >> 15;
-	pmseed = (lo & 0x7fffffff) + (lo >> 31);
+	unsigned long pmseed = (unsigned long)pthread_getspecific(seed_key)
+	if(max < 2)
+		return 0;
+	pmseed = ((pmseed * 1103515245) + 12345) & 0x7fffffff;
 	pthread_setspecific(seed_key, (void *)pmseed);
 	return ((pmseed & 0xffff) * max) >> 16;
 }


### PR DESCRIPTION
Replaced the previous two functions (single and multi threaded) with an
alternative LCG used in glibc's random. The floating point functions
were left as is. It should be ~45% faster now, same average/variance.

I tested several random number geneation functions for small ranges
typically used in computer Go. The standalone code is available at:
https://gist.github.com/gonmf/0ee67393182ef3173de7