### PR TITLE
Prediction rates

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -78,6 +78,7 @@ Pachi consists of the following components:
 				functionality, mainly tactics
 	t-play/		interface for testing performance by playing games
 				against a fixed opponent (e.g. GNUGo)
+	t-predict/      test prediction rates of various components
 
 
 UCT architecture

--- a/dcnn.cpp
+++ b/dcnn.cpp
@@ -17,6 +17,8 @@ extern "C" {
 #include "debug.h"
 #include "board.h"
 #include "dcnn.h"
+#include "engine.h"
+#include "uct/tree.h"
 	
 	
 static shared_ptr<Net<float> > net;
@@ -116,7 +118,76 @@ dcnn_get_moves(struct board *b, enum stone color, float result[])
 	delete[] data;
 	delete blob;
 }
-	
 
+void
+find_dcnn_best_moves(struct board *b, float *r, coord_t *best, float *best_r)
+{
+	for (int i = 0; i < DCNN_BEST_N; i++)
+		best[i] = pass;
+
+	foreach_free_point(b) {
+		int k = (coord_x(c, b) - 1) * 19 + (coord_y(c, b) - 1);
+		for (int i = 0; i < DCNN_BEST_N; i++)
+			if (r[k] > best_r[i]) {
+				for (int j = DCNN_BEST_N - 1; j > i; j--) { // shift
+					best_r[j] = best_r[j - 1];
+					best[j] = best[j - 1];
+				}
+				best_r[i] = r[k];
+				best[i] = c;
+				break;
+			}
+	} foreach_free_point_end;
+}
+	
+void
+print_dcnn_best_moves(struct tree_node *node, struct board *b,
+		      coord_t *best, float *best_r)
+{
+	fprintf(stderr, "%.*sprior_dcnn(%s) = [ ",
+		node->depth * 4, "                                   ",
+		coord2sstr(node_coord(node), b));
+	for (int i = 0; i < DCNN_BEST_N; i++)
+		fprintf(stderr, "%s ", coord2sstr(best[i], b));
+	fprintf(stderr, "]      ");
+
+	fprintf(stderr, "[ ");
+	for (int i = 0; i < DCNN_BEST_N; i++)
+		fprintf(stderr, "%.2f ", best_r[i]);
+	fprintf(stderr, "]\n");
+}
+	
+static coord_t *
+dcnn_genmove(struct engine *e, struct board *b, struct time_info *ti, enum stone color, bool pass_all_alive)
+{
+	float r[19 * 19];
+	float best_r[DCNN_BEST_N] = { 0.0, };
+	coord_t best_moves[DCNN_BEST_N];
+	dcnn_get_moves(b, color, r);
+	find_dcnn_best_moves(b, r, best_moves, best_r);
+	
+	return coord_copy(best_moves[0]);
+}	
+
+struct engine *
+engine_dcnn_init(char *arg, struct board *b)
+{
+	dcnn_init();
+	if (!net) {
+		fprintf(stderr, "Couldn't initialize dcnn, aborting.\n");
+		abort();
+	}
+	//struct patternplay *pp = patternplay_state_init(arg);
+	struct engine *e = (engine*)calloc2(1, sizeof(struct engine));
+	e->name = (char*)"DCNN Engine";
+	e->comment = (char*)"I just select dcnn's best move.";
+	e->genmove = dcnn_genmove;
+	//e->evaluate = dcnn_evaluate;
+	//e->data = pp;
+
+	return e;
+}
+
+	
 } /* extern "C" */
 

