### PR TITLE
tree_expand_node(): check group suicides

### DIFF
--- a/uct/tree.c
+++ b/uct/tree.c
@@ -591,7 +591,7 @@ tree_expand_node(struct tree *t, struct tree_node *node, struct board *b, enum s
 	int child_count = 1; // for pass
 	foreach_free_point(b) {
 		assert(board_at(b, c) == S_NONE);
-		if (!board_is_valid_play(b, color, c))
+		if (!board_is_valid_play_no_suicide(b, color, c))
 			continue;
 		map.consider[c] = true;
 		child_count++;


### PR DESCRIPTION
Hi,

I ran into a situation where a group suicide gets into the tree and makes it crash in tree_expand_node() when it considers opponent playing the same move:

    assert(c != node_coord(node)); // I have spotted "C3 C3" in some sequence... 

Looks like it doesn't happen normally because of current prior code, but in this case i was playing with a different one which triggered it. Doing fine now with this board_is_valid_play_no_suicide()  check in tree_expand_node(). 

btw i was wondering, is the only reason group suicides are allowed in board.h that it's more expensive to check for them ?  (didn't change other board_is_valid_play() calls because of that)
