### PR TITLE
Dcnn pondering experiment

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -181,6 +181,14 @@ support the undo command.  The final_status_list command requires engine
 support.
 
 
+DCNN
+====
+
+dcnn.c has the code that prepares the input planes from board state and
+feeds that to caffe for dcnn evaluation (caffe.cpp). If you want to use
+a network with different inputs this is the place to accomodate it.
+
+
 General Pattern Matcher
 =======================
 

--- a/README.md
+++ b/README.md
@@ -92,19 +92,16 @@ overridden at runtime by setting `DATA_DIR` environment variable.
 
 ## DCNN support
 
-Pachi can use a neural network as source of good moves to consider (priors).
+Pachi can use a neural network as source of good moves to consider.
 With dcnn support Pachi can play at dan level strength on modest hardware.
 For large number of playouts this makes it about 1 stone stronger, and
 tends to make the games more pretty. A raw dcnn engine is available for
 pure dcnn play (not recommended for actual games, pachi won't know when to
 pass or resign !).
 
-Currently dcnn is used only for root node, and pondering and dcnn can't be
-used together (you should get a warning on startup).
-
 To build Pachi with DCNN support:
 - Install [Caffe](http://caffe.berkeleyvision.org)  
-  CPU only build is fine, no need for GPU, cuda or the other optional dependencies.  
+  CPU-only build is fine, no need for GPU, cuda or the other optional dependencies.  
   You need openblas for good performance.
 - Edit Makefile, set DCNN=1, point it to where caffe is installed and build.
 
@@ -114,9 +111,12 @@ Detlef Schmicker's 54% dcnn can be found at:
 
 More information about this dcnn [here](http://computer-go.org/pipermail/computer-go/2015-December/008324.html).
 
-If you want to use a network with different inputs you'll have to tweak
-dcnn.c to accomodate it. Pachi will check for `golast19.prototxt` and
-`golast.trained` files on startup.
+Pachi will look for `golast19.prototxt` and `golast.trained` files on startup.
+
+Althouh it was trained on 19x19 it can be used on other board sizes as well since
+it's fully convolutional (Right now Pachi will use it all the way down to 13x13).
+Currently dcnn is used only for root node, dcnn + pondering is working now.
+(see `dcnn_pondering_prior` and `dcnn_pondering_mcts` uct params to tweak it).
 
 
 ## How to run

--- a/dcnn.c
+++ b/dcnn.c
@@ -15,6 +15,8 @@ static bool dcnn_required = false;
 void disable_dcnn(void)  {  dcnn_enabled = false;  }
 void require_dcnn(void)  {  dcnn_required = true;  }
 
+static void detlef54_dcnn_eval(struct board *b, enum stone color, float result[]);
+
 static bool
 dcnn_supported_board_size(struct board *b)
 {
@@ -38,10 +40,23 @@ dcnn_init(struct board *b)
 }
 
 void
+dcnn_evaluate_quiet(struct board *b, enum stone color, float result[])
+{
+	detlef54_dcnn_eval(b, color, result);
+}
+
+void
 dcnn_evaluate(struct board *b, enum stone color, float result[])
 {
+	double time_start = time_now();	
+	detlef54_dcnn_eval(b, color, result);
+	if (DEBUGL(2))  fprintf(stderr, "dcnn in %.2fs\n", time_now() - time_start);
+}
+
+static void
+detlef54_dcnn_eval(struct board *b, enum stone color, float result[])
+{
 	assert(dcnn_supported_board_size(b));
-	double time_start = time_now();
 
 	int size = real_board_size(b);
 	int dsize = 13 * size * size;
@@ -77,7 +92,6 @@ dcnn_evaluate(struct board *b, enum stone color, float result[])
 
 	caffe_get_data(data, result, 13, size);
 	free(data);
-	if (DEBUGL(2))  fprintf(stderr, "dcnn in %.2fs\n", time_now() - time_start);
 }
 
 
@@ -104,3 +118,4 @@ print_dcnn_best_moves(struct board *b, coord_t *best_c, float *best_r, int nbest
 		fprintf(stderr, "%-3i ", (int)(best_r[i] * 100));
 	fprintf(stderr, "]\n");
 }
+

--- a/dcnn.h
+++ b/dcnn.h
@@ -11,6 +11,7 @@ void require_dcnn(void);
 void disable_dcnn(void);
 
 void dcnn_evaluate(struct board *b, enum stone color, float result[]);
+void dcnn_evaluate_quiet(struct board *b, enum stone color, float result[]);
 bool using_dcnn(struct board *b);
 void dcnn_init(struct board *b);
 void get_dcnn_best_moves(struct board *b, float *r, coord_t *best_c, float *best_r, int nbest);

--- a/mq.h
+++ b/mq.h
@@ -86,11 +86,10 @@ mq_append(struct move_queue *qd, struct move_queue *qs)
 static inline void
 mq_nodup(struct move_queue *q)
 {
-	for (unsigned int i = 1; i < 4; i++) {
-		if (q->moves <= i)
-			return;
-		if (q->move[q->moves - 1 - i] == q->move[q->moves - 1]) {
-			q->tag[q->moves - 1 - i] |= q->tag[q->moves - 1];
+	unsigned int n = q->moves;
+	for (unsigned int i = 0; i < n - 1; i++) {
+		if (q->move[i] == q->move[n - 1]) {
+			q->tag[i] |= q->tag[n - 1];
 			q->moves--;
 			return;
 		}

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -58,13 +58,17 @@ struct uct {
 		TM_TREEVL, /* Tree parallelization with virtual loss. */
 	} thread_model;
 	int virtual_loss;
-	bool pondering_opt; /* User wants pondering */
-	bool pondering; /* Actually pondering now */
 	bool slave; /* Act as slave in distributed engine. */
 	int max_slaves; /* Optional, -1 if not set */
 	int slave_index; /* 0..max_slaves-1, or -1 if not set */
 	enum stone my_color;
 
+	bool pondering_opt;                /* User wants pondering */
+	bool pondering;                    /* Actually pondering now */
+	int     dcnn_pondering_prior;      /* Prior next move guesses */
+	int     dcnn_pondering_mcts;       /* Genmove next move guesses */
+	coord_t dcnn_pondering_mcts_c[20];
+	
 	int fuseki_end;
 	int yose_start;
 
@@ -123,12 +127,13 @@ struct uct {
 	/* Saved dead groups, for final_status_list dead */
 	struct move_queue dead_groups;
 	int pass_moveno;
-
+	
 	/* Timing */
 	double mcts_time_start;
 
 	/* Game state - maintained by setup_state(), reset_state(). */
 	struct tree *t;
+	bool tree_ready;
 };
 
 #define UDEBUGL(n) DEBUGL_(u->debug_level, n)

--- a/uct/prior.h
+++ b/uct/prior.h
@@ -58,5 +58,6 @@ add_prior_value(struct prior_map *map, coord_t c, floating_t value, int playouts
 
 /* Display node's priors best moves */
 void print_node_prior_best_moves(struct board *b, struct tree_node *parent);
+void get_node_prior_best_moves(struct tree_node *parent, coord_t *best_c, float *best_r, int nbest);
 
 #endif

--- a/uct/search.c
+++ b/uct/search.c
@@ -618,9 +618,7 @@ uct_search_result(struct uct *u, struct board *b, enum stone color,
 					(score > 0 ? "B+" : "W+"), fabs(score));
 			}
 			*best_coord = pass;
-			best = u->t->root->children; // pass is the first child
-			assert(is_pass(node_coord(best)));
-			return best;
+			return NULL;
 		}
 		if (UDEBUGL(0))	fprintf(stderr, "Refusing to pass: %s\n", msg);
 	}

--- a/uct/search.h
+++ b/uct/search.h
@@ -41,6 +41,7 @@ struct uct_thread_ctx {
 	unsigned long seed;
 	int games;
 	struct time_info *ti;
+	struct uct_search_state *s;
 };
 
 

--- a/uct/tree.c
+++ b/uct/tree.c
@@ -18,6 +18,7 @@
 #include "uct/prior.h"
 #include "uct/tree.h"
 #include "uct/slave.h"
+#include "dcnn.h"
 
 
 /* Allocate tree node(s). The returned nodes are initialized with zeroes.
@@ -795,12 +796,18 @@ tree_promote_node(struct tree *tree, struct tree_node **node)
 }
 
 bool
-tree_promote_at(struct tree *t, struct board *b, coord_t c)
+tree_promote_at(struct tree *t, struct board *b, coord_t c, int *reason)
 {
+	*reason = 0;
 	tree_fix_symmetry(t, b, c);
 
 	struct tree_node *n = tree_get_node(t->root, c);
 	if (!n)  return false;
+	
+	if (using_dcnn(b) && !(n->hints & TREE_HINT_DCNN)) {
+		*reason = TREE_HINT_DCNN;
+		return false;  /* No dcnn priors, can't reuse ... */
+	}
 	
 	tree_promote_node(t, &n);
 	return true;

--- a/uct/tree.h
+++ b/uct/tree.h
@@ -86,6 +86,7 @@ struct tree_node {
 	unsigned char d;
 
 #define TREE_HINT_INVALID 1 // don't go to this node, invalid move
+#define TREE_HINT_DCNN    2 // node has dcnn priors
 	unsigned char hints;
 
 	/* In case multiple threads walk the tree, is_expanded is set
@@ -161,7 +162,7 @@ struct tree_node *tree_get_node(struct tree_node *parent, coord_t c);
 struct tree_node *tree_get_node2(struct tree *tree, struct tree_node *parent, coord_t c, bool create);
 struct tree_node *tree_garbage_collect(struct tree *tree, struct tree_node *node);
 void tree_promote_node(struct tree *tree, struct tree_node **node);
-bool tree_promote_at(struct tree *tree, struct board *b, coord_t c);
+bool tree_promote_at(struct tree *tree, struct board *b, coord_t c, int *reason);
 
 void tree_expand_node(struct tree *tree, struct tree_node *node, struct board *b, enum stone color, struct uct *u, int parity);
 struct tree_node *tree_lnode_for_node(struct tree *tree, struct tree_node *ni, struct tree_node *lni, int tenuki_d);


### PR DESCRIPTION
Experiment to get dcnn pondering working on the cpu:

Tree search is heavily influenced by initial priors so we can't just reuse the tree and inject dcnn priors later on. But if we can guess opponent's next move then we can do some useful work at pondering time: evaluate dcnn and run tree search ahead of time. Later on when play command arrives we just promote the node and reuse the tree if it matches our guess. If it doesn't match we discard search results and start from scratch.

So after genmove is over, reset the tree, get dcnn priors for our move and likely opponent moves (guess from dcnn priors and genmove search results) and start pondering as usual.

This makes sense when using cpu for dcnn evaluation which is very slow, with a gpu you could evaluate dcnn for every node even during tree search so no need to go through such restrictions.

Number of guesses is controlled by 2 uct params:

* `dcnn_pondering_prior`:  number of guesses from prior best moves (default: 5)
* `dcnn_pondering_mcts`:  number of guesses from genmove search   (default: 3)

For slow games it makes sense to increase this: we spend more time before actual search starts but there's more chance we guess right, so that pondering will be useful. If we guess wrong search results will be discarded and pondering will not be useful for this move. For fast games try decreasing it.