--- a/dcnn.h
+++ b/dcnn.h
@@ -9,10 +9,15 @@ extern "C" {
 
 #ifdef DCNN
 
+#define DCNN_BEST_N 5
+
 void dcnn_get_moves(struct board *b, enum stone color, float result[]);
 bool using_dcnn(struct board *b);
 void dcnn_quiet_caffe(int argc, char *argv[]);
 void dcnn_init();
+void find_dcnn_best_moves(struct board *b, float *r, coord_t *best, float *best_r);
+void print_dcnn_best_moves(struct tree_node *node, struct board *b, coord_t *best, float *best_r);
+struct engine *engine_dcnn_init(char *arg, struct board *b);
 
 #else
 

--- a/montecarlo/internal.h
+++ b/montecarlo/internal.h
@@ -15,6 +15,7 @@ struct montecarlo {
 	int gamelen;
 	floating_t resign_ratio;
 	int loss_threshold;
+	struct joseki_dict *jdict;
 	struct playout_policy *playout;
 };
 

--- a/montecarlo/montecarlo.c
+++ b/montecarlo/montecarlo.c
@@ -204,6 +204,13 @@ move_found:
 	return coord_copy(top_coord);
 }
 
+static void
+montecarlo_done(struct engine *e)
+{
+	struct montecarlo *mc = e->data;
+	playout_policy_done(mc->playout);
+	joseki_done(mc->jdict);
+}
 
 struct montecarlo *
 montecarlo_state_init(char *arg, struct board *b)
@@ -212,6 +219,7 @@ montecarlo_state_init(char *arg, struct board *b)
 
 	mc->debug_level = 1;
 	mc->gamelen = MC_GAMELEN;
