### PR TITLE
Load data files from system DATA_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,15 +55,16 @@ CAFFE_PREFIX=/usr/local/caffe
 # extra data files (such as pattern, joseki or fuseki database) only
 # in the current directory, bundled database files will not be installed
 # in a system directory or loaded from there.
-PREFIX=/usr/local
+PREFIX?=/usr/local
 BINDIR=$(PREFIX)/bin
+DATADIR?=$(PREFIX)/share/pachi
 
 # Generic compiler options. You probably do not really want to twiddle
 # any of this.
 # (N.B. -ffast-math breaks us; -fomit-frame-pointer is added below
 # unless PROFILING=gprof.)
-CUSTOM_CFLAGS?=-Wall -ggdb3 -O3 -std=gnu99 -frename-registers -pthread -Wsign-compare -D_GNU_SOURCE
-CUSTOM_CXXFLAGS?=-Wall -ggdb3 -O3
+CUSTOM_CFLAGS?=-Wall -ggdb3 -O3 -std=gnu99 -frename-registers -pthread -Wsign-compare -D_GNU_SOURCE -DDATA_DIR=\"$(DATADIR)\"
+CUSTOM_CXXFLAGS?=-Wall -ggdb3 -O3 -DDATA_DIR=\"$(DATADIR)\"
 
 ### CONFIGURATION END
 
@@ -147,6 +148,7 @@ ifdef DCNN
 endif
 # Low-level dependencies last
 SUBDIRS=uct uct/policy playout tactics t-unit t-predict distributed engines
+DATAFILES=patterns.prob patterns.spat book.dat golast19.prototxt golast.trained joseki19.pdict
 
 all: gitversion.h all-recursive pachi
 
@@ -174,6 +176,12 @@ gitversion.h: .git/HEAD .git/index
 # install-recursive?
 install:
 	$(INSTALL) ./pachi $(DESTDIR)$(BINDIR)
+	for datafile in $(DATAFILES);          \
+	do                                     \
+		if [ -f $$datafile ]; then           \
+			$(INSTALL) $$datafile $(DATADIR);  \
+		fi;                                  \
+	done;
 
 # Generic clean rule is in Makefile.lib
 clean:: clean-recursive

--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,12 @@ CAFFE_PREFIX=/usr/local/caffe
 # PROFILING=perftools
 
 
-# Target directories when running `make install`. Note that this is NOT
-# quite supported yet - Pachi will work fine, but will always look for
-# extra data files (such as pattern, joseki or fuseki database) only
-# in the current directory, bundled database files will not be installed
-# in a system directory or loaded from there.
+# Target directories when running 'make install' / 'make install-data'.
+# Pachi will look for extra data files (such as dcnn, pattern, joseki or
+# fuseki database) in system directory below in addition to current directory
+# (or DATA_DIR environment variable if present).
 PREFIX?=/usr/local
-BINDIR=$(PREFIX)/bin
+BINDIR?=$(PREFIX)/bin
 DATADIR?=$(PREFIX)/share/pachi
 
 # Generic compiler options. You probably do not really want to twiddle
@@ -64,7 +63,7 @@ DATADIR?=$(PREFIX)/share/pachi
 # (N.B. -ffast-math breaks us; -fomit-frame-pointer is added below
 # unless PROFILING=gprof.)
 CUSTOM_CFLAGS?=-Wall -ggdb3 -O3 -std=gnu99 -frename-registers -pthread -Wsign-compare -D_GNU_SOURCE -DDATA_DIR=\"$(DATADIR)\"
-CUSTOM_CXXFLAGS?=-Wall -ggdb3 -O3 -DDATA_DIR=\"$(DATADIR)\"
+CUSTOM_CXXFLAGS?=-Wall -ggdb3 -O3
 
 ### CONFIGURATION END
 
@@ -175,12 +174,18 @@ gitversion.h: .git/HEAD .git/index
 
 # install-recursive?
 install:
-	$(INSTALL) ./pachi $(DESTDIR)$(BINDIR)
-	for datafile in $(DATAFILES);          \
-	do                                     \
-		if [ -f $$datafile ]; then           \
-			$(INSTALL) $$datafile $(DATADIR);  \
-		fi;                                  \
+	$(INSTALL) -d $(BINDIR)
+	$(INSTALL) pachi $(BINDIR)/
+
+install-data:
+	$(INSTALL) -d $(DATADIR)
+	@for file in $(DATAFILES); do                               \
+		if [ -f $$file ]; then                              \
+                        echo $(INSTALL) $$file $(DATADIR)/;         \
+			$(INSTALL) $$file $(DATADIR)/;              \
+		else                                                \
+			echo "Warning: $$file datafile is missing"; \
+                fi                                                  \
 	done;
 
 # Generic clean rule is in Makefile.lib

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To build Pachi with DCNN support:
   dependencies.
 - Edit Makefile, set DCNN=1, point it to where caffe is installed and build.
 
-Install dcnn files in current directory where pachi will run.  
+Install dcnn files in current directory.
 Detlef Schmicker's 54% dcnn can be found at:  
   http://physik.de/CNNlast.tar.gz
 
@@ -95,21 +95,8 @@ recommended to maximize efficient time allocation). However, most of these
 are accessible only via GTP, that is by the frontend keeping track of time,
 e.g. KGS or gogui.
 
-It's also possible to force time settings through the command line,
-see `pachi -h` for details:
-
-    -t =5000          Will not set the time per se, but number of Monte Carlo
-                      playouts per move. That is, Pachi will play fast on a fast
-                      computer, slow on a slow computer, but it should have fixed strength.
-
-    -t =5000:15000    Same but can continue up to 15000 playouts if best move is unclear.
-
-    -t 20             Sets number of seconds per move. Pachi will spend a little
-                      less to allow for network latency and other unexpected
-                      slowdowns. This is the same as one-period Japanese byoyomi.
-
-    -t _600           Sets the number of seconds for the whole game. Pachi will
-                      allocate time to fit the whole game in "sudden death" mode.
+It's also possible to force time settings via the command line (GTP
+time settings are ignored then), see `pachi -h` for details.
 
 For example:
 
@@ -117,12 +104,14 @@ For example:
 
 This will make Pachi play with max 15000 playouts per move on 4 threads,
 taking up to 100Mb of memory (+ several tens MiB as a constant overhead).
-It should be about 2d with dcnn support.
+It should be about 2d with dcnn and large patterns setup.
 
 	./pachi -t _1200 threads=8,max_tree_size=3072,pondering
 
 This will make Pachi play with time settings 20:00 S.D. with 8 threads,
 taking up to 3GiB of memory, and thinking during the opponent's turn as well.
+
+**Opening book**
 
 Pachi can use an opening book in a Fuego-compatible format - you can
 obtain one at http://gnugo.baduk.org/fuegoob.htm and use it in Pachi
@@ -133,6 +122,8 @@ with the -f parameter:
 You may wish to append some custom Pachi opening book lines to book.dat;
 take them from the book.dat.extra file. If using the default Fuego book,
 you may want to remove the lines listed in book.dat.bad.
+
+**Large patterns**
 
 Pachi can also use a pattern database to improve its playing performance.  
 You can get it at http://pachi.or.cz/pat/ - you will also find further
@@ -147,6 +138,21 @@ you can get a pretty good idea by looking at the uct_state_init() function
 in uct/uct.c - you will find the list of UCT engine options there, each
 with a description. At any rate, usually the three options above are
 the only ones you really want to tweak.
+
+
+## Install
+
+After compiling and setting up data files you can install pachi with:
+
+    make install
+    make install-data
+
+Pachi will look for extra data files (such as dcnn, pattern, joseki or
+fuseki database) in pachi's system directory (/usr/local/share/pachi by
+default) as well as current directory.
+
+System data directory can be overridden at runtime by setting `DATA_DIR`
+environment variable.
 
 
 ## Analyze commands

--- a/caffe.cpp
+++ b/caffe.cpp
@@ -31,15 +31,16 @@ caffe_init()
 	if (net)
 		return;
 
