### PR TITLE
t-unit + side ladder fixes

### DIFF
--- a/t-unit/ladder.t
+++ b/t-unit/ladder.t
@@ -1,0 +1,58 @@
+
+
+% Basic ladder
+boardsize 5
+. . . . .
+. . O . .
+. O X . .
+. . O O .
+. . . . .
+
+ladder b d3 1
+
+% Blocked ladder
+boardsize 7
+. . . . . . .
+. . . . . X .
+. . . . . . .
+. . O . . . .
+. O X . . . .
+. . O O . . .
+. . . . . . .
+
+ladder b d3 0
+
+
+% Side ladder
+boardsize 5
+. . . . .
+. O . . .
+. X O . .
+. O . . .
+. . . . .
+
+ladder b a3 1
+
+
+% Side ladder
+boardsize 4
+. . . .
+. O . .
+. X O .
+. O . .
+
+!ladder b a2 1       # Currently fails, probably no big deal (false negative)
+
+
+
+% False side ladder
+boardsize 7
+. . O . . . .
+. . O X X X X
+. O X O . . .
+. O X X O . .
+. X X O . . .
+. O O . . . .
+. . . . . . .
+
+ladder b a3 0        # Can be disastrous if this one fails (false positive !)

--- a/t-unit/sar.t
+++ b/t-unit/sar.t
@@ -1,8 +1,8 @@
 % Basic self-atari check
 boardsize 3
-XX.
-XXX
-XX.
+X X .
+X X X
+X X .
 sar b c1 1
 sar b c3 1
 sar w c1 1
@@ -10,25 +10,25 @@ sar w c3 1
 
 % Basic suicide check
 boardsize 3
-XXX
-XXX
-XX.
+X X X
+X X X
+X X .
 sar b c1 1
 sar w c1 0
 
 % 2 stones suicide check
 boardsize 3
-XX.
-O.X
-XXX
+X X .
+O . X
+X X X
 sar w b2 1
 sar b b2 0
 
 % Almost-nakade
 boardsize 3
-OOO
-..X
-XX.
+O O O
+. . X
+X X .
 sar b c1 0
 sar w c1 1
 sar b b2 0
@@ -38,9 +38,9 @@ sar w a2 1
 
 % Bulky-five / tetris-four nakade
 boardsize 3
-OOO
-..X
-XXX
+O O O
+. . X
+X X X
 sar b b2 0
 sar w b2 0
 sar b a2 1
@@ -48,9 +48,9 @@ sar w a2 1
 
 % Bulky-five
 boardsize 3
-OOO
-.X.
-XXX
+O O O
+. X .
+X X X
 sar b c2 0
 sar w c2 1  # Makes bent 4, bad normally    (except in corner ... FIXME ?)
 sar b a2 0
@@ -58,10 +58,10 @@ sar w a2 1
 
 % Rabbity six nakade 1
 boardsize 4
-XXOO
-.X.O
-OXOO
-OOOO
+X X O O
+. X . O
+O X O O
+O O O O
 sar w a3 1
 sar b a3 0
 sar w c3 1
@@ -69,10 +69,10 @@ sar b c3 1
 
 % Rabbity six nakade 2 - seki
 boardsize 4
-X.OO
-.XXO
-OXOO
-OOOO
+X . O O
+. X X O
+O X O O
+O O O O
 sar w a3 1
 sar b a3 1
 sar w b4 1
@@ -80,10 +80,10 @@ sar b b4 1
 
 % Rabbity six nakade 3
 boardsize 4
-XXOO
-XX.O
-O.OO
-OOOO
+X X O O
+X X . O
+O . O O
+O O O O
 sar w b2 1
 sar b b2 0
 sar w c3 1
@@ -91,20 +91,20 @@ sar b c3 0
 
 % Triangle six lives
 boardsize 5
-OOOOO
-O..OO
-OXXOO
-OXXXO
-OOOOO
+O O O O O
+O . . O O
+O X X O O
+O X X X O
+O O O O O
 sar b b4 1
 sar b c4 1
 
 % Seki destruction
 boardsize 4
