### PR TITLE
is_bad_selfatari() fixes !

### DIFF
--- a/t-unit/sar.t
+++ b/t-unit/sar.t
@@ -16,6 +16,14 @@ XX.
 sar b c1 1
 sar w c1 0
 
+% 2 stones suicide check
+boardsize 3
+XX.
+O.X
+XXX
+sar w b2 1
+sar b b2 0
+
 % Almost-nakade
 boardsize 3
 OOO
@@ -36,6 +44,16 @@ XXX
 sar b b2 0
 sar w b2 0
 sar b a2 1
+sar w a2 1
+
+% Bulky-five
+boardsize 3
+OOO
+.X.
+XXX
+sar b c2 0
+sar w c2 1  # Makes bent 4, bad normally    (except in corner ... FIXME ?)
+sar b a2 0
 sar w a2 1
 
 % Rabbity six nakade 1
@@ -71,7 +89,17 @@ sar b b2 0
 sar w c3 1
 sar b c3 0
 
-% Weird three nakade
+% Triangle six lives
+boardsize 5
+OOOOO
+O..OO
+OXXOO
+OXXXO
+OOOOO
+sar b b4 1
+sar b c4 1
+
+% Seki destruction
 boardsize 4
 XXX.
 XOOO
@@ -94,6 +122,18 @@ sar w c3 0
 sar b c2 1
 sar w c2 1
 
+% Bulky five nakade (outside lib)
+boardsize 5
+XXXXX
+XOOXX
+XO.XX
+XX.XX
+XXXX.
+sar b c3 0
+sar w c3 0
+sar b c2 1
+sar w c2 1
+
 % Capture-from-within 2pt-eye nakade
 boardsize 3
 OOO
@@ -103,6 +143,25 @@ sar w b2 1
 sar b b2 0
 sar w c2 1
 sar b c2 0
+
+% Not Capture-from-within 2pt-eye nakade
+boardsize 4
+....
+.OOO
+.O..
+.OOO
+sar b c2 1
+sar b d2 1
+
+% Forbidden throw-in to get seki
+boardsize 5
+.XXX.
+XXOOO
+XOO..
+XOOOO
+XXXXX
+sar b d3 0	# Gosh, sometimes bad moves are good
+sar b e3 0
 
 % Capture-from-within 3pt-eye (straight) nakade
 boardsize 3
@@ -152,9 +211,9 @@ XO..X
 XXOXX
 XXXXX
 sar b c3 0
-sar w c3 1 # technically, this is 0, but since black is in atari, we misevaluate (it is ok!)
+sar w c3 0 
 sar b d3 1
-sar w d3 0 # captures!
+sar w d3 0	# Captures !
 
 % Multi-b-group nakade
 boardsize 5
@@ -164,11 +223,11 @@ XO.XX
 XX.XX
 ..XXX
 sar b c3 0
-sar w c3 1
+sar w c3 0
 sar b c2 0
 sar w c2 1
 sar b d5 0
-sar w d5 0 # throw-in
+sar w d5 0	# Throw-in
 sar b e4 0
 sar w e4 1
 sar b e5 0
@@ -196,9 +255,9 @@ OXXXO.
 O.XXO.
 OOOOO.
 sar b b4 0
-sar w b4 1
+sar w b4 0	# Have to allow this or we may never be able to kill that group
 sar b c5 0
-sar w c5 1
+sar w c5 0
 
 % Almost multi-b-group nakade (mirrored)
 boardsize 6
@@ -209,9 +268,9 @@ boardsize 6
 .OX.OX
 .OOXXX
 sar b d2 0
-sar w d2 1
+sar w d2 0
 sar b e3 0
-sar w e3 1
+sar w e3 0
 
 % Eyeshape-avoidance nakade 1
 boardsize 4
@@ -219,6 +278,15 @@ XXXX
 XO.X
 XX.X
 XXXX
+sar w c3 0
+sar w c2 1
+
+% Eyeshape-avoidance nakade 1 (outside lib)
+boardsize 4
+XXXX
+XO.X
+XX.X
+.XXX
 sar w c3 0
 sar w c2 1
 
@@ -230,6 +298,33 @@ XX.X
 XXXX
 sar w c3 0
 sar w c2 1
+
+% Eyeshape-avoidance nakade 2 (outside lib)
+boardsize 4
+XXXX
+XO.O
+XX.X
+.XXX
+sar w c3 0
+sar w c2 1
+
+% Eyeshape-avoidance nakade 3
+boardsize 4
+XXXX
+XO.O
+XXX.
+XXXX
+sar w c3 0
+sar w d2 1
+
+% Eyeshape-avoidance nakade 3 (outside lib)
+boardsize 4
+XXXX
+XO.O
+XXX.
+.XXX
+sar w c3 0
+sar w d2 1
 
 % False nakade
 boardsize 5
