### PR TITLE
Feature for skipping tests

### DIFF
--- a/t-unit/sar.t
+++ b/t-unit/sar.t
@@ -190,7 +190,7 @@ O.X
 OOO
 sar w b3 1
 sar b b3 0
-% sar w b2 1 % this FAILS, see Issue #3 on GitHub
+sar w b2 1
 sar b b2 0
 
 % Eye falsification nakade

--- a/t-unit/sar.t
+++ b/t-unit/sar.t
@@ -160,8 +160,8 @@ XXOOO
 XOO..
 XOOOO
 XXXXX
-sar b d3 0	# Gosh, sometimes bad moves are good
-sar b e3 0
+! sar b d3 0	# Gosh, sometimes bad moves are good
+! sar b e3 0
 
 % Capture-from-within 3pt-eye (straight) nakade
 boardsize 3

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -90,6 +90,7 @@ unittest(char *filename)
 		exit(EXIT_FAILURE);
 	}
 
+	int skipped = 0;
 	bool passed = true;
 
 	struct board *b = board_init(NULL);
@@ -98,6 +99,7 @@ unittest(char *filename)
 		line[strlen(line) - 1] = 0; // chomp
 		switch (line[0]) {
 			case '%': printf("\n%s\n", line); continue;
+			case '!': printf("%s...\tSKIPPED\n", line); skipped++; continue;
 			case 0: continue;
 		}
 		if (!strncmp(line, "boardsize ", 10)) {
@@ -111,10 +113,14 @@ unittest(char *filename)
 	}
 
 	fclose(f);
-        if (passed) {
-		printf("\nAll tests PASSED\n");
-        } else {
-		printf("\nSome tests FAILED\n");
+ 	if (passed) {
+		printf("\nAll tests PASSED");
+	} else {
+		printf("\nSome tests FAILED");
 		exit(EXIT_FAILURE);
-        }
+	}
+	if (skipped > 0) {
+		printf(", %d test(s) SKIPPED", skipped);
+	}
+	printf("\n");
 }


### PR DESCRIPTION
Skipping tests is easy, even the error message I wrote about is easy. Adding a command line switch, something analogous to [--gtest_also_run_disabled_tests](https://github.com/google/googletest/blob/35fb11efbe1a2761ce923f49a9df1a430e5d16be/googletest/docs/V1_7_AdvancedGuide.md#temporarily-disabling-tests) option seems to be bigger deal (adding a new command line parameter) so I won't be doing that. (Unless we agree that really is what we want. @lemonsqueeze in PR #12 suggested prefixing broken tests with `xxx` and having a flag `----skip-broken`. I think `!` is better)