### PR TITLE
reduce cache contention by removing struct tree_node padding

### DIFF
--- a/stats.h
+++ b/stats.h
@@ -10,8 +10,8 @@
  * slightly wrong, but not drastically corrupted. */
 
 struct move_stats {
-	int playouts; // # of playouts
 	floating_t value; // BLACK wins/playouts
+	int playouts; // # of playouts
 };
 
 /* Add a result to the stats. */

--- a/uct/tree.c
+++ b/uct/tree.c
@@ -258,8 +258,8 @@ tree_node_save(FILE *f, struct tree_node *node, int thres)
 		node->is_expanded = 0;
 
 	fputc(1, f);
-	fwrite(((void *) node) + offsetof(struct tree_node, depth),
-	       sizeof(struct tree_node) - offsetof(struct tree_node, depth),
+	fwrite(((void *) node) + offsetof(struct tree_node, u),
+	       sizeof(struct tree_node) - offsetof(struct tree_node, u),
 	       1, f);
 
 	if (save_children) {
@@ -293,9 +293,9 @@ tree_node_load(FILE *f, struct tree_node *node, int *num)
 {
 	(*num)++;
 
-	fread(((void *) node) + offsetof(struct tree_node, depth),
-	       sizeof(struct tree_node) - offsetof(struct tree_node, depth),
-	       1, f);
+	fread(((void *) node) + offsetof(struct tree_node, u),
+	      sizeof(struct tree_node) - offsetof(struct tree_node, u),
+	      1, f);
 
 	/* Keep values in sane scale, otherwise we start overflowing. */
 #define MAX_PLAYOUTS	10000000

--- a/uct/tree.h
+++ b/uct/tree.h
@@ -60,31 +60,6 @@ struct tree_node {
 
 	/*** From here on, struct is saved/loaded from opening tbook */
 
-	unsigned short depth; // just for statistics
-
-	/* Common Fate Graph distance from parent, but at most TREE_NODE_D_MAX+1 */
-#define TREE_NODE_D_MAX 3
-	unsigned char d;
-
-#define TREE_HINT_INVALID 1 // don't go to this node, invalid move
-	unsigned char hints;
-
-	/* Number of parallel descents going through this node at the moment.
-	 * Used for virtual loss computation. */
-	signed char descents;
-
-	/* coord is usually coord_t, but this is very space-sensitive. */
-#define node_coord(n) ((int) (n)->coord)
-	short coord;
-
-	/* In case multiple threads walk the tree, is_expanded is set
-	 * atomically. Only the first thread setting it expands the node.
-	 * The node goes through 3 states:
-	 *   1) children == null, is_expanded == false: leaf node
-	 *   2) children == null, is_expanded == true: one thread currently expanding
-	 *   2) children != null, is_expanded == true: fully expanded node */
-	bool is_expanded;
-
 	struct move_stats u;
 	struct move_stats prior;
 	/* XXX: Should be way for policies to add their own stats */
@@ -95,6 +70,31 @@ struct tree_node {
 	 * of the tree coordinate corresponding to the node */
 	struct move_stats winner_owner; // owner == winner
 	struct move_stats black_owner; // owner == black
+
+	/* coord is usually coord_t, but this is very space-sensitive. */
+#define node_coord(n) ((int) (n)->coord)
+	short coord;
+
+	unsigned short depth; // just for statistics
+
+	/* Number of parallel descents going through this node at the moment.
+	* Used for virtual loss computation. */
+	signed char descents;
+
+	/* Common Fate Graph distance from parent, but at most TREE_NODE_D_MAX+1 */
+#define TREE_NODE_D_MAX 3
+	unsigned char d;
+
+#define TREE_HINT_INVALID 1 // don't go to this node, invalid move
+	unsigned char hints;
+
+	/* In case multiple threads walk the tree, is_expanded is set
+	* atomically. Only the first thread setting it expands the node.
+	* The node goes through 3 states:
+	*   1) children == null, is_expanded == false: leaf node
+	*   2) children == null, is_expanded == true: one thread currently expanding
+	*   2) children != null, is_expanded == true: fully expanded node */
+	bool is_expanded;
 };
 
 struct tree_hash;


### PR DESCRIPTION
Crude tests show around 10% gain in amount of evaluations done.