### PR TITLE
Segfault on DCNN is back!

### DIFF
--- a/dcnn.cpp
+++ b/dcnn.cpp
@@ -70,6 +70,11 @@ dcnn_get_moves(struct board *b, enum stone color, float result[])
 {
 	assert(real_board_size(b) == 19);
 
+  std::cout << "dcnn_get_moves: board is at " << b << std::endl;
+  std::cout << "dcnn_get_moves: address of board.captures is " << &(b->captures) << std::endl;
+  std::cout << "dcnn_get_moves: address of board.komi is " << &(b->komi) << std::endl;
+
+
 	int size = 19;
 	int dsize = 13 * size * size;
 	float *data = new float[dsize];

--- a/dcnn.cpp
+++ b/dcnn.cpp
@@ -73,6 +73,7 @@ dcnn_get_moves(struct board *b, enum stone color, float result[])
   std::cout << "dcnn_get_moves: board is at " << b << std::endl;
   std::cout << "dcnn_get_moves: address of board.captures is " << &(b->captures) << std::endl;
   std::cout << "dcnn_get_moves: address of board.komi is " << &(b->komi) << std::endl;
+  std::cout << "dcnn_get_moves: S_MAX is " << S_MAX << std::endl;
 
 
 	int size = 19;

--- a/uct/prior.c
+++ b/uct/prior.c
@@ -76,6 +76,9 @@ uct_prior_dcnn(struct uct *u, struct tree_node *node, struct prior_map *map)
 	float r[19 * 19];
 	float best_r[DCNN_BEST_N] = { 0.0, };
 	coord_t best_moves[DCNN_BEST_N];
+  printf("uct_prior: board is at 0x%p\n", map->b);
+  printf("uct_prior: address of board.captures is 0x%p\n", &(map->b->captures));
+  printf("uct_prior: address of board.komi is 0x%p\n", &(map->b->komi));
 	dcnn_get_moves(map->b, map->to_play, r);
 	find_dcnn_best_moves(map->b, r, best_moves, best_r);
 	print_dcnn_best_moves(node, map->b, best_moves, best_r);

--- a/uct/prior.c
+++ b/uct/prior.c
@@ -79,6 +79,7 @@ uct_prior_dcnn(struct uct *u, struct tree_node *node, struct prior_map *map)
   printf("uct_prior: board is at 0x%p\n", map->b);
   printf("uct_prior: address of board.captures is 0x%p\n", &(map->b->captures));
   printf("uct_prior: address of board.komi is 0x%p\n", &(map->b->komi));
+  printf("uct_prior: S_MAX is %d\n", S_MAX);
 	dcnn_get_moves(map->b, map->to_play, r);
 	find_dcnn_best_moves(map->b, r, best_moves, best_r);
 	print_dcnn_best_moves(node, map->b, best_moves, best_r);


### PR DESCRIPTION
**NOTE**: This PR is _not_ meant to be merged, just to share some debugging code!

I keep on hitting the same segfault that @xlvector encountered in #32. The symptoms are identical: in `dcnn_get_moves()` (notably, a C++ file) you have `b->b` appear to be `NULL`, even though in the calling function (notably, a C file) has `b->b` non-`NULL`.

Apparently @xlvector solved his issue just by compiling without `MAC=1`, but unfortunately I believe that's a red herring as I can reproduce this issue in OS X _and_ Ubuntu 16.04 _and_ Ubuntu 14.04, with both GCC 5.4 and 4.8. It is very consistent for me.

I think I've tracked down the issue to a difference in struct-packing between C and C++. If I build the branch in this pull request, which simply prints out the offsets of the fourth and fifth members of the `board` struct,  I get the following:

```
uct_prior: board is at 0x0x7f608c06b9e0
uct_prior: address of board.captures is 0x0x7f608c06b9ec
uct_prior: address of board.komi is 0x0x7f608c06ba00
uct_prior: S_MAX is 4
dcnn_get_moves: board is at 0x7f608c06b9e0
dcnn_get_moves: address of board.captures is 0x7f608c06b9ec
dcnn_get_moves: address of board.komi is 0x7f608c06b9fc
dcnn_get_moves: S_MAX is 4
```

Notice how `board.captures` is perfectly aligned on both, but `board.komi` is 4 bytes later in `uct/prior.c`, but only 1 byte later in `dcnn.cpp`. So for some reason, C++ is allocating only one byte for `int captures[S_MAX]` (even though it knows S_MAX is 4). So then when `dcnn.cpp` looks at `b->b`, it's actually looking 4 bytes too early, into one of the `last_move` structs, and erroneously reads back a null pointer. Again, I can reproduce this on three different operating systems with three different GCC versions.

I'm not much of a C/C++ expert, but this seems like a bug, and the fact that it doesn't happen on your own machines makes it seem platform-dependent somehow. Anyone have any clues?
