### PR TITLE
KGS

### DIFF
--- a/gtp.c
+++ b/gtp.c
@@ -257,6 +257,7 @@ cmd_kgs_rules(struct board *board, struct engine *engine, struct time_info *ti, 
 {
 	char *arg;
 	next_tok(arg);
+	fprintf(stderr, "%s\n", time_str());
 	if (!board_set_rules(board, arg)) {
 		gtp_error(gtp, "unknown rules", NULL);
 		return P_OK;

--- a/timeinfo.c
+++ b/timeinfo.c
@@ -208,6 +208,17 @@ time_now(void)
 #endif
 }
 
+/* Get current time string, format like "Mar 15 07:39:50"
+ * Returns static buffer */
+char *
+time_str()
+{
+    static char buf[80];
+    time_t t = time(NULL);
+    strftime(buf, sizeof(buf), "%b %e %H:%M:%S", localtime(&t));
+    return buf;    
+}
+
 /* Sleep for a given interval (in seconds). Return immediately if interval < 0. */
 void
 time_sleep(double interval)

--- a/timeinfo.h
+++ b/timeinfo.h
@@ -87,6 +87,10 @@ void time_sub(struct time_info *ti, double interval, bool new_move);
 /* Returns the current time. */
 double time_now(void);
 
+/* Get current time string, format like "Mar 15 07:39:50"
+ * Returns static buffer */
+char *time_str();
+
 /* Sleep for a given interval (in seconds). Return immediately if interval < 0. */
 void time_sleep(double interval);
 

--- a/uct/dynkomi.c
+++ b/uct/dynkomi.c
@@ -158,9 +158,9 @@ uct_dynkomi_init_linear(struct uct *u, char *arg, struct board *b)
 
 	/* Force white to feel behind and try harder, but not to the
 	 * point of resigning immediately in high handicap games.
-	 * By move 100 white should still be behind but should have
+	 * By move 150 white should still be behind but should have
 	 * caught up enough to avoid resigning. */
-	int moves = board_large(b) ? 100 : 50;
+	int moves = board_large(b) ? 150 : 50;
 	if (!board_small(b)) {
 		l->moves[S_BLACK] = moves;
 		l->moves[S_WHITE] = moves;
@@ -170,7 +170,7 @@ uct_dynkomi_init_linear(struct uct *u, char *arg, struct board *b)
 	 * But use a lower value to avoid being too pessimistic as black
 	 * or too optimistic as white. */
 	l->handicap_value[S_BLACK] = 8;
-	l->handicap_value[S_WHITE] = 1;
+	l->handicap_value[S_WHITE] = 8;
 
 	l->komi_ratchet = INFINITY;
 	l->green_zone = 0.85;

--- a/uct/search.c
+++ b/uct/search.c
@@ -211,7 +211,7 @@ uct_search_start(struct uct *u, struct board *b, enum stone color,
 {
 	/* Set up search state. */
 	s->base_playouts = s->last_dynkomi = s->last_print = t->root->u.playouts;
-	s->print_interval = u->reportfreq * u->threads;
+	s->print_interval = u->reportfreq;
 	s->fullmem = false;
 
 	if (ti) {

--- a/uct/search.c
+++ b/uct/search.c
@@ -496,16 +496,13 @@ uct_search_result(struct uct *u, struct board *b, enum stone color,
 
 	/* Do not resign if we're so short of time that evaluation of best
 	 * move is completely unreliable, we might be winning actually.
-	 * In this case best is almost random but still better than resign.
-	 * Also do not resign if we are getting bad results while actually
-	 * giving away extra komi points (dynkomi). */
+	 * In this case best is almost random but still better than resign. */
 	if (tree_node_get_value(u->t, 1, best->u.value) < u->resign_threshold
 	    && !is_pass(node_coord(best))
 	    // If only simulated node has been a pass and no other node has
 	    // been simulated but pass won't win, an unsimulated node has
 	    // been returned; test therefore also for #simulations at root.
 	    && (best->u.playouts > GJ_MINGAMES || u->t->root->u.playouts > GJ_MINGAMES * 2)
-	    && (!u->t->use_extra_komi || komi_by_color(u->t->extra_komi, color) < 0.5)
 	    && !u->t->untrustworthy_tree) {
 		*best_coord = resign;
 		return NULL;

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -547,7 +547,7 @@ uct_livegfx_hook(struct engine *e)
 {
 	struct uct *u = e->data;
 	/* Hack: Override reportfreq to get decent update rates in GoGui */
-	u->reportfreq = MIN(u->reportfreq, 250);
+	u->reportfreq = MIN(u->reportfreq, 1000);
 }
 
 static struct tree_node *
@@ -740,7 +740,7 @@ uct_state_init(char *arg, struct board *b)
 	bool pat_setup = false;
 
 	u->debug_level = debug_level;
-	u->reportfreq = 10000;
+	u->reportfreq = 1000;
 	u->gamelen = MC_GAMELEN;
 	u->resign_threshold = 0.2;
 	u->sure_win_threshold = 0.95;

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -771,7 +771,7 @@ uct_state_init(char *arg, struct board *b)
 	u->max_maintime_ratio = 2.0;
 
 	u->val_scale = 0; u->val_points = 40;
-	u->dynkomi_interval = 1000;
+	u->dynkomi_interval = 100;
 	u->dynkomi_mask = S_BLACK | S_WHITE;
 
 	u->tenuki_d = 4;

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -415,7 +415,7 @@ uct_search(struct uct *u, struct board *b, struct time_info *ti, enum stone colo
 	}
 
 	struct uct_thread_ctx *ctx = uct_search_stop();
-	if (UDEBUGL(2)) tree_dump(t, u->dumpthres);
+	if (UDEBUGL(3)) tree_dump(t, u->dumpthres);
 	if (UDEBUGL(2))
 		fprintf(stderr, "(avg score %f/%d; dynkomi's %f/%d value %f/%d)\n",
 			t->avg_score.value, t->avg_score.playouts,

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -609,9 +609,9 @@ uct_playout(struct uct *u, struct board *b, enum stone player_color, struct tree
 	floating_t rval = scale_value(u, b, node_color, significant, result);
 	u->policy->update(u->policy, t, n, node_color, player_color, &amaf, &b2, rval);
 
-	stats_add_result(&t->avg_score, result / 2, 1);
+	stats_add_result(&t->avg_score, (float)result / 2, 1);
 	if (t->use_extra_komi) {
-		stats_add_result(&u->dynkomi->score, result / 2, 1);
+		stats_add_result(&u->dynkomi->score, (float)result / 2, 1);
 		stats_add_result(&u->dynkomi->value, rval, 1);
 	}
 


### PR DESCRIPTION
Sane defaults for running Pachi with low number of playouts / any handicap.

This is the code for Pachi playing as 'pachipachi' on KGS.
It's 2d currently, taking a few seconds per move at 4 threads on Raspberry Pi 3.
It works great on small laptops / desktops too, no need for gpu.

Command line:

    ./pachi -t =5000:15000 --fuseki-time=4000 threads=4,resign_threshold=0.25,max_tree_size=40