-XXX.
-XOOO
-X.XX
-XXXX
+X X X .
+X O O O
+X . X X
+X X X X
 sar w b2 1
 sar b b2 1
 sar w d4 1
@@ -112,11 +112,11 @@ sar b d4 1
 
 % Bulky five nakade
 boardsize 5
-XXXXX
-XOOXX
-XO.XX
-XX.XX
-XXXXX
+X X X X X
+X O O X X
+X O . X X
+X X . X X
+X X X X X
 sar b c3 0
 sar w c3 0
 sar b c2 1
@@ -124,11 +124,11 @@ sar w c2 1
 
 % Bulky five nakade (outside lib)
 boardsize 5
-XXXXX
-XOOXX
-XO.XX
-XX.XX
-XXXX.
+X X X X X
+X O O X X
+X O . X X
+X X . X X
+X X X X .
 sar b c3 0
 sar w c3 0
 sar b c2 1
@@ -136,9 +136,9 @@ sar w c2 1
 
 % Capture-from-within 2pt-eye nakade
 boardsize 3
-OOO
-O..
-OOO
+O O O
+O . .
+O O O
 sar w b2 1
 sar b b2 0
 sar w c2 1
@@ -146,28 +146,28 @@ sar b c2 0
 
 % Not Capture-from-within 2pt-eye nakade
 boardsize 4
-....
-.OOO
-.O..
-.OOO
+. . . .
+. O O O
+. O . .
+. O O O
 sar b c2 1
 sar b d2 1
 
 % Forbidden throw-in to get seki
 boardsize 5
-.XXX.
-XXOOO
-XOO..
-XOOOO
-XXXXX
+. X X X .
+X X O O O
+X O O . .
+X O O O O
+X X X X X
 ! sar b d3 0	# Gosh, sometimes bad moves are good
 ! sar b e3 0
 
 % Capture-from-within 3pt-eye (straight) nakade
 boardsize 3
-OOO
-.X.
-OOO
+O O O
+. X .
+O O O
 sar w a2 1
 sar b a2 0
 sar w c2 1
@@ -175,9 +175,9 @@ sar b c2 0
 
 % Capture-from-within 3pt-eye (bent) nakade
 boardsize 3
-O.O
-OX.
-OOO
+O . O
+O X .
+O O O
 sar w b3 1
 sar b b3 0
 sar w c2 1
@@ -185,9 +185,9 @@ sar b c2 0
 
 % Capture-from-within 4pt-eye (square) nakade
 boardsize 3
-O.X
-O.X
-OOO
+O . X
+O . X
+O O O
 sar w b3 1
 sar b b3 0
 sar w b2 1
@@ -195,9 +195,9 @@ sar b b2 0
 
 % Eye falsification nakade
 boardsize 3
-OOO
-..X
-OOO
+O O O
+. . X
+O O O
 sar w a2 1
 sar b a2 1
 sar w b2 0
@@ -205,11 +205,11 @@ sar b b2 0
 
 % Bulky five multi-w-group nakade
 boardsize 5
-XXXXX
-XOOXX
-XO..X
-XXOXX
-XXXXX
+X X X X X
+X O O X X
+X O . . X
+X X O X X
+X X X X X
 sar b c3 0
 sar w c3 0 
 sar b d3 1
@@ -217,11 +217,11 @@ sar w d3 0	# Captures !
 
 % Multi-b-group nakade
 boardsize 5
-.XX..
-XOOX.
-XO.XX
-XX.XX
-..XXX
+. X X . .
+X O O X .
+X O . X X
+X X . X X
+. . X X X
 sar b c3 0
 sar w c3 0
 sar b c2 0
@@ -235,12 +235,12 @@ sar w e5 0
 
 % Real multi-b-group nakade
 boardsize 6
-XXXOO.
-XO.XO.
-X.OXO.
-OXXXO.
-OOXXO.
-OOOOO.
+X X X O O .
+X O . X O .
+X . O X O .
+O X X X O .
+O O X X O .
+O O O O O .
 sar b b4 1
 sar w b4 0
 sar b c5 1
