### PR TITLE
Bug fix in json reporting for cans != 4

### DIFF
--- a/uct/walk.c
+++ b/uct/walk.c
@@ -158,7 +158,7 @@ uct_progress_json(struct uct *u, struct tree *t, enum stone color, int playouts,
 	while (--cans >= 0) {
 		if (!can[cans]) break;
 		/* Best sequence */
-		fprintf(stderr, "%s[", cans < 3 ? ", " : "");
+		fprintf(stderr, "[");
 		best = can[cans];
 		for (int depth = 0; depth < 4; depth++) {
 			if (!best || best->u.playouts < 25) break;
@@ -167,7 +167,7 @@ uct_progress_json(struct uct *u, struct tree *t, enum stone color, int playouts,
 				tree_node_get_value(t, 1, best->u.value));
 			best = u->policy->choose(u->policy, best, t->board, color, resign);
 		}
-		fprintf(stderr, "]");
+		fprintf(stderr, "]%s", cans > 0 ? ", " : "");
 	}
 	fprintf(stderr, "]");
 


### PR DESCRIPTION
The json formatting was incorrect for cans values (defined at line 146) different than 4.
I modified the values of **cans** to extract more data using **goreviewpartner** and found out about this bug.