### PR TITLE
Can countercap

### DIFF
--- a/playout/moggy.c
+++ b/playout/moggy.c
@@ -192,8 +192,7 @@ test_pattern3_here(struct playout_policy *p, struct board *b, struct move *m, bo
 	/* Ladder moves are stupid. */
 	group_t atari_neighbor = board_get_atari_neighbor(b, m->coord, m->color);
 	if (atari_neighbor && is_ladder(b, m->coord, atari_neighbor, middle_ladder)
-	    && !can_countercapture(b, board_at(b, group_base(atari_neighbor)),
-                                   atari_neighbor, m->color, NULL, 0))
+	    && !can_countercapture(b, atari_neighbor, NULL, 0))
 		return false;
 	//fprintf(stderr, "%s: %d (%.3f)\n", coord2sstr(m->coord, b), (int) pi, pp->pat3_gammas[(int) pi]);
 	if (gamma)

--- a/t-unit/can_countercap.t
+++ b/t-unit/can_countercap.t
@@ -1,0 +1,97 @@
+boardsize 9
+. O X . . O X . .
+. . . . . O X . .
+. O O . . O X . .
+X X O O . O X . .
+. X X O O X X . .
+. . X X O O X O .
+. . . . X X O O .
+. . . X . X X O .
+. . X . O . O . .
+
+can_countercap f2 0
+
+boardsize 9
+. O X . . O X . .
+. . . . . O X . .
+. O O . . O X . .
+X X O O . O X . .
+. X X O O X X . .
+. . X X O O X O .
+. . . O X X O O .
+. . . X . X X O .
+. . X . O . O . .
+
+can_countercap f2 1
+
+boardsize 9
+. O X . . O X . .
+. . . . . O X . .
+. O O . . O X . .
+X X O O . O X . .
+. X X O O X X . .
+. . X X O O X O .
+. . . O X X O O .
+. . . X O X X O .
+. . X . O . O . .
+
+can_countercap f2 1
+
+
+% Snapback
+boardsize 9
+. O X . . O X . .
+. . . . . O X . .
+. O O . . O X . .
+X X O O . O X . .
+. X X O O X X . .
+. . X X O O X O .
+. . . O X X O O .
+. . . O O X X O .
+. . X . O . O X .
+
+can_countercap f2 0
+
+% Snapback
+boardsize 9
+. O X . . O X . .
+. . . . . O X . .
+. O O . . O X . .
+X X O O . O X . .
+. X X O O X X . .
+. . X X O O X O .
+. . . O O X O O .
+. . . O O X X O .
+. . X . O . O X .
+
+can_countercap f2 0
+
+% Snapback
+boardsize 9
+. O X . . O X . .
+. . . . . O X . .
+. O O . . O X . .
+X X O O . O X . .
+. X X O O X X X X
+. . X X O O X O X
+. . . O O O O O X
+. . . O X X X O X
+. . X O X . O X X
+
+can_countercap f2 0
+can_countercap g5 0
+
+
+% Simple snapback
+boardsize 9
+. O X . . O X . .
+. . . . . O X . .
+. O O . . O X . .
+X X O O . O X . .
+. X X O O X X . .
+. . X X O X X O .
+. . . O X X O O .
+. . . O X O X O .
+. . X O O . X O .
+
+can_countercap g1 0

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -175,7 +175,7 @@ test_can_countercapture(struct board *b, char *arg)
 	enum stone color = board_at(b, c);
 	group_t g = group_at(b, c);
 	assert(color == S_BLACK || color == S_WHITE);
-	int rres = can_countercapture(b, color, g, color, NULL, 0);
+	int rres = can_countercapture(b, g, NULL, 0);
 
 	if (rres == eres) {
 		if (DEBUGL(1))

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -10,6 +10,7 @@
 #include "tactics/selfatari.h"
 #include "tactics/dragon.h"
 #include "tactics/ladder.h"
+#include "tactics/1lib.h"
 #include "random.h"
 #include "playout.h"
 #include "timeinfo.h"
@@ -158,6 +159,35 @@ test_ladder(struct board *b, char *arg)
 	}
 
 	return (rres == eres);
+}
+
+static bool
+test_can_countercapture(struct board *b, char *arg)
+{
+	coord_t c = str2scoord(arg, board_size(b));
+	arg += strcspn(arg, " ") + 1;
+	int eres = atoi(arg);
+
+	board_print_test(2, b);
+	if (DEBUGL(1))
+		printf("can_countercap %s %d...\t", coord2sstr(c, b), eres);
+
+	enum stone color = board_at(b, c);
+	group_t g = group_at(b, c);
+	assert(color == S_BLACK || color == S_WHITE);
+	int rres = can_countercapture(b, color, g, color, NULL, 0);
+
+	if (rres == eres) {
+		if (DEBUGL(1))
+			printf("OK\n");
+	} else {
+		if (debug_level <= 2) {
+			board_print_test(0, b);
+			printf("can_countercap %s %d...\t", coord2sstr(c, b), eres);
+		}
+		printf("FAILED (%d)\n", rres);
+	}
+	return rres == eres;
 }
 
 