@@ -250,12 +345,12 @@ XXX.O
 XXX.O
 OOOXX
 OO...
-sar b b1 0
-sar w b1 1
-sar b c3 0
-sar w c3 1
-sar b c4 1
-sar w c4 1
+sar b c1 0
+sar w c1 1
+sar b d3 0
+sar w d3 1
+sar b d4 1
+sar w d4 0
 
 % Snapback
 boardsize 4
@@ -268,9 +363,9 @@ sar w a1 0
 sar b a3 1
 sar w a3 0
 sar b b3 0
-sar w b3 0
+sar w b3 0	# Snapback !
 sar b d4 0
-sar w d4 1
+sar w d4 0
 
 % Real game 1
 boardsize 9
@@ -285,3 +380,291 @@ XXXO..XXX
 XO..O...O
 sar w j8 1
 sar b j8 0
+
+% 3 stones sar nakade to dead shape (middle)
+boardsize 5
+XXXXX
+O.O.X
+XXXXX
+XXXXX
+XXXXX
+sar w b4 0	# Fill eye
+sar b b4 0	# Capture and live
+sar b d4 1   
+
+% 3 stones sar nakade to dead shape 
+boardsize 5
+XXXXX
+OO..X
+XXXXX
+XXXXX
+XXXXX
+sar w c4 0	# Fill eye
+sar b c4 0	# Capture and live
+sar b d4 1   
+
+% 3 stones sar nakade to dead shape (outside libs)
+boardsize 5
+XXXXX
+OO..X
+XXXXX
+.....
+.....
+sar w c4 0	# Fill eye
+sar w d4 1   
+
+% 2 stones sar nakade to dead shape 
+boardsize 4
+XXXX
+O..X
+XXXX
+XXXX
+sar w b3 0	# Fill eye
+sar b b3 0	# Capture and live
+sar b c3 1   
+
+% 2 stones sar nakade to dead shape (outside libs)
+boardsize 4
+XXXX
+O..X
+XXXX
+....
+sar w b3 0	# Fill eye
+
+
+% Bulky-five nakade (outside libs)
+boardsize 6
+XXXXXX
+OOOOXX
+..XOX.
+XXXOXX
+OOOOX.
+OO..XX
+sar b b4 0
+sar b a4 1
+
+% 4 stone nakade
+boardsize 4
+XOOO
+XX.X
+XX.X
+XXXX
+sar w c3 0
+sar w c2 1
+
+% 4 stone nakade (outside libs)
+boardsize 4
+XOOO
+XX.X
+.X.X
+.XXX
+sar w c3 0
+sar w c2 1
+
+% Connection
+boardsize 4
+.XOX
+O.OX
+OXXX
+XX..
+sar b b3 0
+sar w b3 1	# Connect and die
+
+% Bad self-atari (3 stones, connect first !)
+boardsize 5
+O.OO.
+OXXO.
+OX.X.
+OOXX.
+..XX.
+sar b b5 1
+
+% Bad self-atari (3 stones, can escape) 
+boardsize 5
+.OOO.
+.O.OO
+.OXXO
+.OX..
+.OO..
+sar b c4 1
+
+% Bad self-atari (4 stones, connect first !)
+boardsize 6
+OOO.O.
+OOOXOO
+OOOXOO
+.OOX.X
+..OOXX
+......
+sar b d6 1
+
+% Bad self-atari (connecting 4 stones, connect and die)
+boardsize 6
+OOOXO.
+OOO.OO
+OOOXOO
+.OOX.X
+..OOXX
+......
+sar b d5 1
+
+% Bad self-atari (5 stones, connect first !)
+boardsize 6
+OOOOO.
+OO.XOO
+OOXXXO
+.OOX.X
+..OOXX
+......
+sar b c5 1
+
+% Connect instead of self-atari !
+boardsize 5
+XXXO.
+X.O..
+XXXO.
+.OOO.
+.....
+sar w b4 1
+sar w d4 0
+
+% Bad self-atari (not taking away eyeshape and not atari)
+boardsize 4
+OO.X
+X.XX
+XXX.
+....
+sar w c4 1 
+
+% Not a nakade !  (threatening capture)
+boardsize 4
+X.OO
+XXOO
+O..X
+....
+sar b b4 1	# Can escape !
+sar w b4 1	# Can escape !
+
+% Not a nakade !  (threatening nothing)
+boardsize 4
+X.OO
+XXOO
+O...
+....
+sar b b4 1	# Can escape !
+
+% Not a nakade !  (threatening nothing)
+boardsize 5
+OOOOO
+OXOOO
+OX.OO
+OXXOO
+OO...
+sar b c3 1	# Can escape !
+
+
+% Corner nakade (shortage of libs)
+boardsize 4
+.OX.
+XO.X
+XOOO
+XXX.
+sar b c3 0
+sar b d4 0
+
+% Throw-in
+boardsize 5
+...X.
+OOOX.
+O..OO
+OOOX.
+...X.
+sar b c3 0
+sar b b3 1	# Silly
+
+% Throw-in making atari
+boardsize 7
+.......
+...XXXX
+OOOXOOO
+.X.OO.O
+OOOXOOO
+...XXXX
+.......
+sar b c4 0
+sar b a4 1      # silly
+
+% Throw-in making atari (outside group with libs)
+boardsize 7
+.X.OO.O
+OOOXXXO
+..XXX.O
+.X.X.OO
+...X.O.
+...X.OO
+....XX.
+sar b c7 0      # but cutting is good too ...
+sar b a7 1      # silly
+
+% Throw-in making atari with another group on the other side
+boardsize 5
+.X.OO
+OOOXO
+.XXXO
+.XOOO
+.XO.X
+sar b c5 0      
+sar b a5 1      # silly
+
+% 2 stones throw-ins
+boardsize 6
+OOOOX.
+O.X.O.
+OOOOXX
+.OX..X
+XOOOXX
+.X.O..
+
+sar b d5 0   # a) in check_throw_in_or_inside_capture()
+sar b d3 0   # b)
+sar b c1 1   # c) silly, connect first		 [ d) tested in Capture-from-within 3pt-eye (straight) nakade ]
+
+% Not a throw-in 
+boardsize 4
+....
+OO..
+XOOO
+.X.O
+sar b c1 1	# Captures 2 groups
+sar b a1 0
+
+% Side throw-in
+boardsize 5
+.OX..
+.O.O.
+.XOXX
+.XOX.
+..O..
+sar b c4 0
+
+% Side throw-in with outside stone
+boardsize 6
+.OX.X.
+.O.OOX
+.XOX..
+.XOXXX
+..O...
+......
+sar b c5 0
+sar b a6 1
+
+% Side throw-in with outside stone (continued)
+boardsize 6
+.O.OX.
+.O.OOX
+.XOX..
+.XOXXX
+..O...
+......
+sar b c5 0
+sar b c6 1

