### PR TITLE
dcnn: minimize c++ exposure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ INCLUDES=-I.
 
 OBJS=board.o gtp.o move.o ownermap.o pattern3.o pattern.o patternsp.o patternprob.o playout.o probdist.o random.o stone.o timeinfo.o network.o fbook.o chat.o
 ifdef DCNN
-	OBJS+=dcnn.o
+	OBJS+=dcnn.o caffe.o
 endif
 SUBDIRS=random replay patternscan patternplay joseki montecarlo uct uct/policy playout tactics t-unit distributed
 

--- a/caffe.cpp
+++ b/caffe.cpp
@@ -1,0 +1,76 @@
+#define DEBUG
+#include <assert.h>
+#include <ctype.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#define CPU_ONLY 1
+#include <caffe/caffe.hpp>
+using namespace caffe;
+
+extern "C" {
+#include "debug.h"
+#include "util.h"
+
+static shared_ptr<Net<float> > net;
+
+bool
+caffe_ready()
+{
+	return net;
+}
+
+void
+caffe_init()
+{
+	if (net)
+		return;
+
+	struct stat s;	
+	const char *model_file =   "golast19.prototxt";
+	const char *trained_file = "golast.trained";
+	if (stat(model_file, &s) != 0  ||  stat(trained_file, &s) != 0) {
+		if (DEBUGL(1))
+			fprintf(stderr, "No dcnn files found, will not use dcnn code.\n");
+		return;
+	}
+	
+	Caffe::set_mode(Caffe::CPU);       
+	
+	/* Load the network. */
+	net.reset(new Net<float>(model_file, TEST));
+	net->CopyTrainedLayersFrom(trained_file);
+	
+	if (DEBUGL(1))
+		fprintf(stderr, "Initialized dcnn.\n");
+}	
+
+
+void
+caffe_get_data(float *data, float *result)
+{
+	int size = 19;
+	Blob<float> *blob = new Blob<float>(1, 13, size, size);
+	blob->set_cpu_data(data);
+	vector<Blob<float>*> bottom;
+	bottom.push_back(blob);
+	assert(net);
+	const vector<Blob<float>*>& rr = net->Forward(bottom);
+	
+	for (int i = 0; i < size * size; i++) {
+		result[i] = rr[0]->cpu_data()[i];
+		if (result[i] < 0.00001)
+			result[i] = 0.00001;
+	}
+	
+	delete blob;	
+}
+
+	
+} /* extern "C" */
+

--- a/caffe.h
+++ b/caffe.h
@@ -1,0 +1,18 @@
+
+#ifndef PACHI_CAFFE_H
+#define PACHI_CAFFE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+bool caffe_ready();
+void caffe_init();
+void caffe_get_data(float *data, float *result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PACHI_CAFFE_H */

--- a/dcnn.c
+++ b/dcnn.c
@@ -1,32 +1,25 @@
 #define DEBUG
 #include <assert.h>
-#include <ctype.h>
-#include <math.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
-#include <sys/stat.h>
 
-#define CPU_ONLY 1
-#include <caffe/caffe.hpp>
-using namespace caffe;
-
-extern "C" {
 #include "debug.h"
 #include "board.h"
-#include "dcnn.h"
 #include "engine.h"
 #include "uct/tree.h"
+#include "caffe.h"
+#include "dcnn.h"
 	
 	
-static shared_ptr<Net<float> > net;
-
 bool
 using_dcnn(struct board *b)
 {
-	return (real_board_size(b) == 19 && net);
+	return (real_board_size(b) == 19 && caffe_ready());
+}
+
+void
+dcnn_init()
+{
+	caffe_init();
 }
 
 /* Make caffe quiet */
@@ -40,30 +33,6 @@ dcnn_quiet_caffe(int argc, char *argv[])
 	execvp(argv[0], argv);   /* Sucks that we have to do this */
 }
 
-void
-dcnn_init()
-{
-	if (net)
-		return;
-
-	struct stat s;	
-	const char *model_file =   "golast19.prototxt";
-	const char *trained_file = "golast.trained";
-	if (stat(model_file, &s) != 0  ||  stat(trained_file, &s) != 0) {
-		if (DEBUGL(1))
-			fprintf(stderr, "No dcnn files found, will not use dcnn code.\n");
-		return;
-	}
-	
-	Caffe::set_mode(Caffe::CPU);       
-	
-	/* Load the network. */
-	net.reset(new Net<float>(model_file, TEST));
-	net->CopyTrainedLayersFrom(trained_file);
-	
-	if (DEBUGL(1))
-		fprintf(stderr, "Initialized dcnn.\n");
-}
 
 void
 dcnn_get_moves(struct board *b, enum stone color, float result[])
@@ -72,7 +41,7 @@ dcnn_get_moves(struct board *b, enum stone color, float result[])
 
 	int size = 19;
 	int dsize = 13 * size * size;
-	float *data = new float[dsize];
+	float *data = malloc(sizeof(float) * dsize);
 	for (int i = 0; i < dsize; i++) 
 		data[i] = 0.0;
 
@@ -103,20 +72,8 @@ dcnn_get_moves(struct board *b, enum stone color, float result[])
 		}
 	}
 
-	Blob<float> *blob = new Blob<float>(1,13,size,size);
-	blob->set_cpu_data(data);
-	vector<Blob<float>*> bottom;
-	bottom.push_back(blob);
-	assert(net);
-	const vector<Blob<float>*>& rr = net->Forward(bottom);
-	
-	for (int i = 0; i < size * size; i++) {
-		result[i] = rr[0]->cpu_data()[i];
-		if (result[i] < 0.00001)
-			result[i] = 0.00001;
-	}
-	delete[] data;
-	delete blob;
+	caffe_get_data(data, result);
+	free(data);
 }
 
 void
@@ -173,12 +130,12 @@ struct engine *
 engine_dcnn_init(char *arg, struct board *b)
 {
 	dcnn_init();
-	if (!net) {
+	if (!caffe_ready()) {
 		fprintf(stderr, "Couldn't initialize dcnn, aborting.\n");
 		abort();
 	}
 	//struct patternplay *pp = patternplay_state_init(arg);
-	struct engine *e = (engine*)calloc2(1, sizeof(struct engine));
+	struct engine *e = (struct engine*)calloc2(1, sizeof(struct engine));
 	e->name = (char*)"DCNN Engine";
 	e->comment = (char*)"I just select dcnn's best move.";
 	e->genmove = dcnn_genmove;
@@ -189,5 +146,5 @@ engine_dcnn_init(char *arg, struct board *b)
 }
 
 	
-} /* extern "C" */
+
 

--- a/dcnn.h
+++ b/dcnn.h
@@ -2,10 +2,6 @@
 #ifndef PACHI_DCNN_H
 #define PACHI_DCNN_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 
 #ifdef DCNN
 
@@ -28,8 +24,5 @@ struct engine *engine_dcnn_init(char *arg, struct board *b);
 #endif
 
 
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* PACHI_DCNN_H */


### PR DESCRIPTION
Split dcnn.cpp into dcnn.c and caffe.cpp to minimize c++ exposure.