@@ -387,6 +417,8 @@ unittest(char *filename)
 			passed += test_sar(b, line + 4); 
 		else if (!strncmp(line, "ladder ", 7))
 			passed += test_ladder(b, line + 7);
+		else if (!strncmp(line, "can_countercap ", 15))
+			passed += test_can_countercapture(b, line + 15); 
 		else if (!strncmp(line, "two_eyes ", 9))
 			passed += test_two_eyes(b, line + 9); 
 		else if (!strncmp(line, "moggy moves ", 12)) 

--- a/tactics/1lib.h
+++ b/tactics/1lib.h
@@ -15,6 +15,9 @@ struct move_queue;
 bool can_countercapture(struct board *b, enum stone owner, group_t g,
 		        enum stone to_play, struct move_queue *q, int tag);
 
+bool can_countercapture_any(struct board *b, enum stone owner, group_t g,
+			    enum stone to_play, struct move_queue *q, int tag);
+
 /* Examine given group in atari, suggesting suitable moves for player
  * @to_play to deal with it (rescuing or capturing it). */
 /* ladder != NULL implies to always enqueue all relevant moves. */

--- a/tactics/1lib.h
+++ b/tactics/1lib.h
@@ -9,14 +9,11 @@
 struct move_queue;
 
 
-/* For given atari group @group owned by @owner, decide if @to_play
- * can save it / keep it in danger by dealing with one of the
- * neighboring groups. */
-bool can_countercapture(struct board *b, enum stone owner, group_t g,
-		        enum stone to_play, struct move_queue *q, int tag);
-
-bool can_countercapture_any(struct board *b, enum stone owner, group_t g,
-			    enum stone to_play, struct move_queue *q, int tag);
+/* Can group @group usefully capture a neighbor ? 
+ * (usefully: not a snapback) */
+bool can_countercapture(struct board *b, group_t group, struct move_queue *q, int tag);
+/* Can group @group capture *any* neighbor ? */
+bool can_countercapture_any(struct board *b, group_t group, struct move_queue *q, int tag);
 
 /* Examine given group in atari, suggesting suitable moves for player
  * @to_play to deal with it (rescuing or capturing it). */

--- a/tactics/ladder.c
+++ b/tactics/ladder.c
@@ -15,7 +15,7 @@
 bool
 is_border_ladder(struct board *b, coord_t coord, group_t laddered, enum stone lcolor)
 {
-	if (can_countercapture(b, lcolor, laddered, lcolor, NULL, 0))
+	if (can_countercapture(b, laddered, NULL, 0))
 		return false;
 	
 	int x = coord_x(coord, b), y = coord_y(coord, b);
@@ -183,7 +183,7 @@ is_middle_ladder(struct board *b, coord_t coord, group_t laddered, enum stone lc
 	 * board and start selective 2-liberty search. */
 
 	struct move_queue ccq = { .moves = 0 };
-	if (can_countercapture(b, lcolor, laddered, lcolor, &ccq, 0)) {
+	if (can_countercapture(b, laddered, &ccq, 0)) {
 		/* We could escape by countercapturing a group.
 		 * Investigate. */
 		assert(ccq.moves > 0);

--- a/tactics/selfatari.c
+++ b/tactics/selfatari.c
@@ -739,7 +739,7 @@ found:;
 		/* Can we get liberties by capturing a neighbor? */
 		struct move_queue ccq; ccq.moves = 0;
 		if (board_at(b, group) == color &&
-		    can_countercapture(b, color, group, color, &ccq, 0)) {
+		    can_countercapture(b, group, &ccq, 0)) {
 			lib2 = mq_pick(&ccq);
 
 		} else {

--- a/tactics/selfatari.c
+++ b/tactics/selfatari.c
@@ -738,7 +738,8 @@ found:;
 		coord_t lib2;
 		/* Can we get liberties by capturing a neighbor? */
 		struct move_queue ccq; ccq.moves = 0;
-		if (can_countercapture(b, color, group, color, &ccq, 0)) {
+		if (board_at(b, group) == color &&
+		    can_countercapture(b, color, group, color, &ccq, 0)) {
 			lib2 = mq_pick(&ccq);
 
 		} else {


### PR DESCRIPTION
Has can_countercapture() only check for snapback instead of full-fledged is_bad_selfatari(). Faster, and fixes situations where the snapback also looks like a good nakade (doesn't seem to make it any stronger though =)