+	mc->jdict = joseki_load(b->size);
 
 	if (arg) {
 		char *optspec, *next = arg;
@@ -236,7 +244,7 @@ montecarlo_state_init(char *arg, struct board *b)
 				if (playoutarg)
 					*playoutarg++ = 0;
 				if (!strcasecmp(optval, "moggy")) {
-					mc->playout = playout_moggy_init(playoutarg, b, joseki_load(b->size));
+					mc->playout = playout_moggy_init(playoutarg, b, mc->jdict);
 				} else if (!strcasecmp(optval, "light")) {
 					mc->playout = playout_light_init(playoutarg, b);
 				} else {
@@ -267,6 +275,7 @@ engine_montecarlo_init(char *arg, struct board *b)
 	e->name = "MonteCarlo";
 	e->comment = "I'm playing in Monte Carlo. When we both pass, I will consider all the stones on the board alive. If you are reading this, write 'yes'. Please bear with me at the game end, I need to fill the whole board; if you help me, we will both be happier. Filling the board will not lose points (NZ rules).";
 	e->genmove = montecarlo_genmove;
+	e->done = montecarlo_done;
 	e->data = mc;
 
 	return e;

--- a/pachi.c
+++ b/pachi.c
@@ -25,6 +25,7 @@
 #include "random.h"
 #include "version.h"
 #include "network.h"
+#include "uct/tree.h"
 #include "dcnn.h"
 
 int debug_level = 3;
@@ -42,6 +43,9 @@ enum engine_id {
 	E_UCT,
 	E_DISTRIBUTED,
 	E_JOSEKI,
+#ifdef DCNN
+	E_DCNN,
+#endif
 	E_MAX,
 };
 
@@ -54,6 +58,9 @@ static struct engine *(*engine_init[E_MAX])(char *arg, struct board *b) = {
 	engine_uct_init,
 	engine_distributed_init,
 	engine_joseki_init,
+#ifdef DCNN
+	engine_dcnn_init,
+#endif
 };
 
 static struct engine *init_engine(enum engine_id engine, char *e_arg, struct board *b)
@@ -75,7 +82,7 @@ static void done_engine(struct engine *e)
 static void usage(char *name)
 {
 	fprintf(stderr, "Pachi version %s\n", PACHI_VERSION);
-	fprintf(stderr, "Usage: %s [-e random|replay|montecarlo|uct|distributed]\n"
+	fprintf(stderr, "Usage: %s [-e random|replay|montecarlo|uct|distributed|dcnn]\n"
 		" [-d DEBUG_LEVEL] [-D] [-r RULESET] [-s RANDOM_SEED] [-t TIME_SETTINGS] [-u TEST_FILENAME]\n"
 		" [-g [HOST:]GTP_PORT] [-l [HOST:]LOG_PORT] [-f FBOOKFILE] [ENGINE_ARGS]\n", name);
 }
@@ -117,6 +124,10 @@ int main(int argc, char *argv[])
 					engine = E_PATTERNPLAY;
 				} else if (!strcasecmp(optarg, "joseki")) {
 					engine = E_JOSEKI;
+#ifdef DCNN
+				} else if (!strcasecmp(optarg, "dcnn")) {
+					engine = E_DCNN;
+#endif
 				} else {
 					fprintf(stderr, "%s: Invalid -e argument %s\n", argv[0], optarg);
 					exit(1);

--- a/playout.c
+++ b/playout.c
@@ -163,3 +163,11 @@ play_random_game(struct playout_setup *setup,
 
 	return result;
 }
+
+void
+playout_policy_done(struct playout_policy *p)
+{
+	if (p->done) p->done(p);
+	if (p->data) free(p->data);
+	free(p);
+}

--- a/playout.h
+++ b/playout.h
@@ -111,4 +111,6 @@ coord_t play_random_move(struct playout_setup *setup,
 		         struct board *b, enum stone color,
 		         struct playout_policy *policy);
 
+void playout_policy_done(struct playout_policy *p);
+
 #endif

--- a/playout/moggy.c
+++ b/playout/moggy.c
@@ -530,7 +530,7 @@ eye_fix_check(struct playout_policy *p, struct board *b, struct move *m, enum st
 		mq_print(q, b, "Eye fix");
 }
 
-coord_t
+static coord_t
 fillboard_check(struct playout_policy *p, struct board *b)
 {
 	struct moggy_policy *pp = p->data;
@@ -553,7 +553,7 @@ next_try:
 	return pass;
 }
 
-coord_t
+static coord_t
 playout_moggy_seqchoose(struct playout_policy *p, struct playout_setup *s, struct board *b, enum stone to_play)
 {
 	struct moggy_policy *pp = p->data;
@@ -662,7 +662,7 @@ playout_moggy_seqchoose(struct playout_policy *p, struct playout_setup *s, struc
 
 /* Pick a move from queue q, giving different likelihoods to moves
  * based on their tags. */
-coord_t
+static coord_t
 mq_tagged_choose(struct playout_policy *p, struct board *b, enum stone to_play, struct move_queue *q)
 {
 	struct moggy_policy *pp = p->data;
@@ -718,7 +718,7 @@ mq_tagged_choose(struct playout_policy *p, struct board *b, enum stone to_play, 
 	return pass;
 }
 
-coord_t
+static coord_t
 playout_moggy_fullchoose(struct playout_policy *p, struct playout_setup *s, struct board *b, enum stone to_play)
 {
 	struct moggy_policy *pp = p->data;
@@ -806,7 +806,7 @@ playout_moggy_fullchoose(struct playout_policy *p, struct playout_setup *s, stru
 }
 
 
-void
+static void
 playout_moggy_assess_group(struct playout_policy *p, struct prior_map *map, group_t g, int games)
 {
 	struct moggy_policy *pp = p->data;
@@ -906,7 +906,7 @@ playout_moggy_assess_group(struct playout_policy *p, struct prior_map *map, grou
 	}
 }
 
-void
+static void
 playout_moggy_assess_one(struct playout_policy *p, struct prior_map *map, coord_t coord, int games)
 {
 	struct moggy_policy *pp = p->data;
@@ -951,7 +951,7 @@ playout_moggy_assess_one(struct playout_policy *p, struct prior_map *map, coord_
 	return;
 }
 
-void
+static void
 playout_moggy_assess(struct playout_policy *p, struct prior_map *map, int games)
 {
 	struct moggy_policy *pp = p->data;
@@ -970,7 +970,7 @@ playout_moggy_assess(struct playout_policy *p, struct prior_map *map, int games)
 	} foreach_free_point_end;
 }
 
-bool
+static bool
 playout_moggy_permit(struct playout_policy *p, struct board *b, struct move *m)
 {
 	struct moggy_policy *pp = p->data;
@@ -1044,7 +1044,6 @@ eyefill_skip:
 	return true;
 }
 
-
 struct playout_policy *
 playout_moggy_init(char *arg, struct board *b, struct joseki_dict *jdict)
 {
@@ -1054,6 +1053,7 @@ playout_moggy_init(char *arg, struct board *b, struct joseki_dict *jdict)
 	p->choose = playout_moggy_seqchoose;
 	p->assess = playout_moggy_assess;
 	p->permit = playout_moggy_permit;
+	/* no p->done: calling engine owns jdict and should call joseki_done() */
 
 	pp->jdict = jdict;
 

--- a/t-predict/README
+++ b/t-predict/README
@@ -1,0 +1,22 @@
+[ Test prediction rate of various Pachi components ]
+
+Choose engine to test with:
+
+   $ predict -e [patternplay|replay|dcnn] [pachi_args]
+
+and the script will make it try to predict moves from game records.
+
+Note: To change replay's speed/accuracy, adjust sampling:
+
+   $ predict -e replay runs=n
+
+
+[ Setup ]
+
+Place sgf files to use in a t-predict/sgf directory (symlink ok too)
+and convert them to gtp first (see tools/sgf2gtp*).
+(script will be reading t-predict/sgf/*.gtp)
+
+For game collections see:
+  http://www.u-go.net/gamerecords/        (KGS 6d+ games)
+  http://senseis.xmp.net/?GoDatabases

--- a/t-predict/predict
+++ b/t-predict/predict
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Test prediction rate of various Pachi components on game records
+
+die()
+{ echo "$@"; exit 1; }
+
+usage()
+{  die "Usage: predict -e [patternplay|replay|dcnn] [pachi_args]";  }
+
+cd  `dirname $0`
+[ "$1" = "-e" ] || usage
+[ -d sgf ] || die "Please setup 't-predict/sgf/' directory first"
+
+# Ensure pachi args are sane
+( cd .. ; ./pachi -d 0 "$@" < /dev/null ) || exit 1
+
+echo "Prediction rate for $2 (even games):"
+for f in sgf/*.gtp; do
+    if ! grep -q handicap "$f"; then
+	cat "$f" | sed -e 's/^play /pachi-predict /'
+    fi
+done |
+( cd .. ; ./pachi -d 0 "$@" 2>&1 | grep Predicted )
+

--- a/tools/moggy_games
+++ b/tools/moggy_games
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Moggy text-mode screensaver =)
+# Adjust speed by giving it an extra runs=n argument.
+
+cd `dirname $0`
+while true ; do
+    echo boardsize 9 ; echo clear_board
+    for f in `seq 1 70` ; do
+	echo genmove b ; echo genmove w;  
+    done
+done  |
+  (cd ..; ./pachi -e replay "$@")
+

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -295,14 +295,6 @@ uct_dead_group_list(struct engine *e, struct board *b, struct move_queue *mq)
 }
 
 static void
-playout_policy_done(struct playout_policy *p)
-{
-	if (p->done) p->done(p);
-	if (p->data) free(p->data);
-	free(p);
-}
-
-static void
 uct_stop(struct engine *e)
 {
 	/* This is called on game over notification. However, an undo

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -13,7 +13,6 @@
 #include "chat.h"
 #include "move.h"
 #include "mq.h"
-#include "dcnn.h"
 #include "joseki/base.h"
 #include "playout.h"
 #include "playout/moggy.h"
@@ -29,6 +28,7 @@
 #include "uct/tree.h"
 #include "uct/uct.h"
 #include "uct/walk.h"
+#include "dcnn.h"
 
 struct uct_policy *policy_ucb1_init(struct uct *u, char *arg);
 struct uct_policy *policy_ucb1amaf_init(struct uct *u, char *arg, struct board *board);


### PR DESCRIPTION
Hi, here's my branch to check prediction rates:

I added a dcnn engine (just plays best move) and made replay sample a number of moggy runs by default. There's a `t-predict/` directory for testing prediction rates.

To run the tests convert sgf files to gtp first and create a `t-predict/sgf` symlink to the game collection, then:

    $ t-predict/predict -e [dcnn|patternplay|replay]

When i feel brave enough i might add cumulative stats on n best moves...