--- a/tactics/nakade.c
+++ b/tactics/nakade.c
@@ -9,20 +9,20 @@
 #include "tactics/nakade.h"
 
 
-coord_t
-nakade_point(struct board *b, coord_t around, enum stone color)
+static inline int
+nakade_area(struct board *b, coord_t around, enum stone color, coord_t *area)
 {
 	/* First, examine the nakade area. For sure, it must be at most
 	 * six points. And it must be within color group(s). */
 #define NAKADE_MAX 6
-	coord_t area[NAKADE_MAX]; int area_n = 0;
+	int area_n = 0;
 
 	area[area_n++] = around;
 
 	for (int i = 0; i < area_n; i++) {
 		foreach_neighbor(b, area[i], {
 			if (board_at(b, c) == stone_other(color))
-				return pass;
+				return -1;
 			if (board_at(b, c) == S_NONE) {
 				bool dup = false;
 				for (int j = 0; j < area_n; j++)
@@ -34,18 +34,23 @@ nakade_point(struct board *b, coord_t around, enum stone color)
 
 				if (area_n >= NAKADE_MAX) {
 					/* Too large nakade area. */
-					return pass;
+					return -1;
 				}
 				area[area_n++] = c;
 			}
 		});
 	}
 
+	return area_n;
+}
+
+static inline void
+get_neighbors(struct board *b, coord_t *area, int area_n, int *neighbors, int *ptbynei)
+{
 	/* We also collect adjecency information - how many neighbors
 	 * we have for each area point, and histogram of this. This helps
 	 * us verify the appropriate bulkiness of the shape. */
-	int neighbors[area_n]; int ptbynei[9] = {area_n, 0};
-	memset(neighbors, 0, sizeof(neighbors));
+        memset(neighbors, 0, area_n * sizeof(int));
 	for (int i = 0; i < area_n; i++) {
 		for (int j = i + 1; j < area_n; j++)
 			if (coord_is_adjecent(area[i], area[j], b)) {
@@ -57,7 +62,11 @@ nakade_point(struct board *b, coord_t around, enum stone color)
 				ptbynei[neighbors[j]]++;
 			}
 	}
+}
 
