### PR TITLE
Msys fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tags
 book.dat
 patterns.prob
 patterns.spat
+pachi.exe

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Uncomment one of the options below to change the way Pachi is built.
 # Alternatively, you can pass the option to make itself, like:
-# 	make MAC=1 DOUBLE=1
+# 	make MAC=1 DOUBLE_TIME=1
 
 
 # Do you compile on Windows instead of Linux? Please note that the
@@ -31,7 +31,7 @@
 # e.g. with extremely long thinking times or massive parallelization;
 # 24 bits of floating_t mantissa become insufficient then.
 
-# DOUBLE=1
+# DOUBLE_TIME=1
 
 # Enable performance profiling using gprof. Note that this also disables
 # inlining, which allows more fine-grained profile, but may also distort
@@ -97,8 +97,8 @@ ifdef DCNN
 	SYS_LIBS:=-lcaffe -lboost_system -lstdc++ $(SYS_LIBS)
 endif
 
-ifdef DOUBLE
-	CUSTOM_CFLAGS+=-DDOUBLE
+ifdef DOUBLE_TIME
+	CUSTOM_CFLAGS+=-DDOUBLE_TIME
 endif
 
 ifeq ($(PROFILING), gprof)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Uncomment one of the options below to change the way Pachi is built.
 # Alternatively, you can pass the option to make itself, like:
-# 	make MAC=1 DOUBLE_TIME=1
+# 	make MAC=1 DOUBLE_FLOATING=1
 
 
 # Do you compile on Windows instead of Linux? Please note that the
@@ -35,7 +35,7 @@
 # e.g. with extremely long thinking times or massive parallelization;
 # 24 bits of floating_t mantissa become insufficient then.
 
-# DOUBLE_TIME=1
+# DOUBLE_FLOATING=1
 
 # Enable performance profiling using gprof. Note that this also disables
 # inlining, which allows more fine-grained profile, but may also distort
@@ -70,7 +70,7 @@ CUSTOM_CXXFLAGS?=-Wall -ggdb3 -O3
 ifdef MSYS2_64
 	WIN=1
 	WIN_HAVE_NO_REGEX_SUPPORT=1
-	DOUBLE_TIME=1
+	DOUBLE_FLOATING=1
 endif
 
 ifdef WIN
@@ -106,8 +106,8 @@ ifdef DCNN
 	SYS_LIBS:=-lcaffe -lboost_system -lstdc++ $(SYS_LIBS)
 endif
 
-ifdef DOUBLE_TIME
-	CUSTOM_CFLAGS+=-DDOUBLE_TIME
+ifdef DOUBLE_FLOATING
+	CUSTOM_CFLAGS+=-DDOUBLE_FLOATING
 endif
 
 ifeq ($(PROFILING), gprof)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@
 
 # WIN=1
 
+# To compile 64-bit version in msys2 with mingw64, uncomment the
+# following line
+# MSYS2_64=1
+
 # Do you compile on MacOS/X instead of Linux? Please note that the
 # performance may not be optimal.
 # (XXX: We are looking for volunteers contributing support for other
@@ -63,6 +67,11 @@ CUSTOM_CXXFLAGS?=-Wall -ggdb3 -O3
 
 ### CONFIGURATION END
 
+ifdef MSYS2_64
+	WIN=1
+	WIN_HAVE_NO_REGEX_SUPPORT=1
+	DOUBLE_TIME=1
+endif
 
 ifdef WIN
 	SYS_CFLAGS?=

--- a/util.h
+++ b/util.h
@@ -43,9 +43,9 @@ more_hay:;
 
 /* Misc. definitions. */
 
-/* Use make DOUBLE=1 in large configurations with counts > 1M
+/* Use make DOUBLE_TIME=1 in large configurations with counts > 1M
  * where 24 bits of floating_t mantissa become insufficient. */
-#ifdef DOUBLE
+#ifdef DOUBLE_TIME
 #  define floating_t double
 #  define PRIfloating "%lf"
 #else

--- a/util.h
+++ b/util.h
@@ -43,9 +43,9 @@ more_hay:;
 
 /* Misc. definitions. */
 
-/* Use make DOUBLE_TIME=1 in large configurations with counts > 1M
+/* Use make DOUBLE_FLOATING=1 in large configurations with counts > 1M
  * where 24 bits of floating_t mantissa become insufficient. */
-#ifdef DOUBLE_TIME
+#ifdef DOUBLE_FLOATING
 #  define floating_t double
 #  define PRIfloating "%lf"
 #else


### PR DESCRIPTION
Changes to allow pachi to be compiled using mingw64 in msys2 environment. The gist of it is changing "DOUBLE" to "DOUBLE_TIME" since the former breaks compilation (conflicts with some system headers?)