@@ -248,12 +248,12 @@ sar w c5 0
 
 % Almost multi-b-group nakade
 boardsize 6
-XXXOO.
-XO.XO.
-X.OXO.
-OXXXO.
-O.XXO.
-OOOOO.
+X X X O O .
+X O . X O .
+X . O X O .
+O X X X O .
+O . X X O .
+O O O O O .
 sar b b4 0
 sar w b4 0	# Have to allow this or we may never be able to kill that group
 sar b c5 0
@@ -261,12 +261,12 @@ sar w c5 0
 
 % Almost multi-b-group nakade (mirrored)
 boardsize 6
-.OOOOO
-.OXX.O
-.OXXXO
-.OXO.X
-.OX.OX
-.OOXXX
+. O O O O O
+. O X X . O
+. O X X X O
+. O X O . X
+. O X . O X
+. O O X X X
 sar b d2 0
 sar w d2 0
 sar b e3 0
@@ -274,65 +274,65 @@ sar w e3 0
 
 % Eyeshape-avoidance nakade 1
 boardsize 4
-XXXX
-XO.X
-XX.X
-XXXX
+X X X X
+X O . X
+X X . X
+X X X X
 sar w c3 0
 sar w c2 1
 
 % Eyeshape-avoidance nakade 1 (outside lib)
 boardsize 4
-XXXX
-XO.X
-XX.X
-.XXX
+X X X X
+X O . X
+X X . X
+. X X X
 sar w c3 0
 sar w c2 1
 
 % Eyeshape-avoidance nakade 2
 boardsize 4
-XXXX
-XO.O
-XX.X
-XXXX
+X X X X
+X O . O
+X X . X
+X X X X
 sar w c3 0
 sar w c2 1
 
 % Eyeshape-avoidance nakade 2 (outside lib)
 boardsize 4
-XXXX
-XO.O
-XX.X
-.XXX
+X X X X
+X O . O
+X X . X
+. X X X
 sar w c3 0
 sar w c2 1
 
 % Eyeshape-avoidance nakade 3
 boardsize 4
-XXXX
-XO.O
-XXX.
-XXXX
+X X X X
+X O . O
+X X X .
+X X X X
 sar w c3 0
 sar w d2 1
 
 % Eyeshape-avoidance nakade 3 (outside lib)
 boardsize 4
-XXXX
-XO.O
-XXX.
-.XXX
+X X X X
+X O . O
+X X X .
+. X X X
 sar w c3 0
 sar w d2 1
 
 % False nakade
 boardsize 5
-X.XX.
-XOOXX
-XOOX.
-X.OXX
-XOOXX
+X . X X .
+X O O X X
+X O O X .
+X . O X X
+X O O X X
 sar w b2 1
 sar b b2 1
 sar w b5 1
@@ -340,11 +340,11 @@ sar b b5 0
 
 % Not-quite-snapback
 boardsize 5
-XXXXO
-XXX.O
-XXX.O
-OOOXX
-OO...
+X X X X O
+X X X . O
+X X X . O
+O O O X X
+O O . . .
 sar b c1 0
 sar w c1 1
 sar b d3 0
@@ -354,10 +354,10 @@ sar w d4 0
 
 % Snapback
 boardsize 4
-XXO.
-..X.
-OX..
-....
+X X O .
+. . X .
+O X . .
+. . . .
 sar b a1 1
 sar w a1 0
 sar b a3 1
@@ -369,261 +369,261 @@ sar w d4 0
 
 % Real game 1
 boardsize 9
-O.O..OXX.
-.O.O.OOX.
-OO..OOXXO
-XOOOOXOOO
-XXOXXXXXO
-.XOOOXXXX
-.XOXXX..X
-XXXO..XXX
-XO..O...O
+O . O . . O X X .
+. O . O . O O X .
+O O . . O O X X O
+X O O O O X O O O
+X X O X X X X X O
+. X O O O X X X X
+. X O X X X . . X
+X X X O . . X X X
+X O . . O . . . O
 sar w j8 1
 sar b j8 0
 
 % 3 stones sar nakade to dead shape (middle)
 boardsize 5
