### PR TITLE
GoGui gfx analyze commands

### DIFF
--- a/engine.h
+++ b/engine.h
@@ -32,6 +32,8 @@ typedef void (*engine_done)(struct engine *e);
 
 /* GoGui hooks */
 typedef float (*engine_owner_map)(struct engine *e, struct board *b, coord_t c);
+typedef void (*engine_best_moves)(struct engine *e, struct board *b, enum stone color);
+typedef void (*engine_live_gfx_hook)(struct engine *e);
 
 /* This is engine data structure. A new engine instance is spawned
  * for each new game during the program lifetime. */
@@ -55,6 +57,8 @@ struct engine {
 	engine_stop stop;
 	engine_done done;
 	engine_owner_map owner_map;
+	engine_best_moves best_moves;
+	engine_live_gfx_hook live_gfx_hook;
 	void *data;
 };
 

--- a/engine.h
+++ b/engine.h
@@ -30,6 +30,9 @@ typedef void (*engine_stop)(struct engine *e);
 /* e->data and e will be free()d by caller afterwards. */
 typedef void (*engine_done)(struct engine *e);
 
+/* GoGui hooks */
+typedef float (*engine_owner_map)(struct engine *e, struct board *b, coord_t c);
+
 /* This is engine data structure. A new engine instance is spawned
  * for each new game during the program lifetime. */
 struct engine {
@@ -51,6 +54,7 @@ struct engine {
 	engine_dead_group_list dead_group_list;
 	engine_stop stop;
 	engine_done done;
+	engine_owner_map owner_map;
 	void *data;
 };
 

--- a/gogui.h
+++ b/gogui.h
@@ -1,0 +1,19 @@
+#ifndef PACHI_GOGUI_H
+#define PACHI_GOGUI_H
+
+/* How many candidates to display */
+#define GOGUI_CANDIDATES 5
+
+enum gogui_reporting {
+	UR_GOGUI_ZERO,
+	UR_GOGUI_CAN,
+	UR_GOGUI_SEQ,
+	UR_GOGUI_WR,
+};
+
+extern enum gogui_reporting gogui_live_gfx;
+
+extern char gogui_gfx_buf[];
+
+#endif
+

--- a/gtp.c
+++ b/gtp.c
@@ -689,6 +689,11 @@ next_group:;
 		next_tok(arg);
 		char *reply = gogui_best_moves(board, engine, arg, false);
 		gtp_reply(id, reply, NULL);
+	} else if (!strcasecmp(cmd, "gogui-winrates")) {
+		char *arg;
+		next_tok(arg);
+		char *reply = gogui_best_moves(board, engine, arg, true);
+		gtp_reply(id, reply, NULL);
 
 	} else {
 		gtp_error(id, "unknown command", NULL);

--- a/gtp.c
+++ b/gtp.c
@@ -680,6 +680,11 @@ next_group:;
 
 		gtp_reply(id, NULL);
 
+	} else if (!strcasecmp(cmd, "gogui-live_gfx")) {
+		char *arg;
+		next_tok(arg);
+		gogui_set_live_gfx(engine, arg);
+		gtp_reply(id, NULL);
 	} else if (!strcasecmp(cmd, "gogui-owner_map")) {
 		char reply[5000];
 		gogui_owner_map(board, engine, reply);

--- a/gtp.h
+++ b/gtp.h
@@ -16,7 +16,7 @@ enum parse_code {
 
 enum parse_code gtp_parse(struct board *b, struct engine *e, struct time_info *ti, char *buf);
 void gtp_reply(int id, ...);
-bool gtp_is_valid(const char *cmd);
+bool gtp_is_valid(struct engine *e, const char *cmd);
 
 #define is_gamestart(cmd) (!strcasecmp((cmd), "boardsize"))
 #define is_reset(cmd) (is_gamestart(cmd) || !strcasecmp((cmd), "clear_board") || !strcasecmp((cmd), "kgs-rules"))

--- a/ownermap.c
+++ b/ownermap.c
@@ -30,6 +30,16 @@ board_ownermap_merge(int bsize2, struct board_ownermap *dst, struct board_ownerm
 			dst->map[i][j] += src->map[i][j];
 }
 
+float
+board_ownermap_estimate_point(struct board_ownermap *ownermap, coord_t c)
+{
+	assert(ownermap->map);
+	int b = ownermap->map[c][S_BLACK];
+	int w = ownermap->map[c][S_WHITE];
+	int total = ownermap->playouts;
+	return 1.0 * (b - w) / total;
+}
+
 enum point_judgement
 board_ownermap_judge_point(struct board_ownermap *ownermap, coord_t c, floating_t thres)
 {

--- a/ownermap.h
+++ b/ownermap.h
@@ -29,6 +29,7 @@ enum point_judgement {
 	PJ_UNKNOWN = 3,
 };
 enum point_judgement board_ownermap_judge_point(struct board_ownermap *ownermap, coord_t c, floating_t thres);
+float board_ownermap_estimate_point(struct board_ownermap *ownermap, coord_t c);
 
 
 /* Estimate status of stones on board based on ownermap stats. */

--- a/uct/slave.c
+++ b/uct/slave.c
@@ -194,7 +194,7 @@ uct_notify(struct engine *e, struct board *b, int id, char *cmd, char *args, cha
 
 		*reply = buf;
 		/* Let gtp_parse() complain about invalid commands. */
-		if (!gtp_is_valid(cmd) && !is_repeated(cmd)) return P_OK;
+		if (!gtp_is_valid(e, cmd) && !is_repeated(cmd)) return P_OK;
 		return P_DONE_ERROR;
 	}
 	return reply_disabled(id) ? P_NOREPLY : P_OK;

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -157,6 +157,13 @@ uct_printhook_ownermap(struct board *board, coord_t c, char *s, char *end)
 	return s;
 }
 
+static float
+uct_owner_map(struct engine *e, struct board *b, coord_t c)
+{
+	struct uct *u = b->es;
+	return board_ownermap_estimate_point(&u->ownermap, c);
+}
+
 static char *
 uct_notify_play(struct engine *e, struct board *b, struct move *m, char *enginearg)
 {
@@ -1272,6 +1279,7 @@ engine_uct_init(char *arg, struct board *b)
 	e->dead_group_list = uct_dead_group_list;
 	e->stop = uct_stop;
 	e->done = uct_done;
+	e->owner_map = uct_owner_map;
 	e->data = u;
 	if (u->slave)
 		e->notify = uct_notify;

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -21,6 +21,7 @@
 #include "uct/tree.h"
 #include "uct/uct.h"
 #include "uct/walk.h"
+#include "gogui.h"
 
 #define DESCENT_DLEN 512
 
@@ -79,6 +80,46 @@ uct_progress_text(struct uct *u, struct tree *t, enum stone color, int playouts)
 	}
 
 	fprintf(stderr, "\n");
+}
+
+/* Display best moves graphically in GoGui.
+ * gfx commands printed on stderr are for live gfx,
+ * and the last run is kept in a buffer in case we need a gtp reply.
+ */
+static void
+uct_progress_gogui_candidates(struct uct *u, struct tree *t, enum stone color, int playouts)
+{
+	struct tree_node *best = t->root->children;
+	int cans = GOGUI_CANDIDATES;
+	struct tree_node *can[cans];
+	memset(can, 0, sizeof(can));
+	while (best) {
+		int c = 0;
+		while ((!can[c] || best->u.playouts > can[c]->u.playouts) && ++c < cans);
+		for (int d = 0; d < c; d++) can[d] = can[d + 1];
+		if (c > 0) can[c - 1] = best;
+		best = best->sibling;
+	}
+
+	fprintf(stderr, "gogui-gfx:\n");
+	char *buf = gogui_gfx_buf;
+	if (--cans >= 0)
+		if (can[cans]) {
+			sprintf(buf, "VAR %s %s\n", 
+				(color == S_WHITE ? "w" : "b"),
+				coord2sstr(node_coord(can[cans]), t->board) );
+			fprintf(stderr, "%s", buf);
+			buf += strlen(buf);
+		}
+	while (--cans >= 0)
+		if (can[cans]) {
+			sprintf(buf, "LABEL %s %i\n", 
+				coord2sstr(node_coord(can[cans]), t->board),
+				GOGUI_CANDIDATES - cans);
+			fprintf(stderr, "%s", buf);
+			buf += strlen(buf);
+		}
+	fprintf(stderr, "\n");	
 }
 
 void
@@ -183,8 +224,16 @@ uct_progress_status(struct uct *u, struct tree *t, enum stone color, int playout
 			break;
 		default: assert(0);
 	}
-}
 
+	if (!gogui_live_gfx)
+		return;
+	switch(gogui_live_gfx) {
+		case UR_GOGUI_CAN:
+			uct_progress_gogui_candidates(u, t, color, playouts);
+			break;
+		default: assert(0);
+	}
+}
 
 static inline void
 record_amaf_move(struct playout_amafmap *amaf, coord_t coord, bool is_ko_capture)


### PR DESCRIPTION
Hi,

I finally got to play with GoGui gfx commands. Here's what I got so far, hopefully i've hooked things in the right places.

This is heavily inspired from [michi-c2's](https://github.com/db3108/michi-c2/blob/master/doc/manual.rst) use of GoGui analyze commands.

Commands can be accessed from GoGui's analyze window. So far it supports:  
- Owner map
- Best moves
- Best sequence
- Best moves' winrates

Some of these can also be used as live gfx to see what's going on while pachi is thinking, have to admit this looks very very cool !
(GoGui must be able to see pachi's stderr for this to work)

Only uct engine is supported atm. I'll post some screenshots tomorrow.

Cheers