### PR TITLE
Add a get_data_file method to check system DATA_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,15 +55,16 @@
 # extra data files (such as pattern, joseki or fuseki database) only
 # in the current directory, bundled database files will not be installed
 # in a system directory or loaded from there.
-PREFIX=/usr/local
+PREFIX?=/usr/local
 BINDIR=$(PREFIX)/bin
+DATADIR?=$(PREFIX)/share/pachi
 
 # Generic compiler options. You probably do not really want to twiddle
 # any of this.
 # (N.B. -ffast-math breaks us; -fomit-frame-pointer is added below
 # unless PROFILING=gprof.)
-CUSTOM_CFLAGS?=-Wall -ggdb3 -O3 -std=gnu99 -frename-registers -pthread -Wsign-compare -D_GNU_SOURCE
-CUSTOM_CXXFLAGS?=-Wall -ggdb3 -O3
+CUSTOM_CFLAGS?=-Wall -ggdb3 -O3 -std=gnu99 -frename-registers -pthread -Wsign-compare -D_GNU_SOURCE -DDATA_DIR=\"$(DATADIR)\"
+CUSTOM_CXXFLAGS?=-Wall -ggdb3 -O3 -DDATA_DIR=\"$(DATADIR)\"
 
 ### CONFIGURATION END
 
@@ -144,6 +145,7 @@ ifdef DCNN
 	OBJS+=dcnn.o
 endif
 SUBDIRS=random replay patternscan patternplay joseki montecarlo uct uct/policy playout tactics t-unit distributed
+DATAFILES=patterns.prob patterns.spat book.dat golast19.prototxt golast.trained joseki19.pdict
 
 all: all-recursive pachi
 
@@ -164,6 +166,12 @@ pachi-profiled:
 # install-recursive?
 install:
 	$(INSTALL) ./pachi $(DESTDIR)$(BINDIR)
+	for datafile in $(DATAFILES);          \
+	do                                     \
+		if [ -f $$datafile ]; then           \
+			$(INSTALL) $$datafile $(DATADIR);  \
+		fi;                                  \
+	done;
 
 
 clean: clean-recursive

--- a/README
+++ b/README
@@ -93,7 +93,7 @@ First, build Pachi with DCNN support:
   dependencies.
 - Edit Makefile, set DCNN=1, point it to where caffe is installed and build.
 
-Install dcnn files in current directory where pachi will run.
+Install dcnn files in Pachi's data directory.
 Detlef Schmicker's 54% dcnn can be found at:  
   http://physik.de/CNNlast.tar.gz
 

--- a/dcnn.cpp
+++ b/dcnn.cpp
@@ -19,6 +19,7 @@ extern "C" {
 #include "dcnn.h"
 #include "engine.h"
 #include "uct/tree.h"
+#include "util.h"
 	
 	
 static shared_ptr<Net<float> > net;
@@ -47,11 +48,13 @@ dcnn_init()
 		return;
 
 	struct stat s;	
-	const char *model_file =   "golast19.prototxt";
-	const char *trained_file = "golast.trained";
-	if (stat(model_file, &s) != 0  ||  stat(trained_file, &s) != 0) {
+	const char *model_file =   get_data_file("golast19.prototxt");
+	const char *trained_file = get_data_file("golast.trained");
+	if (open_data_file(model_file) == NULL  ||  open_data_file(trained_file) == NULL) {
 		if (DEBUGL(1))
 			fprintf(stderr, "No dcnn files found, will not use dcnn code.\n");
+    close(model_file);
+    close(trained_file);
 		return;
 	}
 	

--- a/joseki/base.c
+++ b/joseki/base.c
@@ -23,7 +23,7 @@ joseki_load(int bsize)
 {
 	char fname[1024];
 	snprintf(fname, 1024, "joseki%d.pdict", bsize - 2);
-	FILE *f = fopen(fname, "r");
+	FILE *f = fopen(get_data_file(fname), "r");
 	if (!f) {
 		if (DEBUGL(3))
 			perror(fname);

--- a/patternprob.c
+++ b/patternprob.c
@@ -9,6 +9,7 @@
 #include "pattern.h"
 #include "patternsp.h"
 #include "patternprob.h"
+#include "util.h"
 
 
 /* We try to avoid needlessly reloading probability dictionary
@@ -25,7 +26,7 @@ pattern_pdict_init(char *filename, struct pattern_config *pc)
 
 	if (!filename)
 		filename = "patterns.prob";
-	FILE *f = fopen(filename, "r");
+	FILE *f = fopen(get_data_file(filename), "r");
 	if (!f) {
 		if (DEBUGL(1))
 			fprintf(stderr, "No pattern probtable, will not use learned patterns.\n");

--- a/patternsp.c
+++ b/patternsp.c
@@ -9,6 +9,7 @@
 #include "debug.h"
 #include "pattern.h"
 #include "patternsp.h"
+#include "util.h"
 
 /* Mapping from point sequence to coordinate offsets (to determine
  * coordinates relative to pattern center). The array is ordered
@@ -394,7 +395,7 @@ spatial_dict_init(bool will_append, bool hash)
 	if (cached_dict && !will_append)
 		return cached_dict;
 
-	FILE *f = fopen(spatial_dict_filename, "r");
+	FILE *f = fopen(get_data_file(spatial_dict_filename), "r");
 	if (!f && !will_append) {
 		if (DEBUGL(1))
 			fprintf(stderr, "No spatial dictionary, will not match spatial pattern features.\n");

--- a/util.h
+++ b/util.h
@@ -3,6 +3,8 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
 
 /* Portability definitions. */
 
@@ -82,5 +84,26 @@ checked_calloc(size_t nmemb, size_t size, const char *filename, unsigned int lin
 
 #define malloc2(size)        checked_malloc((size), __FILE__, __LINE__, __func__)
 #define calloc2(nmemb, size) checked_calloc((nmemb), (size), __FILE__, __LINE__, __func__)
+
+/* Data-loading definitions */
+static inline const char *
+get_data_file(const char *filename)
+{
+  struct stat s;
+
+  if (stat(filename, &s) == 0) {
+    return filename;
+  }
+
+#ifdef DATA_DIR
+  char *data_dir_filename = malloc(strlen(DATA_DIR) + 1 + strlen(filename) + 1);
+  sprintf(data_dir_filename, "%s/%s", DATA_DIR, filename);
+  if (stat(data_dir_filename, &s) == 0) {
+    return (const char *)data_dir_filename;
+  }
+#endif
+
+  return NULL;
+}
 
 #endif


### PR DESCRIPTION
This adds a much-needed quality-of-life improvement for users and packagers, namely the ability to specify a data directory when compiling (by default the standard `/usr/local/share/pachi`) and let Pachi load data files from that path in addition to the current working directory. This removes the need to always run pachi from the location of the data files, which is especially useful when using GUIs like [Sabaki](http://sabaki.yichuanshen.de/) which don't let you set the working directory.

It is applied in the code to the datafiles now specified in Makefile, namely:
- `joseki19.pdict`
- `patterns.prob`
- `patterns.spat`
- `golast.trained`
- `golast19.prototxt`

Please let me know if there's any I'm missing.

Note that this change is fully backwards compatible, as the current directory is _still_ checked in addition to the global one.

Tested on both Linux and OS X. It will probably need some modification for Windows.