-XXXXX
-O.O.X
-XXXXX
-XXXXX
-XXXXX
+X X X X X
+O . O . X
+X X X X X
+X X X X X
+X X X X X
 sar w b4 0	# Fill eye
 sar b b4 0	# Capture and live
 sar b d4 1   
 
 % 3 stones sar nakade to dead shape 
 boardsize 5
-XXXXX
-OO..X
-XXXXX
-XXXXX
-XXXXX
+X X X X X
+O O . . X
+X X X X X
+X X X X X
+X X X X X
 sar w c4 0	# Fill eye
 sar b c4 0	# Capture and live
 sar b d4 1   
 
 % 3 stones sar nakade to dead shape (outside libs)
 boardsize 5
-XXXXX
-OO..X
-XXXXX
-.....
-.....
+X X X X X
+O O . . X
+X X X X X
+. . . . .
+. . . . .
 sar w c4 0	# Fill eye
 sar w d4 1   
 
 % 2 stones sar nakade to dead shape 
 boardsize 4
-XXXX
-O..X
-XXXX
-XXXX
+X X X X
+O . . X
+X X X X
+X X X X
 sar w b3 0	# Fill eye
 sar b b3 0	# Capture and live
 sar b c3 1   
 
 % 2 stones sar nakade to dead shape (outside libs)
 boardsize 4
-XXXX
-O..X
-XXXX
-....
+X X X X
+O . . X
+X X X X
+. . . .
 sar w b3 0	# Fill eye
 
 
 % Bulky-five nakade (outside libs)
 boardsize 6
-XXXXXX
-OOOOXX
-..XOX.
-XXXOXX
-OOOOX.
-OO..XX
+X X X X X X
+O O O O X X
+. . X O X .
+X X X O X X
+O O O O X .
+O O . . X X
 sar b b4 0
 sar b a4 1
 
 % 4 stone nakade
 boardsize 4
-XOOO
-XX.X
-XX.X
-XXXX
+X O O O
+X X . X
+X X . X
+X X X X
 sar w c3 0
 sar w c2 1
 
 % 4 stone nakade (outside libs)
 boardsize 4
-XOOO
-XX.X
-.X.X
-.XXX
+X O O O
+X X . X
+. X . X
+. X X X
 sar w c3 0
 sar w c2 1
 
 % Connection
 boardsize 4
-.XOX
-O.OX
-OXXX
-XX..
+. X O X
+O . O X
+O X X X
+X X . .
 sar b b3 0
 sar w b3 1	# Connect and die
 
 % Bad self-atari (3 stones, connect first !)
 boardsize 5
-O.OO.
-OXXO.
-OX.X.
-OOXX.
-..XX.
+O . O O .
+O X X O .
+O X . X .
+O O X X .
+. . X X .
 sar b b5 1
 
 % Bad self-atari (3 stones, can escape) 
 boardsize 5
-.OOO.
-.O.OO
-.OXXO
-.OX..
-.OO..
+. O O O .
+. O . O O
+. O X X O
+. O X . .
+. O O . .
 sar b c4 1
 
 % Bad self-atari (4 stones, connect first !)
 boardsize 6
-OOO.O.
-OOOXOO
-OOOXOO
-.OOX.X
-..OOXX
-......
+O O O . O .
+O O O X O O
+O O O X O O
+. O O X . X
+. . O O X X
+. . . . . .
 sar b d6 1
 
 % Bad self-atari (connecting 4 stones, connect and die)
 boardsize 6
-OOOXO.
-OOO.OO
-OOOXOO
-.OOX.X
-..OOXX
-......
+O O O X O .
+O O O . O O
+O O O X O O
+. O O X . X
+. . O O X X
+. . . . . .
 sar b d5 1
 
 % Bad self-atari (5 stones, connect first !)
 boardsize 6
