### PR TITLE
Configure Continuous Integration (Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+# http://docs.travis-ci.com/user/languages/c/
+# start from https://github.com/rubinius/rubinius/blob/master/.travis.yml
+language: c
+sudo: false
+
+compiler:
+  - clang
+  - gcc
+os:
+  - linux
+
+# https://blog.lukaspradel.com/continuous-integration-for-cmake-projects-using-travis-ci/  
+script:
+  - make -j2 && ./pachi -u t-unit/sar.t
+
+matrix:
+  allow_failures:
+    - compiler: clang 

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -51,7 +51,7 @@ board_load(struct board *b, FILE *f, unsigned int size)
 		board_print(b, stderr);
 }
 
-void
+bool
 test_sar(struct board *b, char *arg)
 {
 	enum stone color = str2stone(arg);
@@ -78,7 +78,7 @@ test_sar(struct board *b, char *arg)
 		}
 		printf("FAILED (%d)\n", rres);
 	}
-
+	return rres == eres;
 }
 
 void
@@ -89,6 +89,8 @@ unittest(char *filename)
 		perror(filename);
 		exit(EXIT_FAILURE);
 	}
+
+	bool passed = true;
 
 	struct board *b = board_init(NULL);
 	char line[256];
@@ -101,7 +103,7 @@ unittest(char *filename)
 		if (!strncmp(line, "boardsize ", 10)) {
 			board_load(b, f, atoi(line + 10));
 		} else if (!strncmp(line, "sar ", 4)) {
-			test_sar(b, line + 4);
+			passed = test_sar(b, line + 4) && passed; 
 		} else {
 			fprintf(stderr, "Syntax error: %s\n", line);
 			exit(EXIT_FAILURE);
@@ -109,4 +111,10 @@ unittest(char *filename)
 	}
 
 	fclose(f);
+        if (passed) {
+		printf("\nAll tests PASSED\n");
+        } else {
+		printf("\nSome tests FAILED\n");
+		exit(EXIT_FAILURE);
+        }
 }


### PR DESCRIPTION
To enable Travis (a free CI service provided by a German company), it is necessary to follow the guide at https://docs.travis-ci.com/user/getting-started/.

You can then link a build status image ([![Build Status](https://travis-ci.org/jirkadanek/pachi.svg?branch=master)](https://travis-ci.org/jirkadanek/pachi)) from the README or from somewhere else.