### PR TITLE
the C language doesn't allow for argument name omission

### DIFF
--- a/chat.c
+++ b/chat.c
@@ -124,7 +124,7 @@ char
 	return NULL;
 }
 #else
-void chat_init(char *) {}
+void chat_init(char *chat_file) {}
 
 void chat_done() {}
 


### PR DESCRIPTION
This fixes the case of missing regex.h on mingw-w64.

Too much C++ I guess.