### PR TITLE
fix warnings

### DIFF
--- a/board.c
+++ b/board.c
@@ -407,7 +407,7 @@ static char*
 print_target_move_handler(struct board *b, coord_t c, void *data)
 {	
 	static char buf[32];
-	coord_t target_move = (coord_t)data;
+	coord_t target_move = (coord_t)(intptr_t)data;
 
 	if (c == target_move)	sprintf(buf, "\e[40;33;1m*\e[0m");
 	else			sprintf(buf, "%c", stone2char(board_at(b, c)));
@@ -419,7 +419,7 @@ board_print_target_move(struct board *b, FILE *f, coord_t target_move)
 {
 	assert(!is_pass(target_move));
 	assert(board_at(b, target_move) == S_NONE);
-	board_hprint(b, f, print_target_move_handler, (void*)target_move);
+	board_hprint(b, f, print_target_move_handler, (void*)(intptr_t)target_move);
 }
 
 

--- a/caffe.h
+++ b/caffe.h
@@ -7,8 +7,8 @@ extern "C" {
 #endif
 
 
-bool caffe_ready();
-void caffe_init();
+bool caffe_ready(void);
+void caffe_init(void);
 void caffe_get_data(float *data, float *result, int planes, int size);
 
 #ifdef DCNN

--- a/caffe.h
+++ b/caffe.h
@@ -14,7 +14,7 @@ void caffe_get_data(float *data, float *result, int planes, int size);
 #ifdef DCNN
 void quiet_caffe(int argc, char *argv[]);
 #else
-#define quiet_caffe(argc, argv)
+#define quiet_caffe(argc, argv) ((void)0)
 #endif
 
 

--- a/chat.c
+++ b/chat.c
@@ -67,7 +67,7 @@ void chat_init(char *chat_file) {
 		fprintf(stderr, "Loaded %u chat entries from %s\n", (unsigned)(entry - chat_table), chat_file);
 }
 
-void chat_done() {
+void chat_done(void) {
 	if (chat_table) {
 		free(chat_table);
 		chat_table = NULL;
@@ -127,7 +127,7 @@ generic_chat(struct board *b, bool opponent, char *from, char *cmd, enum stone c
 #else
 void chat_init(char *chat_file) {}
 
-void chat_done() {}
+void chat_done(void) {}
 
 char
 *generic_chat(struct board *b, bool opponent, char *from, char *cmd, enum stone color, coord_t move,

--- a/chat.h
+++ b/chat.h
@@ -9,7 +9,7 @@
 struct board;
 
 void chat_init(char *chat_file);
-void chat_done();
+void chat_done(void);
 
 char *generic_chat(struct board *b, bool opponent, char *from, char *cmd, enum stone color, coord_t move,
 		   int playouts, int machines, int threads, double winrate, double extra_komi, char *score_est);

--- a/dcnn.c
+++ b/dcnn.c
@@ -12,8 +12,8 @@
 
 static bool dcnn_enabled = true;
 static bool dcnn_required = false;
-void disable_dcnn()     {  dcnn_enabled = false;  }
-void require_dcnn()     {  dcnn_required = true;  dcnn_init();  }
+void disable_dcnn(void)     {  dcnn_enabled = false;  }
+void require_dcnn(void)     {  dcnn_required = true;  dcnn_init();  }
 
 bool
 using_dcnn(struct board *b)
@@ -24,7 +24,7 @@ using_dcnn(struct board *b)
 }
 
 void
-dcnn_init()
+dcnn_init(void)
 {
 	if (dcnn_enabled)  caffe_init();
 	if (dcnn_required && !caffe_ready())  die("dcnn required, aborting.\n");

--- a/dcnn.h
+++ b/dcnn.h
@@ -7,12 +7,12 @@
 #define DCNN_BEST_N 20
 
 /* Ensure / disable dcnn */
-void require_dcnn(); 
-void disable_dcnn();
+void require_dcnn(void);
+void disable_dcnn(void);
 
 void dcnn_get_moves(struct board *b, enum stone color, float result[]);
 bool using_dcnn(struct board *b);
-void dcnn_init();
+void dcnn_init(void);
 void find_dcnn_best_moves(struct board *b, float *r, coord_t *best_c, float *best_r, int nbest);
 void print_dcnn_best_moves(struct board *b, coord_t *best_c, float *best_r, int nbest);
 

--- a/dcnn.h
+++ b/dcnn.h
@@ -32,10 +32,10 @@ coord2dcnn_idx(coord_t c, struct board *b)
 #else
 
 
-#define disable_dcnn()
+#define disable_dcnn() ((void)0)
 #define require_dcnn()     die("dcnn required but not compiled in, aborting.\n")
 #define using_dcnn(b)  0
-#define dcnn_init()
+#define dcnn_init() ((void)0)
 
 
 #endif

--- a/fifo.c
+++ b/fifo.c
@@ -176,14 +176,14 @@ attach_shm()
 /***************************************************************************************************/
 
 void
-fifo_init()
+fifo_init(void)
 {
 	if (!attach_shm())
 		create_shm();
 }
 
 int
-fifo_task_queue()
+fifo_task_queue(void)
 {
 	return ticket_lock(&shm->queue);
 }

--- a/fifo.h
+++ b/fifo.h
@@ -3,8 +3,8 @@
 
 #ifdef PACHI_FIFO
 
-void fifo_init();
-int  fifo_task_queue();
+void fifo_init(void);
+int  fifo_task_queue(void);
 void fifo_task_done(int ticket);
 
 #else

--- a/fifo.h
+++ b/fifo.h
@@ -8,7 +8,7 @@ int  fifo_task_queue(void);
 void fifo_task_done(int ticket);
 
 #else
-#define fifo_init()
+#define fifo_init() ((void)0)
 #endif /* FIFO */
 
 #endif /* PACHI_FIFO_H */

--- a/move.c
+++ b/move.c
@@ -20,7 +20,7 @@ coord2bstr(char *buf, coord_t c, struct board *board)
 		return "resign";
 	} else {
 		/* Some GTP servers are broken and won't grok lowercase coords */
-		snprintf(buf, 4, "%c%d", toupper(asdf[coord_x(c, board) - 1]), coord_y(c, board));
+		snprintf(buf, 4, "%c%u", toupper(asdf[coord_x(c, board) - 1]), coord_y(c, board) % 100);
 		return buf;
 	}
 }

--- a/network.c
+++ b/network.c
@@ -96,7 +96,8 @@ static int
 open_client_connection(char *port_name)
 {
 	char hostname[BSIZE];
-	strncpy(hostname, port_name, sizeof(hostname));
+	strncpy(hostname, port_name, sizeof(hostname)-1);
+	hostname[sizeof(hostname)-1] = 0;
 	char *port = strchr(hostname, ':');
 	assert(port);
 	*port++ = '\0';

--- a/patternsp.c
+++ b/patternsp.c
@@ -408,7 +408,7 @@ spatial_dict_hashstats(struct spatial_dict *dict)
 			dict->collisions, dict->repetitions,
 			(double) dict->fills * 100 / buckets,
 			dict->fills, buckets,
-			sizeof(dict->hash) / 1024 / 1024);
+			(int)(sizeof(dict->hash) / 1024 / 1024));
 }
 
 void

--- a/playout/moggy.c
+++ b/playout/moggy.c
@@ -1102,6 +1102,7 @@ playout_moggy_permit(struct playout_policy *p, struct board *b, struct move *m, 
 					m->coord = c;
 					return true;
 				}
+				/* FALLTHROUGH */
 			case 2: /* Try to switch to some 2-lib neighbor. */
 				for (int i = 0; i < 2; i++) {
 					coord_t l = board_group_info(b, group_at(b, c)).lib[i];

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -628,7 +628,8 @@ unit_test(char *filename)
 		optional = 0;
 		switch (line[0]) {
 			case '%':
-				strncpy(title, line, sizeof(title));
+				strncpy(title, line, sizeof(title)-1);
+				title[sizeof(title)-1] = 0;
 				if (DEBUGL(1))  fprintf(stderr, "\n%s\n", line);
 				continue;
 			case '!':

--- a/timeinfo.c
+++ b/timeinfo.c
@@ -220,8 +220,8 @@ time_str()
 {
     static char buf[80];
     time_t t = time(NULL);
-    strftime(buf, sizeof(buf), "%b %e %H:%M:%S", localtime(&t));
-    return buf;    
+    strftime(buf, sizeof(buf), "%b %d %H:%M:%S", localtime(&t));
+    return buf;
 }
 
 /* Sleep for a given interval (in seconds). Return immediately if interval < 0. */

--- a/util.h
+++ b/util.h
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#undef MIN
+#undef MAX
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b));
 #define MAX(a, b) ((a) > (b) ? (a) : (b));


### PR DESCRIPTION
This only fixes warnings with no semantic changes. Emitted by GCC 8.2.0.

The win32 `strftime(3)` change could be worked around with `#ifdef`'s but that's ugly.