-OOOOO.
-OO.XOO
-OOXXXO
-.OOX.X
-..OOXX
-......
+O O O O O .
+O O . X O O
+O O X X X O
+. O O X . X
+. . O O X X
+. . . . . .
 sar b c5 1
 
 % Connect instead of self-atari !
 boardsize 5
-XXXO.
-X.O..
-XXXO.
-.OOO.
-.....
+X X X O .
+X . O . .
+X X X O .
+. O O O .
+. . . . .
 sar w b4 1
 sar w d4 0
 
 % Bad self-atari (not taking away eyeshape and not atari)
 boardsize 4
-OO.X
-X.XX
-XXX.
-....
+O O . X
+X . X X
+X X X .
+. . . .
 sar w c4 1 
 
 % Not a nakade !  (threatening capture)
 boardsize 4
-X.OO
-XXOO
-O..X
-....
+X . O O
+X X O O
+O . . X
+. . . .
 sar b b4 1	# Can escape !
 sar w b4 1	# Can escape !
 
 % Not a nakade !  (threatening nothing)
 boardsize 4
-X.OO
-XXOO
-O...
-....
+X . O O
+X X O O
+O . . .
+. . . .
 sar b b4 1	# Can escape !
 
 % Not a nakade !  (threatening nothing)
 boardsize 5
-OOOOO
-OXOOO
-OX.OO
-OXXOO
-OO...
+O O O O O
+O X O O O
+O X . O O
+O X X O O
+O O . . .
 sar b c3 1	# Can escape !
 
 
 % Corner nakade (shortage of libs)
 boardsize 4
-.OX.
-XO.X
-XOOO
-XXX.
+. O X .
+X O . X
+X O O O
+X X X .
 sar b c3 0
 sar b d4 0
 
 % Throw-in
 boardsize 5
-...X.
-OOOX.
-O..OO
-OOOX.
-...X.
+. . . X .
+O O O X .
+O . . O O
+O O O X .
+. . . X .
 sar b c3 0
 sar b b3 1	# Silly
 
 % Throw-in making atari
 boardsize 7
-.......
-...XXXX
-OOOXOOO
-.X.OO.O
-OOOXOOO
-...XXXX
-.......
+. . . . . . .
+. . . X X X X
+O O O X O O O
+. X . O O . O
+O O O X O O O
+. . . X X X X
+. . . . . . .
 sar b c4 0
 sar b a4 1      # silly
 
 % Throw-in making atari (outside group with libs)
 boardsize 7
-.X.OO.O
-OOOXXXO
-..XXX.O
-.X.X.OO
-...X.O.
-...X.OO
-....XX.
+. X . O O . O
+O O O X X X O
+. . X X X . O
+. X . X . O O
+. . . X . O .
+. . . X . O O
+. . . . X X .
 sar b c7 0      # but cutting is good too ...
 sar b a7 1      # silly
 
 % Throw-in making atari with another group on the other side
 boardsize 5
-.X.OO
-OOOXO
-.XXXO
-.XOOO
-.XO.X
+. X . O O
+O O O X O
+. X X X O
+. X O O O
+. X O . X
 sar b c5 0      
 sar b a5 1      # silly
 
 % 2 stones throw-ins
 boardsize 6
-OOOOX.
-O.X.O.
-OOOOXX
-.OX..X
-XOOOXX
-.X.O..
+O O O O X .
+O . X . O .
+O O O O X X
+. O X . . X
+X O O O X X
+. X . O . .
 
 sar b d5 0   # a) in check_throw_in_or_inside_capture()
 sar b d3 0   # b)
@@ -631,40 +631,40 @@ sar b c1 1   # c) silly, connect first		 [ d) tested in Capture-from-within 3pt-
 
 % Not a throw-in 
 boardsize 4
-....
-OO..
-XOOO
-.X.O
+. . . .
+O O . .
+X O O O
+. X . O
 sar b c1 1	# Captures 2 groups
 sar b a1 0
 
 % Side throw-in
 boardsize 5
