### PR TITLE
Seki !

### DIFF
--- a/board.c
+++ b/board.c
@@ -225,6 +225,7 @@ board_copy(struct board *b2, struct board *b1)
 
 	// XXX: Special semantics.
 	b2->fbook = NULL;
+	b2->ps = NULL;
 
 	return b2;
 }
@@ -234,6 +235,7 @@ board_done_noalloc(struct board *board)
 {
 	if (board->b) free(board->b);
 	if (board->fbook) fbook_done(board->fbook);
+	if (board->ps) free(board->ps);
 }
 
 void

--- a/board.c
+++ b/board.c
@@ -1870,6 +1870,15 @@ int board_undo(struct board *board)
 	return 0;
 }
 
+bool
+board_permit(struct board *b, struct move *m, void *data)
+{
+	if (unlikely(board_is_one_point_eye(b, m->coord, m->color)) /* bad idea to play into one, usually */
+	    || !board_is_valid_move(b, m))
+		return false;
+	return true;
+}
+
 static inline bool
 board_try_random_move(struct board *b, enum stone color, coord_t *coord, int f, ppr_permit permit, void *permit_data)
 {
@@ -1877,9 +1886,8 @@ board_try_random_move(struct board *b, enum stone color, coord_t *coord, int f, 
 	struct move m = { *coord, color };
 	if (DEBUGL(6))
 		fprintf(stderr, "trying random move %d: %d,%d %s %d\n", f, coord_x(*coord, b), coord_y(*coord, b), coord2sstr(*coord, b), board_is_valid_move(b, &m));
-	if (unlikely(board_is_one_point_eye(b, *coord, color)) /* bad idea to play into one, usually */
-		|| !board_is_valid_move(b, &m)
-		|| (permit && !permit(permit_data, b, &m)))
+	permit = (permit ? permit : board_permit);
+	if (!permit(b, &m, permit_data))
 		return false;
 	if (m.coord == *coord) {
 		return likely(board_play_f(b, &m, f, NULL) >= 0);

--- a/board.h
+++ b/board.h
@@ -262,8 +262,7 @@ FB_ONLY(int last_ko_age);
 	void *es;
 
 	/* Playout-specific state; persistent through board development,
-	 * but its lifetime is maintained in play_random_game(); it should
-	 * not be set outside of it. */
+	 * initialized by play_random_game() and free()'d at board destroy time */
 	void *ps;
 
 

--- a/board.h
+++ b/board.h
@@ -401,7 +401,8 @@ int board_play(struct board *board, struct move *m);
  * when no move can be played. You can impose extra restrictions if you
  * supply your own permit function; the permit function can also modify
  * the move coordinate to redirect the move elsewhere. */
-typedef bool (*ppr_permit)(void *data, struct board *b, struct move *m);
+typedef bool (*ppr_permit)(struct board *b, struct move *m, void *data);
+bool board_permit(struct board *b, struct move *m, void *data);
 void board_play_random(struct board *b, enum stone color, coord_t *coord, ppr_permit permit, void *permit_data);
 
 /* Undo, supported only for pass moves. Returns -1 on error, 0 otherwise. */

--- a/playout.c
+++ b/playout.c
@@ -197,9 +197,6 @@ play_random_game(struct playout_setup *setup,
 	if (ownermap)
 		board_ownermap_fill(ownermap, b);
 
-	if (b->ps)
-		free(b->ps);
-
 #ifdef DEBUGL_BY_PLAYOUT
 	debug_level = debug_level_orig;
 #endif

--- a/playout.c
+++ b/playout.c
@@ -21,13 +21,55 @@
 #define PLDEBUGL(n) DEBUGL_(policy->debug_level, n)
 
 
+/* Full permit logic, ie m->coord may get changed to an alternative move */
+static bool
+playout_permit_move(struct playout_policy *p, struct board *b, struct move *m, bool alt)
+{	
+	coord_t coord = m->coord;
+	if (coord == pass || coord == resign)
+		return false;
+
+	if (!board_permit(b, m, NULL) ||
+	    (p->permit && !p->permit(p, b, m, alt)))
+		return false;
+
+	return true;
+}
+
+/* Return coord if move is ok, an alternative move or pass if not */
+static coord_t
+playout_check_move(struct playout_policy *p, struct board *b, coord_t coord, enum stone color)
+{
+	struct move m = { .coord = coord, .color = color };
+	if (!playout_permit_move(p, b, &m, 1))
+		return pass;
+	return m.coord;
+}
+
+/* Is *this* move permitted ? 
+ * Called by policy permit() to check something so never the main permit() call. */
+bool
+playout_permit(struct playout_policy *p, struct board *b, coord_t coord, enum stone color)
+{
+	struct move m = { .coord = coord, .color = color };
+	return playout_permit_move(p, b, &m, 0);
+}
+
+static bool
+permit_handler(struct board *b, struct move *m, void *data)
+{
+	struct playout_policy *policy = data;
+	return playout_permit_move(policy, b, m, 1);
+}
+
+
 coord_t
 play_random_move(struct playout_setup *setup,
 		 struct board *b, enum stone color,
 		 struct playout_policy *policy)
 {
 	coord_t coord = pass;
-
+	
 	if (setup->prepolicy_hook) {
 		coord = setup->prepolicy_hook(policy, setup, b, color);
 		// fprintf(stderr, "prehook: %s\n", coord2sstr(coord, b));
@@ -35,6 +77,7 @@ play_random_move(struct playout_setup *setup,
 
 	if (is_pass(coord)) {
 		coord = policy->choose(policy, setup, b, color);
+		coord = playout_check_move(policy, b, coord, color);
 		// fprintf(stderr, "policy: %s\n", coord2sstr(coord, b));
 	}
 
@@ -44,12 +87,12 @@ play_random_move(struct playout_setup *setup,
 	}
 
 	if (is_pass(coord)) {
-play_random:
+	play_random:
 		/* Defer to uniformly random move choice. */
 		/* This must never happen if the policy is tracking
 		 * internal board state, obviously. */
 		assert(!policy->setboard || policy->setboard_randomok);
-		board_play_random(b, color, &coord, (ppr_permit) policy->permit, policy);
+		board_play_random(b, color, &coord, permit_handler, policy);
 
 	} else {
 		struct move m;
@@ -164,6 +207,7 @@ play_random_game(struct playout_setup *setup,
 	return result;
 }
 
+
 void
 playout_policy_done(struct playout_policy *p)
 {
@@ -171,3 +215,5 @@ playout_policy_done(struct playout_policy *p)
 	if (p->data) free(p->data);
 	free(p);
 }
+
+

--- a/playout.h
+++ b/playout.h
@@ -32,8 +32,10 @@ typedef coord_t (*playoutp_choose)(struct playout_policy *playout_policy, struct
  * just use uct/prior.h:add_prior_value(). */
 typedef void (*playoutp_assess)(struct playout_policy *playout_policy, struct prior_map *map, int games);
 
-/* Allow play of randomly selected move. */
-typedef bool (*playoutp_permit)(struct playout_policy *playout_policy, struct board *b, struct move *m);
+/* Whether to allow given move. All playout moves must pass permit()
+ * before being played. if alt parameter is true policy may suggest
+ * another move if this one doesn't pass (in which case m will be changed) */
+typedef bool (*playoutp_permit)(struct playout_policy *playout_policy, struct board *b, struct move *m, bool alt);
 
 /* Tear down the policy state; policy and policy->data will be free()d by caller. */
 typedef void (*playoutp_done)(struct playout_policy *playout_policy);
@@ -110,6 +112,10 @@ int play_random_game(struct playout_setup *setup,
 coord_t play_random_move(struct playout_setup *setup,
 		         struct board *b, enum stone color,
 		         struct playout_policy *policy);
+
+/* Is *this* move permitted ? 
+ * Called by policy permit() to check something so never the main permit() call. */
+bool playout_permit(struct playout_policy *p, struct board *b, coord_t coord, enum stone color);
 
 void playout_policy_done(struct playout_policy *p);
 

--- a/playout.h
+++ b/playout.h
@@ -19,7 +19,7 @@ struct playout_setup;
  * (but not assess/permit calls!) will all be made on the same board; if
  * setboard is used, it is guaranteed that choose will pick all moves played
  * on the board subsequently. The routine is expected to initialize b->ps
- * with internal data. At the playout end, b->ps will be simply free()d,
+ * with internal data. b->ps will be simply free()d when board is destroyed,
  * so make sure all data is within single allocated block. */
 typedef void (*playoutp_setboard)(struct playout_policy *playout_policy, struct board *b);
 

--- a/playout/moggy.c
+++ b/playout/moggy.c
@@ -21,6 +21,7 @@
 #include "tactics/ladder.h"
 #include "tactics/nakade.h"
 #include "tactics/selfatari.h"
+#include "tactics/seki.h"
 #include "uct/prior.h"
 
 #define PLDEBUGL(n) DEBUGL_(p->debug_level, n)
@@ -1045,6 +1046,9 @@ playout_moggy_permit(struct playout_policy *p, struct board *b, struct move *m, 
 	}
 
 eyefill_skip:
+	if (breaking_3_stone_seki(b, m->coord, m->color))
+		return false;
+
 	return true;
 }
 

--- a/playout/moggy.c
+++ b/playout/moggy.c
@@ -970,7 +970,7 @@ playout_moggy_assess(struct playout_policy *p, struct prior_map *map, int games)
 }
 
 static bool
-playout_moggy_permit(struct playout_policy *p, struct board *b, struct move *m)
+playout_moggy_permit(struct playout_policy *p, struct board *b, struct move *m, bool alt)
 {
 	struct moggy_policy *pp = p->data;
 

--- a/replay/replay.c
+++ b/replay/replay.c
@@ -37,6 +37,7 @@ replay_sample_moves(struct engine *e, struct board *b, enum stone color,
 		    int *played, int *pmost_played)
 {
 	struct replay *r = e->data;
+	struct playout_policy *policy = r->playout;
 	struct playout_setup setup;	        memset(&setup, 0, sizeof(setup));
 	struct move m = { .coord = pass, .color = color };
 	int most_played = 0;
@@ -45,6 +46,9 @@ replay_sample_moves(struct engine *e, struct board *b, enum stone color,
         for (int i = 0; i < r->runs; i++) {
 		struct board b2;
 		board_copy(&b2, b);
+		
+		if (policy->setboard)
+			policy->setboard(policy, &b2);
 		
 		if (DEBUGL(4))  fprintf(stderr, "---------------------------------\n");		
 		coord_t c = play_random_move(&setup, &b2, color, r->playout);		

--- a/t-unit/moggy_lifedeath.t
+++ b/t-unit/moggy_lifedeath.t
@@ -177,3 +177,28 @@ X O X X . X X . . . X O X O X X O O .
 . . . . . . . . . . . . . . . . . . .
 
 moggy status (n2) b16		# origin: b16 black 59%
+
+
+% Test 8 - Simple atari defense check
+boardsize 19
+. . . . O X X X X O . O X X . . . . .
+O O O . O O X O O . . O O X . . . . .
+O X X O . O X X O O O . O X X . . . .
+X X . X O O X X X O X . O O X . X . .
+. . X X O O O O X X O O O O O X . . .
+. . . X X O X X X O O X O O X X . X .
+X X X O O O O X O O X X O O O X . O O
+O O X O O . O X O X X X O X O X X O X
+O . O . . O X X O X O X O X X X . X .
+. O O O O X X O O O O X X X O O X X X
+. . O X X X X O O O O O O O O O X O O
+. . X O X . X X X O X O X O X O O . O
+. . . O X X . . X O X X X X X O . O .
+. . . O O X O . X O O O O X X X O . .
+. O X O . O X X X O X O X X X O . O .
+O . O O . O O X . X X X X O O O . . .
+O O X X O O X X . X X . X X O . O . .
+O X X . X O X X X . . . X O O . O . .
+X X . X X O O O O X . . X X O . . O .
+
+moggy status (t13) t13		# origin: t13 black 94%

--- a/t-unit/moggy_seki.t
+++ b/t-unit/moggy_seki.t
@@ -1,0 +1,81 @@
+
+% Seki !
+boardsize 9
+O O O O . X X X O
+. O O O X X X O O
+O O O X X X O O O
+X X X X O O . O O
+. X X O O . O O .
+X X X O O O . O O
+X X O O . O O O O
+X O O O O O . O O
+O O . O O . O . O
+
+moggy moves a1
+moggy status a1
+
+
+% Early seki
+boardsize 19
+. . . . . . . . . . . . . . . . . . .
+. . . . . . X O O O O . O O X . O . .
+. . . . . . X X X X X O O X . X O . .
+. . . X . . . . . . O X O X . X . O .
+. . X . . . . . . X . X X O X . . . .
+. . . . . . . . . X . X O O O O O . O
+. . X . . . X . . . O O X O O . . O O
+. . X O X . O X X . . O X X O X X X X
+. . O X X . X . . X O O X O O O X . O
+. . O O . . O . X . O X X X . O X X O
+. . . . . O . . . O O X X X X O X . O
+. . O . . . O O O O X O O O X X X X X
+. X O . . . . X X X X . . O O O O O .
+. X O . O . . X O O O O O X . O X . .
+. X O . . X . . X X X X X X O X . . .
+. X O X . . . . . . . . . O O X O O .
+. . X . . X . . . . . X X O X O X . .
+. . . . . . . . . . . . . X X O O . .
+. . . . . . . . . . . . . . . . . . .
+
+moggy status t11
+
+
+% Nakade move breaking seki
+boardsize 7
+. X O O O O O
+. X X X O X X
+. X . O O X .
+. X . O X X X
+O O O O X O .
+. O O O X O O
+O . O O X O .
+
+!moggy status d1         # Eeek, shouldn't nakade here !
+
+
+% Ok to break seki
+boardsize 7
+. X . X O . .
+. X X X O O O
+. . X . O . X
+. . X . O O X
+. . X . O . X
+. . X X O O O
+. . . X X X .
+
+moggy status g4
+
+
+% Must break seki !
+boardsize 9
+. . . . . . . . .
+. X . X X X X X .
+. . X . O O O X .
+. . X . O . X O O
+. . X . O O X O .
+. . X . O . X O O
+. . X . O O O X .
+. . . X X X X X .
+. . . . . . . . .
+
+moggy status g4

--- a/t-unit/test_undo.c
+++ b/t-unit/test_undo.c
@@ -125,9 +125,9 @@ test_undo(struct board *orig, coord_t c, enum stone color)
 static playoutp_permit policy_permit = NULL;
 
 static bool
-permit_hook(struct playout_policy *playout_policy, struct board *b, struct move *m)
+permit_hook(struct playout_policy *playout_policy, struct board *b, struct move *m, bool alt)
 {
-	bool permit = (policy_permit ? policy_permit(playout_policy, b, m) : true);
+	bool permit = (policy_permit ? policy_permit(playout_policy, b, m, alt) : true);
 	if (!permit)
 		return false;
 	

--- a/tactics/2lib.h
+++ b/tactics/2lib.h
@@ -12,4 +12,8 @@ struct move_queue;
 void can_atari_group(struct board *b, group_t group, enum stone owner, enum stone to_play, struct move_queue *q, int tag, bool use_def_no_hopeless);
 void group_2lib_check(struct board *b, group_t group, enum stone to_play, struct move_queue *q, int tag, bool use_miaisafe, bool use_def_no_hopeless);
 
+bool can_capture_2lib_group(struct board *b, group_t g, enum stone color, struct move_queue *q, int tag);
+void group_2lib_capture_check(struct board *b, group_t group, enum stone to_play, struct move_queue *q, int tag, bool use_miaisafe, bool use_def_no_hopeless);
+
+
 #endif

--- a/tactics/Makefile
+++ b/tactics/Makefile
@@ -1,5 +1,5 @@
 INCLUDES=-I..
-OBJS=1lib.o 2lib.o nlib.o ladder.o nakade.o selfatari.o util.o dragon.o
+OBJS=1lib.o 2lib.o nlib.o ladder.o nakade.o selfatari.o util.o dragon.o seki.o
 
 all: tactics.a
 tactics.a: $(OBJS)

--- a/tactics/dragon.c
+++ b/tactics/dragon.c
@@ -98,8 +98,6 @@ board_print_dragons(struct board *board, FILE *f)
 #define own_stone_atxy(x, y)    (board_atxy(b, (x), (y)) == color)
 #define enemy_stone_atxy(x, y)  (board_atxy(b, (x), (y)) == stone_other(color))
 
-static bool
-is_controlled_eye_point(struct board *b, coord_t to, enum stone color);
 
 /* Check if g and g2 are virtually connected through lib.
  * c2 is a stone of g2 next to lib */
@@ -356,7 +354,7 @@ big_eye_area(struct board *b, enum stone color, coord_t around, int *visited)
  * Opponent can't play there or we can capture if he does.
  * TODO - could make tiger mouth check smarter (check selfatari) 
  *      - handle more exotic cases (ladders ?) */
-static bool
+bool
 is_controlled_eye_point(struct board *b, coord_t to, enum stone color)
 {
 	assert(no_stone_at(to));

--- a/tactics/dragon.h
+++ b/tactics/dragon.h
@@ -46,6 +46,10 @@ bool neighbor_is_safe(struct board *b, group_t g);
  * Returns size of the area, or 0 if doesn't match.  */
 int big_eye_area(struct board *b, enum stone color, coord_t around, int *visited);
 
+/* Point we control: 
+ * Opponent can't play there or we can capture if he does. */
+bool is_controlled_eye_point(struct board *b, coord_t to, enum stone color);
+
 /* Try to find out if dragon is completely surrounded:
  * Look for outwards 2-stones gap from our external liberties. 
  * (hack, but works pretty well in practice) */

--- a/tactics/seki.c
+++ b/tactics/seki.c
@@ -1,0 +1,102 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define QUICK_BOARD_CODE
+
+#define DEBUG
+#include "board.h"
+#include "debug.h"
+#include "tactics/1lib.h"
+#include "tactics/dragon.h"
+#include "tactics/seki.h"
+
+
+bool
+breaking_3_stone_seki(struct board *b, coord_t coord, enum stone color)
+{
+	enum stone other_color = stone_other(color);
+	
+	/* Opponent's 3-stone group with 2 libs nearby ? */
+	group_t g3 = 0;
+	foreach_neighbor(b, coord, {
+		if (board_at(b, c) != other_color)
+			continue;
+		group_t g = group_at(b, c);
+		if (board_group_info(b, g).libs != 2 ||
+		    group_stone_count(b, g, 4) != 3)
+			return false;
+		if (g3)  /* Multiple groups or bad bent-3 */
+			return false;
+		g3 = g;
+	});
+	if (!g3)
+		return false;
+
+	/* Check neighbours of the 2 liberties first (also checks shape :) */
+	// FIXME is this enough to check all the bad shapes ?
+	for (int i = 0; i < 2; i++) {
+		coord_t lib = board_group_info(b, g3).lib[i];
+		if (immediate_liberty_count(b, lib) >= 1)
+			return false;  /* Bad shape or can escape */
+		if (neighbor_count_at(b, lib, other_color) >= 2)
+			return false;  /* Bad bent-3 or can connect out */
+	}
+
+	/*  Anything with liberty next to bent-3's center is no seki:
+	 *   . O O O .    . O O O .   
+	 *   O O X O O 	  O O X . O 
+	 *   O X X . O 	  O X X O O 
+	 *   O O . O O 	  O O . O O 
+	 *   . O O O . 	  . O O O . 
+	 */
+	for (int i = 0; i < 2; i++) {
+		coord_t lib = board_group_info(b, g3).lib[i];
+		foreach_neighbor(b, lib, {   /* Find adjacent stone */
+			if (board_at(b, c) == other_color &&
+			    neighbor_count_at(b, c, other_color) == 2)
+				return false;
+			break;        /* Bad bent-3 already taken care of */
+		});
+	}
+
+	/* Find our group */
+	group_t own = 0;
+	foreach_neighbor(b, coord, {
+		if (board_at(b, c) != color)
+			continue;
+		// FIXME multiple own groups around ?
+		own = group_at(b, c);
+	});
+	if (!own)
+		return false;
+
+	/* Check group is completely surrounded.
+	 * If it can countercapture for sure it's not completely surrounded */
+	if (can_countercapture(b, g3, NULL, 0))
+		return false;
+	int visited[BOARD_MAX_COORDS] = {0, };
+	if (!big_eye_area(b, color, group_base(g3), visited))
+		return false;
+	
+	/* Already have 2 eyes ? No need for seki then */
+	int eyes = 1;
+	if (dragon_is_safe_full(b, own, color, visited, &eyes))
+		return false;
+
+	/* Safe after capturing these stones ? */
+	bool safe = false;
+	coord_t lib1 = board_group_info(b, g3).lib[0];
+	coord_t lib2 = board_group_info(b, g3).lib[1];
+	with_move(b, lib1, color, {
+		with_move(b, lib2, color, {
+			group_t g = group_at(b, own);
+			assert(g);  assert(!group_at(b, g3));
+			safe = dragon_is_safe(b, g, color);
+		});
+	});
+	if (safe)
+		return false;
+
+	return true;
+}

--- a/tactics/seki.h
+++ b/tactics/seki.h
@@ -1,0 +1,6 @@
+#ifndef PACHI_TACTICS_SEKI_H
+#define PACHI_TACTICS_SEKI_H
+
+bool breaking_3_stone_seki(struct board *b, coord_t coord, enum stone color);
+
+#endif /* PACHI_TACTICS_SEKI_H */

--- a/tactics/selfatari.h
+++ b/tactics/selfatari.h
@@ -13,6 +13,11 @@
  * or throw-ins. */
 static bool is_bad_selfatari(struct board *b, enum stone color, coord_t to);
 
+/* Check if this move is a really bad self-atari, allowing opponent to capture
+ * 3 stones or more that could have been saved / don't look like useful nakade.
+ * Doesn't care much about 1 stone / 2 stones business unlike is_bad_selfatari(). */
+static bool is_really_bad_selfatari(struct board *b, enum stone color, coord_t to);
+
 /* Check if move results in self-atari. */
 static bool is_selfatari(struct board *b, enum stone color, coord_t to);
 
@@ -25,7 +30,11 @@ static bool is_selfatari(struct board *b, enum stone color, coord_t to);
 coord_t selfatari_cousin(struct board *b, enum stone color, coord_t coord, group_t *bygroup);
 
 
-bool is_bad_selfatari_slow(struct board *b, enum stone color, coord_t to);
+#define SELFATARI_3LIB_SUICIDE		1
+#define SELFATARI_BIG_GROUPS_ONLY	2
+
+bool is_bad_selfatari_slow(struct board *b, enum stone color, coord_t to, int flags);
+
 static inline bool
 is_bad_selfatari(struct board *b, enum stone color, coord_t to)
 {
@@ -33,10 +42,19 @@ is_bad_selfatari(struct board *b, enum stone color, coord_t to)
 	if (immediate_liberty_count(b, to) > 1)
 		return false;
 
-	return is_bad_selfatari_slow(b, color, to);
+	return is_bad_selfatari_slow(b, color, to, SELFATARI_3LIB_SUICIDE);
 }
 
-/* TODO use static rule instead ... */
+static inline bool
+is_really_bad_selfatari(struct board *b, enum stone color, coord_t to)
+{
+	/* More than one immediate liberty, thumbs up! */
+	if (immediate_liberty_count(b, to) > 1)
+		return false;
+
+	return is_bad_selfatari_slow(b, color, to, SELFATARI_BIG_GROUPS_ONLY);
+}
+
 static inline bool
 is_selfatari(struct board *b, enum stone color, coord_t to)
 {


### PR DESCRIPTION
Here we go:

I've tried to keep things together, but even then it's not a small patch...
There are a few branches on top of each other, maybe easiest is to go through them in order:

[[moggy_test]](https://github.com/lemonsqueeze/pachi/tree/moggy_test) branch is my moggy test suite. The last test in moggy.t is nice to check raw playout speed.

[[board_undo]](https://github.com/lemonsqueeze/pachi/tree/board_undo) is the optimization i was talking about:
play() + undo() on the same board gives a nice boost compared to board_copy() + board_play()
(~10% on x64, 20% on x86 iirc). Middle ladder reader especially benefits a lot, i've see x6 / x12 speedups depending on hardware.
There's a `with_move()` construct to combine play() + undo(). Syntax is nice and it helps ensure that undo() does get called. There are runtime checks also one can enable (`BOARD_UNDO_CHECKS`) to ensure board isn't left in an inconsistent state, but in my experience it's not necessary: code asserts out eventually anyway even without it. Since quick_play() doesn't maintain all board fields (hashes, pattern ...) i also put some countermeasures in place to disable them in all tactics code. Lastly i'd rather not consider the possibility of a bug in the undo layer so there's a fairly thorough stress test in t-unit.

[[tactics_undo]](https://github.com/lemonsqueeze/pachi/tree/tactics_undo) uses undo in ladder / selfatari code.

[[dragon]](https://github.com/lemonsqueeze/pachi/tree/dragon) branch tries to deal with virtually connected groups (group has 2 eyes etc)

[[can_countercap]](https://github.com/lemonsqueeze/pachi/tree/can_countercap) has can_countercapture() only check for snapback instead of full-fledged is_bad_selfatari(). Faster, and fixes situations where the snapback also looks like a good nakade (doesn't seem to make it any stronger though =)

[[ladder]](https://github.com/lemonsqueeze/pachi/tree/ladder) branch can read out countercaptures (overkill ?) and fixes some issues with suicides. New code matches *many* more ladders (around x4 iirc) so it can become a problem for life&death if they all get pruned in prior code. useful_ladder() tries to address that.

And at last [[seki]](https://github.com/lemonsqueeze/pachi/tree/seki) which has been discussed mostly already.

Could probably use more cleanup, and i'm sure i missed some obvious stuff by staring at it too much,
Let me know what you think =)