-	struct stat s;	
-	const char *model_file =   "golast19.prototxt";
-	const char *trained_file = "golast.trained";
-	if (stat(model_file, &s) != 0  ||  stat(trained_file, &s) != 0) {
+	const char *model_file =   get_data_file("golast19.prototxt");
+	const char *trained_file = get_data_file("golast.trained");
+	if (open_data_file(model_file) == NULL  ||  open_data_file(trained_file) == NULL) {
 		if (DEBUGL(1))
 			fprintf(stderr, "No dcnn files found, will not use dcnn code.\n");
+    close(model_file);
+    close(trained_file);
 		return;
 	}
-	
+
 	Caffe::set_mode(Caffe::CPU);       
 	
 	/* Load the network. */

--- a/caffe.cpp
+++ b/caffe.cpp
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/stat.h>
 
 #define CPU_ONLY 1
 #include <caffe/caffe.hpp>
@@ -28,19 +27,15 @@ caffe_ready()
 void
 caffe_init()
 {
-	if (net)
-		return;
-
-	const char *model_file =   get_data_file("golast19.prototxt");
-	const char *trained_file = get_data_file("golast.trained");
-	if (open_data_file(model_file) == NULL  ||  open_data_file(trained_file) == NULL) {
-		if (DEBUGL(1))
-			fprintf(stderr, "No dcnn files found, will not use dcnn code.\n");
-    close(model_file);
-    close(trained_file);
+	if (net)  return;
+	
+	char model_file[256];    get_data_file(model_file, "golast19.prototxt");
+	char trained_file[256];  get_data_file(trained_file, "golast.trained");
+	if (!file_exists(model_file) || !file_exists(trained_file)) {
+		if (DEBUGL(1))  fprintf(stderr, "No dcnn files found, will not use dcnn code.\n");
 		return;
 	}
-
+	
 	Caffe::set_mode(Caffe::CPU);       
 	
 	/* Load the network. */

--- a/engine.h
+++ b/engine.h
@@ -7,6 +7,7 @@
 
 struct move_queue;
 
+typedef struct engine *(*engine_init_t)(char *arg, struct board *b);
 typedef enum parse_code (*engine_notify_t)(struct engine *e, struct board *b, int id, char *cmd, char *args, char **reply);
 typedef void (*engine_board_print_t)(struct engine *e, struct board *b, FILE *f);
 typedef char *(*engine_notify_play_t)(struct engine *e, struct board *b, struct move *m, char *enginearg);

--- a/engines/josekibase.c
+++ b/engines/josekibase.c
@@ -23,7 +23,7 @@ joseki_load(int bsize)
 {
 	char fname[1024];
 	snprintf(fname, 1024, "joseki%d.pdict", bsize - 2);
-	FILE *f = fopen(get_data_file(fname), "r");
+	FILE *f = fopen_data_file(fname, "r");
 	if (!f) {
 		if (DEBUGL(3))
 			perror(fname);

--- a/engines/josekibase.c
+++ b/engines/josekibase.c
@@ -23,7 +23,7 @@ joseki_load(int bsize)
 {
 	char fname[1024];
 	snprintf(fname, 1024, "joseki%d.pdict", bsize - 2);
-	FILE *f = fopen(fname, "r");
+	FILE *f = fopen(get_data_file(fname), "r");
 	if (!f) {
 		if (DEBUGL(3))
 			perror(fname);

--- a/engines/patternscan.c
+++ b/engines/patternscan.c
@@ -187,9 +187,9 @@ patternscan_done(struct engine *e)
 	/* Save newly found patterns. */
 
 	bool newfile = true;
-	FILE *f = fopen(spatial_dict_filename, "r");
+	FILE *f = fopen_data_file(spatial_dict_filename, "r");
 	if (f) { fclose(f); newfile = false; }
-	f = fopen(spatial_dict_filename, "a");
+	f = fopen_data_file(spatial_dict_filename, "a");
 	if (newfile)
 		spatial_dict_writeinfo(ps->pat.pc.spat_dict, f);
 

--- a/fbook.c
+++ b/fbook.c
@@ -68,7 +68,7 @@ fbook_init(char *filename, struct board *b)
 	    && fbcache->handicap == b->handicap)
 		return fbcache;
 
-	FILE *f = fopen(filename, "r");
+	FILE *f = fopen_data_file(filename, "r");
 	if (!f) {
 		perror(filename);
 		return NULL;

--- a/pachi.c
+++ b/pachi.c
@@ -230,6 +230,9 @@ int main(int argc, char *argv[])
 		open_log_port(log_port);
 
 	fprintf(stderr, "Pachi version %s\n", PACHI_VERSION);
+	if (DEBUGL(0) && getenv("DATA_DIR"))
+		fprintf(stderr, "Using data dir %s\n", getenv("DATA_DIR"));
+	
 	fast_srandom(seed);
 	if (DEBUGL(0))
 		fprintf(stderr, "Random seed: %d\n", seed);

--- a/pattern3.c
+++ b/pattern3.c
@@ -218,9 +218,9 @@ patterns_gen(struct pattern3s *p, char src[][11], int src_n)
 }
 
 static bool
-patterns_load(char src[][11], int src_n, char *filename)
+patterns_load(char src[][11], int src_n)
 {
-	FILE *f = fopen("moggy.patterns", "r");
+	FILE *f = fopen_data_file("moggy.patterns", "r");
 	if (!f) return false;
 
 	int i;
@@ -247,7 +247,7 @@ pattern3s_init(struct pattern3s *p, char src[][11], int src_n)
 {
 	char nsrc[src_n][11];
 
-	if (!patterns_load(nsrc, src_n, "moggy.patterns")) {
+	if (!patterns_load(nsrc, src_n)) {
 		/* Use default pattern set. */
 		for (int i = 0; i < src_n; i++)
 			strcpy(nsrc[i], src[i]);

--- a/patternprob.c
+++ b/patternprob.c
@@ -9,7 +9,6 @@
 #include "pattern.h"
 #include "patternsp.h"
 #include "patternprob.h"
-#include "util.h"
 
 
 /* We try to avoid needlessly reloading probability dictionary
@@ -26,7 +25,7 @@ pattern_pdict_init(char *filename, struct pattern_config *pc)
 
 	if (!filename)
 		filename = "patterns.prob";
-	FILE *f = fopen(get_data_file(filename), "r");
+	FILE *f = fopen_data_file(filename, "r");
 	if (!f) {
 		if (DEBUGL(1))
 			fprintf(stderr, "No pattern probtable, will not use learned patterns.\n");

--- a/patternprob.c
+++ b/patternprob.c
@@ -9,6 +9,7 @@
 #include "pattern.h"
 #include "patternsp.h"
 #include "patternprob.h"
+#include "util.h"
 
 
 /* We try to avoid needlessly reloading probability dictionary
@@ -25,7 +26,7 @@ pattern_pdict_init(char *filename, struct pattern_config *pc)
 
 	if (!filename)
 		filename = "patterns.prob";
-	FILE *f = fopen(filename, "r");
+	FILE *f = fopen(get_data_file(filename), "r");
 	if (!f) {
 		if (DEBUGL(1))
 			fprintf(stderr, "No pattern probtable, will not use learned patterns.\n");

--- a/patternsp.c
+++ b/patternsp.c
@@ -9,7 +9,6 @@
 #include "debug.h"
 #include "pattern.h"
 #include "patternsp.h"
-#include "util.h"
 
 /* Mapping from point sequence to coordinate offsets (to determine
  * coordinates relative to pattern center). The array is ordered
@@ -395,7 +394,7 @@ spatial_dict_init(bool will_append, bool hash)
 	if (cached_dict && !will_append)
 		return cached_dict;
 
-	FILE *f = fopen(get_data_file(spatial_dict_filename), "r");
+	FILE *f = fopen_data_file(spatial_dict_filename, "r");
 	if (!f && !will_append) {
 		if (DEBUGL(1))
 			fprintf(stderr, "No spatial dictionary, will not match spatial pattern features.\n");

--- a/patternsp.c
+++ b/patternsp.c
@@ -9,6 +9,7 @@
 #include "debug.h"
 #include "pattern.h"
 #include "patternsp.h"
+#include "util.h"
 
 /* Mapping from point sequence to coordinate offsets (to determine
  * coordinates relative to pattern center). The array is ordered
@@ -394,7 +395,7 @@ spatial_dict_init(bool will_append, bool hash)
 	if (cached_dict && !will_append)
 		return cached_dict;
 
-	FILE *f = fopen(spatial_dict_filename, "r");
+	FILE *f = fopen(get_data_file(spatial_dict_filename), "r");
 	if (!f && !will_append) {
 		if (DEBUGL(1))
 			fprintf(stderr, "No spatial dictionary, will not match spatial pattern features.\n");

--- a/util.h
+++ b/util.h
@@ -4,7 +4,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/stat.h>
 
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b));
@@ -18,6 +17,21 @@ void die(const char *format, ...)  __attribute__ ((noreturn));
 
 /* Terminate after system call failure (calls perror()) */
 void fail(char *msg) __attribute__ ((noreturn));
+
+int file_exists(const char *name);
+
+/**************************************************************************************************/
+/* Data files */
+
+/* Lookup data file in the following places:
+ * 1) Current directory
+ * 2) DATA_DIR environment variable / compile time default
+ * Copies first match to @buffer (if no match @filename is still copied). */
+#define get_data_file(buffer, filename)    get_data_file_(buffer, sizeof(buffer), filename)
+void get_data_file_(char buffer[], int size, const char *filename);
+
+/* get_data_file() + fopen() */
+FILE *fopen_data_file(const char *filename, const char *mode);
 
 
 /**************************************************************************************************/
@@ -116,30 +130,6 @@ strbuf_t *new_strbuf(int size);
  * Use sbprintf(buf, format, ...) to accumulate output. */
 int strbuf_printf(strbuf_t *buf, const char *format, ...);
 #define sbprintf strbuf_printf
-
-
-/**************************************************************************************************/
-
-/* Data-loading definitions */
-static inline const char *
-get_data_file(const char *filename)
-{
-  struct stat s;
-
-  if (stat(filename, &s) == 0) {
-    return filename;
-  }
-
-#ifdef DATA_DIR
-  char *data_dir_filename = malloc(strlen(DATA_DIR) + 1 + strlen(filename) + 1);
-  sprintf(data_dir_filename, "%s/%s", DATA_DIR, filename);
-  if (stat(data_dir_filename, &s) == 0) {
-    return (const char *)data_dir_filename;
-  }
-#endif
-
-  return NULL;
-}
 
 
 #endif

--- a/util.h
+++ b/util.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b));
@@ -115,6 +116,30 @@ strbuf_t *new_strbuf(int size);
  * Use sbprintf(buf, format, ...) to accumulate output. */
 int strbuf_printf(strbuf_t *buf, const char *format, ...);
 #define sbprintf strbuf_printf
+
+
+/**************************************************************************************************/
+
+/* Data-loading definitions */
+static inline const char *
+get_data_file(const char *filename)
+{
+  struct stat s;
+
+  if (stat(filename, &s) == 0) {
+    return filename;
+  }
+
+#ifdef DATA_DIR
+  char *data_dir_filename = malloc(strlen(DATA_DIR) + 1 + strlen(filename) + 1);
+  sprintf(data_dir_filename, "%s/%s", DATA_DIR, filename);
+  if (stat(data_dir_filename, &s) == 0) {
+    return (const char *)data_dir_filename;
+  }
+#endif
+
+  return NULL;
+}
 
 
 #endif


### PR DESCRIPTION
Cleaned up Adrian's branch from PR #58 and check `DATA_DIR` environment variable as well:

Pachi will look for extra data files (such as dcnn, pattern, joseki or fuseki database) in pachi's system directory (/usr/local/share/pachi by default) as well as current directory.

System data directory can be overridden at runtime by setting `DATA_DIR` environment variable.

Makefile:
`make install`:       install pachi binary
`make install-data`:  install data files