-.OX..
-.O.O.
-.XOXX
-.XOX.
-..O..
+. O X . .
+. O . O .
+. X O X X
+. X O X .
+. . O . .
 sar b c4 0
 
 % Side throw-in with outside stone
 boardsize 6
-.OX.X.
-.O.OOX
-.XOX..
-.XOXXX
-..O...
-......
+. O X . X .
+. O . O O X
+. X O X . .
+. X O X X X
+. . O . . .
+. . . . . .
 sar b c5 0
 sar b a6 1
 
 % Side throw-in with outside stone (continued)
 boardsize 6
-.O.OX.
-.O.OOX
-.XOX..
-.XOXXX
-..O...
-......
+. O . O X .
+. O . O O X
+. X O X . .
+. X O X X X
+. . O . . .
+. . . . . .
 sar b c5 0
 sar b c6 1

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -24,21 +24,26 @@ board_load(struct board *b, FILE *f, unsigned int size)
 			exit(EXIT_FAILURE);
 		}
 		line[strlen(line) - 1] = 0; // chomp
-		if (strlen(line) != size) {
-			fprintf(stderr, "Line not %d char long: %s\n", size, line);
+		if (strlen(line) != size * 2 - 1) {
+			fprintf(stderr, "Line not %d char long: %s\n", size * 2 - 1, line);
 			exit(EXIT_FAILURE);
 		}
-		for (unsigned int x = 0; x < size; x++) {
+		for (unsigned int i = 0; i < size * 2; i++) {
 			enum stone s;
-			switch (line[x]) {
+			switch (line[i]) {
 				case '.': s = S_NONE; break;
 				case 'X': s = S_BLACK; break;
 				case 'O': s = S_WHITE; break;
-				default: fprintf(stderr, "Invalid stone %c\n", line[x]);
+				default: fprintf(stderr, "Invalid stone '%c'\n", line[i]);
 					 exit(EXIT_FAILURE);
 			}
+			i++;
+			if (line[i] != ' ' && i/2 < size - 1) {
+				fprintf(stderr, "No space after stone %i: '%c'\n", i/2 + 1, line[i]);
+				exit(EXIT_FAILURE);
+			}
 			if (s == S_NONE) continue;
-			struct move m = { .color = s, .coord = coord_xy(b, x + 1, y + 1) };
+			struct move m = { .color = s, .coord = coord_xy(b, i/2 + 1, y + 1) };
 			if (board_play(b, &m) < 0) {
 				fprintf(stderr, "Failed to play %s %s\n",
 					stone2str(s), coord2sstr(m.coord, b));

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #include "board.h"
 #include "debug.h"
@@ -54,6 +55,8 @@ board_load(struct board *b, FILE *f, unsigned int size)
 	}
 	if (DEBUGL(2))
 		board_print(b, stderr);
+	int suicides = b->captures[S_BLACK] || b->captures[S_WHITE];
+	assert(!suicides);
 }
 
 bool
@@ -68,6 +71,7 @@ test_sar(struct board *b, char *arg)
 	if (DEBUGL(1))
 		printf("sar %s %s %d...\t", stone2str(color), coord2sstr(c, b), eres);
 
+	assert(board_at(b, c) == S_NONE);
 	int rres = is_bad_selfatari(b, color, c);
 
 	if (rres == eres) {

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -99,11 +99,13 @@ unittest(char *filename)
 		exit(EXIT_FAILURE);
 	}
 
+	int total = 0;
+	int passed = 0;
 	int skipped = 0;
-	bool passed = true;
-
+	
 	struct board *b = board_init(NULL);
 	char line[256];
+
 	while (fgets(line, sizeof(line), f)) {
 		line[strlen(line) - 1] = 0; // chomp
 		switch (line[0]) {
@@ -113,23 +115,28 @@ unittest(char *filename)
 		}
 		if (!strncmp(line, "boardsize ", 10)) {
 			board_load(b, f, atoi(line + 10));
-		} else if (!strncmp(line, "sar ", 4)) {
-			passed = test_sar(b, line + 4) && passed; 
-		} else {
+			continue;
+		}
+		
+		total++;
+		if (!strncmp(line, "sar ", 4))
+			passed += test_sar(b, line + 4); 
+		else {
 			fprintf(stderr, "Syntax error: %s\n", line);
 			exit(EXIT_FAILURE);
 		}
 	}
 
 	fclose(f);
- 	if (passed) {
+	
+	printf("\n\n----------- [  %i/%i tests passed (%i%%)  ] -----------\n\n", passed, total, passed * 100 / total);
+ 	if (total == passed)
 		printf("\nAll tests PASSED");
-	} else {
-		printf("\nSome tests FAILED");
+	else {
+		printf("\nSome tests FAILED\n");
 		exit(EXIT_FAILURE);
 	}
-	if (skipped > 0) {
+	if (skipped > 0)
 		printf(", %d test(s) SKIPPED", skipped);
-	}
 	printf("\n");
 }

--- a/t-unit/to_new_format
+++ b/t-unit/to_new_format
@@ -1,0 +1,12 @@
+#!/usr/bin/perl
+# Usage: to_new_format < sar.t
+# convert sar.t from old format to new format (spaces between stones)
+
+foreach my $str (<STDIN>)
+{
+    if ($str =~ m/^[.XO]+$/)
+    {   $str =~ s/([.XO])/$1 /g;  
+	$str =~ s/ $//;
+    }
+    print $str;
+}

--- a/tactics/ladder.c
+++ b/tactics/ladder.c
@@ -11,8 +11,11 @@
 
 
 bool
-is_border_ladder(struct board *b, coord_t coord, enum stone lcolor)
+is_border_ladder(struct board *b, coord_t coord, group_t laddered, enum stone lcolor)
 {
+	if (can_countercapture(b, lcolor, laddered, lcolor, NULL, 0))
+		return false;
+	
 	int x = coord_x(coord, b), y = coord_y(coord, b);
 
 	if (DEBUGL(5))

--- a/tactics/ladder.h
+++ b/tactics/ladder.h
@@ -17,8 +17,8 @@ static bool is_ladder(struct board *b, coord_t coord, group_t laddered, bool tes
 bool wouldbe_ladder(struct board *b, group_t group, coord_t escapelib, coord_t chaselib, enum stone lcolor);
 
 
-bool is_border_ladder(struct board *b, coord_t coord, enum stone lcolor);
-bool is_middle_ladder(struct board *b, coord_t coord, group_t group, enum stone lcolor);
+bool is_border_ladder(struct board *b, coord_t coord, group_t laddered, enum stone lcolor);
+bool is_middle_ladder(struct board *b, coord_t coord, group_t laddered, enum stone lcolor);
 static inline bool
 is_ladder(struct board *b, coord_t coord, group_t laddered, bool test_middle)
 {
@@ -32,7 +32,7 @@ is_ladder(struct board *b, coord_t coord, group_t laddered, bool test_middle)
 	 * of ladders we actually meet and want to play. */
 	if (neighbor_count_at(b, coord, S_OFFBOARD) == 1
 	    && neighbor_count_at(b, coord, lcolor) == 1) {
-		bool l = is_border_ladder(b, coord, lcolor);
+		bool l = is_border_ladder(b, coord, laddered, lcolor);
 		if (DEBUGL(6)) fprintf(stderr, "border ladder solution: %d\n", l);
 		return l;
 	}


### PR DESCRIPTION
Hi,

This one fixes a nasty side ladder issue that came up in a game, adds a ladder unit test (ladder.t) and some minor t-unit improvements : sanity checks, new board format with spaces (infinitely nicer to work with !) and displays some stats at the end.

There's a `t-unit/to_new_format` script to convert old sar.t files if needed.

The side ladder looked like this:

    . . O . . . .
    . . O X X X X
    . O X O . . .
    . O X X O . .
    . X X O . . .
    . O O . . . .
    . . . . . . .