+static inline coord_t
+nakade_point_(coord_t *area, int area_n, int *neighbors, int *ptbynei)
+{
 	/* For each given neighbor count, arbitrary one coordinate
 	 * featuring that. */
 	coord_t coordbynei[9];
@@ -69,7 +78,7 @@ nakade_point(struct board *b, coord_t around, enum stone color)
 		case 2: return pass;
 		case 3: assert(ptbynei[2] == 1);
 			return coordbynei[2]; // middle point
-		case 4: if (ptbynei[3] != 1) return pass; // long line
+		case 4: if (ptbynei[3] != 1) return pass; // long line, L shape, or square
 			return coordbynei[3]; // tetris four
 		case 5: if (ptbynei[3] == 1 && ptbynei[1] == 1) return coordbynei[3]; // bulky five
 			if (ptbynei[4] == 1) return coordbynei[4]; // cross five
@@ -79,4 +88,40 @@ nakade_point(struct board *b, coord_t around, enum stone color)
 			return pass; // anything else
 		default: assert(0);
 	}
+}
+
+coord_t
+nakade_point(struct board *b, coord_t around, enum stone color)
+{
+	assert(board_at(b, around) == S_NONE);	
+	coord_t area[NAKADE_MAX]; int area_n = 0;
+	area_n = nakade_area(b, around, color, area);
+	if (area_n == -1)
+		return pass;
+
+	int neighbors[area_n]; int ptbynei[9] = {area_n, 0};
+	get_neighbors(b, area, area_n, neighbors, ptbynei);
+	
+	return nakade_point_(area, area_n, neighbors, ptbynei);
+}
+
+
+bool
+nakade_dead_shape(struct board *b, coord_t around, enum stone color)
+{
+	assert(board_at(b, around) == S_NONE);
+	coord_t area[NAKADE_MAX]; int area_n = 0;
+	area_n = nakade_area(b, around, color, area);
+	if (area_n == -1)	return false;
+	if (area_n <= 3)	return true;
+	
+	int neighbors[area_n]; int ptbynei[9] = {area_n, 0};
+	get_neighbors(b, area, area_n, neighbors, ptbynei);
+	
+	if (area_n == 4 && ptbynei[2] == 4)  // square 4
+		return true;
+	
+	/* nakade_point() should be able to deal with the rest ... */
+	coord_t nakade = nakade_point_(area, area_n, neighbors, ptbynei);
+	return  nakade != pass;
 }

--- a/tactics/nakade.h
+++ b/tactics/nakade.h
@@ -11,4 +11,7 @@
  * Returns pass if the area is not a nakade shape or not internal. */
 coord_t nakade_point(struct board *b, coord_t around, enum stone color);
 
+/* big eyespace can be reduced to one eye */
+bool nakade_dead_shape(struct board *b, coord_t around, enum stone color);
+
 #endif


### PR DESCRIPTION
Hi,

Following up on the life & death issue in moggy I thought I'd post
the result of my is_bad_selfatari() hacks.

So, initial motivation was to try and help with these situations:

    O X X * . O
    O O O O O O

Current is_bad_selfatari() logic says * is bad move unless white has no
outside libs, so the idea was to allow playing nakade first when created
shape is dead.

I came up with nakade_making_dead_shape() to decide the shapes. It's
accurate but expensive so I thought that was going to be slow, but turns
out when combined with the existing checks it's about as fast as before. I
guess it gets called rarely enough that it doesn't make a difference (!)

I ended up going through many of the code paths in
setup_nakade_or_snapback() and found a few issues as well. In one of them
it didn't check if it's possible to connect out instead, and that seems to
have contributed a fair amount of strange self-atariing in moggy. Looks
like it tended to make pachi squeeze oponent's stones into strange (but
safe !) shapes thinking there's a good chance he'll self-atari them =)
Maybe b center group in this one is a good example:
  http://files.gokgs.com/games/2015/12/22/pachipachi-fakioba.sgf

Number of unit tests in sar.t almost doubled, indeed many of the new ones
are just outside libs versions of the previous ones to test the new code
paths. Came across a 'forbidden throw-in to get seki' case that both
current & old code fail to address but that'll be for another day. In the
meantime comparing unit tests results across previous version is pretty
rewarding =)

I tentatively put moggy selfatarirate back to 95 although I don't know
what's the best value now. I doubt new code is perfect, but it should be
able to cope with something > 60. Will report impact on strength once I
figure out how to run automated playing tests. At any rate judging from
what pachi's doing on kgs atm it doesn't seem catastrophic ;)
