### PR TITLE
C++ Pachi, Type cleanup

### DIFF
--- a/board.c
+++ b/board.c
@@ -152,7 +152,7 @@ board_resize(struct board *board, int size)
 	while ((1 << board->bits2) < board->size2) board->bits2++;
 }
 
-struct board_statics board_statics = { .size = 0 };
+struct board_statics board_statics = { 0, };
 
 static void
 board_statics_init(struct board *board)
@@ -562,8 +562,7 @@ break_symmetry:
 static void
 board_handicap_stone(struct board *board, int x, int y, struct move_queue *q)
 {
-	struct move m;
-	m.color = S_BLACK; m.coord = coord_xy(board, x, y);
+	struct move m = move(coord_xy(board, x, y), S_BLACK);
 
 	int r = board_play(board, &m);  assert(r >= 0);
 
@@ -1403,7 +1402,7 @@ board_undo_suicide(struct board *b, struct board_undo *u, struct move *m)
 	enum stone other_color = stone_other(m->color);
 	
 	// Pretend it's capture ...
-	struct move m2 = { .coord = m->coord, .color = other_color };
+	struct move m2 = move(m->coord, other_color);
 	b->captures[other_color] -= u->ncaptures;
 	
 	restore_suicide(b, u, &m2);

--- a/board.c
+++ b/board.c
@@ -62,7 +62,7 @@ board_init(board_t *b, int bsize, char *fbookfile)
 board_t *
 board_new(int bsize, char *fbookfile)
 {
-	board_t *b = malloc2(sizeof(board_t));
+	board_t *b = malloc2(board_t);
 	board_init(b, bsize, fbookfile);
 	return b;
 }

--- a/board.c
+++ b/board.c
@@ -424,7 +424,7 @@ board_hash_update(board_t *board, coord_t coord, enum stone color)
 {
 	board->hash ^= hash_at(coord, color);
 	if (DEBUGL(8))
-		fprintf(stderr, "board_hash_update(%d,%d,%d) ^ %"PRIhash" -> %"PRIhash"\n", color, coord_x(coord), coord_y(coord), hash_at(coord, color), board->hash);
+		fprintf(stderr, "board_hash_update(%d,%d,%d) ^ %" PRIhash " -> %" PRIhash "\n", color, coord_x(coord), coord_y(coord), hash_at(coord, color), board->hash);
 
 #if defined(BOARD_PAT3)
 	/* @color is not what we need in case of capture. */
@@ -457,7 +457,7 @@ static void profiling_noinline
 board_hash_commit(board_t *board)
 {
 	if (DEBUGL(8))
-		fprintf(stderr, "board_hash_commit %"PRIhash"\n", board->hash);
+		fprintf(stderr, "board_hash_commit %" PRIhash "\n", board->hash);
 	if (likely(board->history_hash[board->hash & history_hash_mask]) == 0) {
 		board->history_hash[board->hash & history_hash_mask] = board->hash;
 		return;
@@ -1479,13 +1479,15 @@ board_play_random(board_t *b, enum stone color, coord_t *coord, ppr_permit permi
 	if (unlikely(b->flen == 0))
 		goto play_pass;
 
-	int base = fast_random(b->flen), f;
-	for (f = base; f < b->flen; f++)
-		if (board_try_random_move(b, color, coord, f, permit, permit_data))
-			return;
-	for (f = 0; f < base; f++)
-		if (board_try_random_move(b, color, coord, f, permit, permit_data))
-			return;
+	{
+		int base = fast_random(b->flen), f;
+		for (f = base; f < b->flen; f++)
+			if (board_try_random_move(b, color, coord, f, permit, permit_data))
+				return;
+		for (f = 0; f < base; f++)
+			if (board_try_random_move(b, color, coord, f, permit, permit_data))
+				return;
+	}
 
 play_pass:
 	*coord = pass;
@@ -1499,10 +1501,10 @@ play_pass:
 bool
 board_is_false_eyelike(board_t *board, coord_t coord, enum stone eye_color)
 {
-	enum stone color_diag_libs[S_MAX] = {0, 0, 0, 0};
+	int color_diag_libs[S_MAX] = {0, 0, 0, 0};
 
 	foreach_diag_neighbor(board, coord) {
-		color_diag_libs[(enum stone) board_at(board, c)]++;
+		color_diag_libs[board_at(board, c)]++;
 	} foreach_diag_neighbor_end;
 	
 	/* For false eye, we need two enemy stones diagonally in the

--- a/board.h
+++ b/board.h
@@ -457,7 +457,7 @@ void board_quick_undo(struct board *b, struct move *m, struct board_undo *u);
 #define with_move(board_, coord_, color_, body_) \
        do { \
 	       struct board *board__ = (board_);  /* For with_move_return() */		\
-               struct move m_ = { .coord = (coord_), .color = (color_) }; \
+               struct move m_ = move((coord_), (color_));	  \
                struct board_undo u_; \
                if (board_quick_play(board__, &m_, &u_) >= 0) {	  \
 	               do { body_ } while(0);                     \
@@ -474,7 +474,7 @@ void board_quick_undo(struct board *b, struct move *m, struct board_undo *u);
 #define with_move_strict(board_, coord_, color_, body_) \
        do { \
 	       struct board *board__ = (board_);  /* For with_move_return() */		\
-               struct move m_ = { .coord = (coord_), .color = (color_) }; \
+               struct move m_ = move((coord_), (color_));	  \
                struct board_undo u_; \
                assert (board_quick_play(board__, &m_, &u_) >= 0);  \
                do { body_ } while(0);                     \

--- a/board.h
+++ b/board.h
@@ -287,13 +287,16 @@ struct board_undo {
 /* Avoid unused variable warnings */
 #define board_size(b)  (((b) == (b)) ? BOARD_SIZE + 2 : 0)
 #define board_size2(b) (board_size(b) * board_size(b))
+#define the_board_size()  (BOARD_SIZE + 2)
 #else
 #define board_size(b)  ((b)->size)
 #define board_size2(b) ((b)->size2)
+#define the_board_size()  (board_statics.size)
 #endif
 
 #define real_board_size(b)  (board_size(b) - 2)
 #define real_board_size2(b) (real_board_size(b) * real_board_size(b))
+#define the_real_board_size()  (the_board_size() - 2)
 
 /* This is a shortcut for taking different action on smaller
  * and large boards (e.g. picking different variable defaults).
@@ -662,15 +665,15 @@ group_stone_count(struct board *b, group_t group, int max)
 static inline bool
 board_coord_in_symmetry(struct board *b, coord_t c)
 {
-	if (coord_y(c, b) < b->symmetry.y1 || coord_y(c, b) > b->symmetry.y2)
+	if (coord_y(c) < b->symmetry.y1 || coord_y(c) > b->symmetry.y2)
 		return false;
-	if (coord_x(c, b) < b->symmetry.x1 || coord_x(c, b) > b->symmetry.x2)
+	if (coord_x(c) < b->symmetry.x1 || coord_x(c) > b->symmetry.x2)
 		return false;
 	if (b->symmetry.d) {
-		int x = coord_x(c, b);
+		int x = coord_x(c);
 		if (b->symmetry.type == SYM_DIAG_DOWN)
 			x = board_size(b) - 1 - x;
-		if (x > coord_y(c, b))
+		if (x > coord_y(c))
 			return false;
 	}
 	return true;

--- a/board.h
+++ b/board.h
@@ -37,7 +37,7 @@ struct ownermap;
 #define BOARD_MAX_GROUPS (BOARD_MAX_SIZE * BOARD_MAX_SIZE * 2 / 3)
 /* For 19x19, max 19*2*6 = 228 groups (stacking b&w stones, each third line empty) */
 
-enum e_sym {
+enum symmetry {
 		SYM_FULL,
 		SYM_DIAG_UP,
 		SYM_DIAG_DOWN,
@@ -49,7 +49,7 @@ enum e_sym {
 
 /* Some engines might normalize their reading and skip symmetrical
  * moves. We will tell them how can they do it. */
-struct board_symmetry {
+typedef struct {
 	/* Playground is in this rectangle. */
 	int x1, x2, y1, y2;
 	/* d ==  0: Full rectangle
@@ -58,8 +58,8 @@ struct board_symmetry {
 	/* General symmetry type. */
 	/* Note that the above is redundant to this, but just provided
 	 * for easier usage. */
-	enum e_sym type;
-};
+	enum symmetry type;
+} board_symmetry_t;
 
 
 typedef uint64_t hash_t;
@@ -74,7 +74,7 @@ typedef uint32_t hash3_t; // 3x3 pattern hash
  * connected for us. */
 typedef coord_t group_t;
 
-struct group {
+typedef struct {
 	/* We keep track of only up to GROUP_KEEP_LIBS; over that, we
 	 * don't care. */
 	/* _Combination_ of these two values can make some difference
@@ -88,11 +88,11 @@ struct group {
 	 * It denotes only number of items in lib[], thus you can rely
 	 * on it to store real liberties only up to <= GROUP_REFILL_LIBS. */
 	int libs;
-};
+} group_info_t;
 
-struct neighbor_colors {
+typedef struct {
 	char colors[S_MAX];
-};
+} neighbors_t;
 
 
 /* Quick hack to help ensure tactics code stays within quick board limitations.
@@ -115,7 +115,7 @@ struct neighbor_colors {
  * However, we accept suicide moves by the opponent, so we
  * should work with rules allowing suicide, just not taking
  * full advantage of them. */
-enum go_ruleset {
+enum rules {
 	RULES_CHINESE, /* default value */
 	RULES_AGA,
 	RULES_NEW_ZEALAND,
@@ -135,7 +135,7 @@ enum go_ruleset {
 };
 
 /* Data shared by all boards of a given size */
-struct board_statics {
+typedef struct {
 	int size;	
 
 	/* Iterator offsets for foreach_neighbor*() */
@@ -146,15 +146,15 @@ struct board_statics {
 
 	/* Cached information on x-y coordinates so that we avoid division. */
 	uint8_t coord[BOARD_MAX_COORDS][2];
-};
+} board_statics_t;
 
 /* Only one board size in use at any given time so don't need array */
-extern struct board_statics board_statics;
+extern board_statics_t board_statics;
 
 /* You should treat this struct as read-only. Always call functions below if
  * you want to change it. */
 
-struct board {
+typedef struct board {
 	int size; /* Including S_OFFBOARD margin - see below. */
 	int size2; /* size^2 */
 	int bits2; /* ceiling(log2(size2)) */
@@ -162,15 +162,15 @@ struct board {
 	int passes[S_MAX];
 	floating_t komi;
 	int handicap;
-	enum go_ruleset rules;
+	enum rules rules;
 	char *fbookfile;
 	struct fbook *fbook;
 
 	int moves;
-	struct move last_move;
-	struct move last_move2; /* second-to-last move */
-FB_ONLY(struct move last_move3); /* just before last_move2, only set if last_move is pass */
-FB_ONLY(struct move last_move4); /* just before last_move3, only set if last_move & last_move2 are pass */
+	move_t last_move;
+	move_t last_move2; /* second-to-last move */
+FB_ONLY(move_t last_move3); /* just before last_move2, only set if last_move is pass */
+FB_ONLY(move_t last_move4); /* just before last_move3, only set if last_move & last_move2 are pass */
 	/* Whether we tried to add a hash twice; board_play*() can
 	 * set this, but it will still carry out the move as well! */
 FB_ONLY(bool superko_violation);
@@ -188,7 +188,7 @@ FB_ONLY(bool superko_violation);
 	/* Positions of next stones in the stone group; 0 == last stone */
 	coord_t p[BOARD_MAX_COORDS];
 	/* Neighboring colors; numbers of neighbors of index color */
-	struct neighbor_colors n[BOARD_MAX_COORDS];
+	neighbors_t n[BOARD_MAX_COORDS];
 
 #ifdef BOARD_PAT3
 	/* 3x3 pattern code for each position; see pattern3.h for encoding
@@ -197,7 +197,7 @@ FB_ONLY(hash3_t pat3)[BOARD_MAX_COORDS];
 #endif
 
 	/* Group information - indexed by gid (which is coord of base group stone) */
-	struct group gi[BOARD_MAX_COORDS];
+	group_info_t gi[BOARD_MAX_COORDS];
 
 	/* List of free positions */
 	/* Note that free position here is any valid move; including single-point eyes!
@@ -212,14 +212,14 @@ FB_ONLY(group_t c)[BOARD_MAX_GROUPS];  FB_ONLY(int clen);
 #endif
 
 	/* Symmetry information */
-FB_ONLY(struct board_symmetry symmetry);
+FB_ONLY(board_symmetry_t symmetry);
 
 	/* Last ko played on the board. */
-FB_ONLY(struct move last_ko);
+FB_ONLY(move_t last_ko);
 FB_ONLY(int last_ko_age);
 
 	/* Basic ko check */
-	struct move ko;
+	move_t ko;
 
 #ifdef BOARD_UNDO_CHECKS
 	/* Guard against invalid quick_play() / quick_undo() uses */
@@ -248,39 +248,39 @@ FB_ONLY(int last_ko_age);
 FB_ONLY(hash_t history_hash)[1 << history_hash_bits];
 	/* Hash of current board position. */
 FB_ONLY(hash_t hash);
-};
+} board_t;
 
-struct undo_merge {
+typedef struct {
 	group_t	     group;
 	coord_t	     last;  
-	struct group info;
-};
+	group_info_t info;
+} undo_merge_t;
 
-struct undo_enemy {
+typedef struct {
 	group_t      group;
-	struct group info;
+	group_info_t info;
 	coord_t     *stones;
-};
+} undo_enemy_t;
 
-struct board_undo {
-	struct move last_move2;
-	struct move ko;
-	struct move last_ko;
-	int	    last_ko_age;
+typedef struct {
+	move_t  last_move2;
+	move_t  ko;
+	move_t  last_ko;
+	int     last_ko_age;
 	
 	coord_t next_at;
 	
 	coord_t	inserted;
-	struct undo_merge merged[4];
+	undo_merge_t merged[4];
 	int nmerged;
 	int nmerged_tmp;
 
-	struct undo_enemy enemies[4];
+	undo_enemy_t enemies[4];
 	int nenemies;
 	coord_t  captures[BOARD_MAX_COORDS];
 	coord_t *captures_end;
 	int      ncaptures;
-};
+} board_undo_t;
 
 
 #ifdef BOARD_SIZE
@@ -344,90 +344,89 @@ struct board_undo {
 
 #define hash_at(coord, color) (board_statics.h[(color) == S_BLACK][coord])
 
-void board_init(struct board *b, int bsize, char *fbookfile);
-struct board *board_new(int bsize, char *fbookfile);
-struct board *board_copy(struct board *board2, struct board *board1);
-void board_done_noalloc(struct board *board);
-void board_done(struct board *board);
+void board_init(board_t *b, int bsize, char *fbookfile);
+board_t *board_new(int bsize, char *fbookfile);
+board_t *board_copy(board_t *board2, board_t *board1);
+void board_done_noalloc(board_t *board);
+void board_done(board_t *board);
 /* size here is without the S_OFFBOARD margin. */
-void board_resize(struct board *board, int size);
-void board_clear(struct board *board);
+void board_resize(board_t *board, int size);
+void board_clear(board_t *board);
 
-typedef void  (*board_cprint)(struct board *b, coord_t c, strbuf_t *buf, void *data);
-typedef char *(*board_print_handler)(struct board *b, coord_t c, void *data);
-void board_print(struct board *board, FILE *f);
-void board_print_custom(struct board *board, FILE *f, board_cprint cprint, void *data);
-void board_hprint(struct board *board, FILE *f, board_print_handler handler, void *data);
+typedef void  (*board_cprint)(board_t *b, coord_t c, strbuf_t *buf, void *data);
+typedef char *(*board_print_handler)(board_t *b, coord_t c, void *data);
+void board_print(board_t *board, FILE *f);
+void board_print_custom(board_t *board, FILE *f, board_cprint cprint, void *data);
+void board_hprint(board_t *board, FILE *f, board_print_handler handler, void *data);
 /* @target_move displayed as '*' (must be empty spot) */
-void board_print_target_move(struct board *b, FILE *f, coord_t target_move);
+void board_print_target_move(board_t *b, FILE *f, coord_t target_move);
 
 /* Debugging: Compare 2 boards byte by byte. Don't use that for sorting =) */
-int board_cmp(struct board *b1, struct board *b2);
+int board_cmp(board_t *b1, board_t *b2);
 /* Same but only care about fields maintained by quick_play() / quick_undo() */
-int board_quick_cmp(struct board *b1, struct board *b2);
+int board_quick_cmp(board_t *b1, board_t *b2);
 
 /* Place given handicap on the board; coordinates are printed to f. */
-void board_handicap(struct board *board, int stones, struct move_queue *q);
+void board_handicap(board_t *board, int stones, move_queue_t *q);
 
 /* Returns group id, 0 on allowed suicide, pass or resign, -1 on error */
-int board_play(struct board *board, struct move *m);
+int board_play(board_t *board, move_t *m);
 /* Like above, but plays random move; the move coordinate is recorded
  * to *coord. This method will never fill your own eye. pass is played
  * when no move can be played. You can impose extra restrictions if you
  * supply your own permit function; the permit function can also modify
  * the move coordinate to redirect the move elsewhere. */
-typedef bool (*ppr_permit)(struct board *b, struct move *m, void *data);
-bool board_permit(struct board *b, struct move *m, void *data);
-void board_play_random(struct board *b, enum stone color, coord_t *coord, ppr_permit permit, void *permit_data);
+typedef bool (*ppr_permit)(board_t *b, move_t *m, void *data);
+bool board_permit(board_t *b, move_t *m, void *data);
+void board_play_random(board_t *b, enum stone color, coord_t *coord, ppr_permit permit, void *permit_data);
 
 /* Returns true if given move can be played. */
-static bool board_is_valid_play(struct board *b, enum stone color, coord_t coord);
-static bool board_is_valid_move(struct board *b, struct move *m);
+static bool board_is_valid_play(board_t *b, enum stone color, coord_t coord);
+static bool board_is_valid_move(board_t *b, move_t *m);
 /* Returns true if ko was just taken. */
-static bool board_playing_ko_threat(struct board *b);
+static bool board_playing_ko_threat(board_t *b);
 /* Returns true if the move is not obvious self-atari. */
-static bool board_safe_to_play(struct board *b, coord_t coord, enum stone color);
+static bool board_safe_to_play(board_t *b, coord_t coord, enum stone color);
 
 /* Determine number of stones in a group, up to @max stones. */
-static int group_stone_count(struct board *b, group_t group, int max);
+static int group_stone_count(board_t *b, group_t group, int max);
 
 #ifndef QUICK_BOARD_CODE
 /* Adjust symmetry information as if given coordinate has been played. */
-void board_symmetry_update(struct board *b, struct board_symmetry *symmetry, coord_t c);
+void board_symmetry_update(board_t *b, board_symmetry_t *symmetry, coord_t c);
 /* Check if coordinates are within symmetry base. (If false, they can
  * be derived from the base.) */
-static bool board_coord_in_symmetry(struct board *b, coord_t c);
+static bool board_coord_in_symmetry(board_t *b, coord_t c);
 #endif
 
 /* Returns true if given coordinate has all neighbors of given color or the edge. */
-static bool board_is_eyelike(struct board *board, coord_t coord, enum stone eye_color);
+static bool board_is_eyelike(board_t *board, coord_t coord, enum stone eye_color);
 /* Returns true if given coordinate could be a false eye; this check makes
  * sense only if you already know the coordinate is_eyelike(). */
-bool board_is_false_eyelike(struct board *board, coord_t coord, enum stone eye_color);
+bool board_is_false_eyelike(board_t *board, coord_t coord, enum stone eye_color);
 /* Returns true if given coordinate is a 1-pt eye (checks against false eyes, or
  * at least tries to). */
-bool board_is_one_point_eye(struct board *board, coord_t c, enum stone eye_color);
+bool board_is_one_point_eye(board_t *board, coord_t c, enum stone eye_color);
 /* Returns 1pt eye color (can be false-eye) */
-enum stone board_eye_color(struct board *board, coord_t c);
+enum stone board_eye_color(board_t *board, coord_t c);
 
 /* board_official_score() is the scoring method for yielding score suitable
  * for external presentation. For fast scoring of entirely filled boards
  * (e.g. playouts), use board_fast_score(). */
 /* Positive: W wins */
 /* Compare number of stones + 1pt eyes. */
-floating_t board_fast_score(struct board *board);
-floating_t board_score(struct board *b, int scores[S_MAX]);
+floating_t board_fast_score(board_t *board);
+floating_t board_score(board_t *b, int scores[S_MAX]);
 /* Tromp-Taylor scoring, assuming given groups are actually dead. */
-struct move_queue;
-floating_t board_official_score(struct board *board, struct move_queue *dead);
-floating_t board_official_score_color(struct board *board, struct move_queue *dead, enum stone color);
-floating_t board_official_score_details(struct board *board, struct move_queue *dead, int *dame, int *seki, int *ownermap, struct ownermap *po);
-void       board_print_official_ownermap(struct board *b, int *final_ownermap);
+floating_t board_official_score(board_t *board, move_queue_t *dead);
+floating_t board_official_score_color(board_t *board, move_queue_t *dead, enum stone color);
+floating_t board_official_score_details(board_t *board, move_queue_t *dead, int *dame, int *seki, int *ownermap, struct ownermap *po);
+void       board_print_official_ownermap(board_t *b, int *final_ownermap);
 
 /* Set board rules according to given string. Returns false in case
  * of unknown ruleset name. */
-bool board_set_rules(struct board *board, char *name);
-const char *rules2str(enum go_ruleset rules);
+bool board_set_rules(board_t *board, char *name);
+const char *rules2str(enum rules rules);
 
 /* Quick play/undo to try out a move.
  * WARNING  Only core board structures are maintained !
@@ -448,8 +447,8 @@ const char *rules2str(enum go_ruleset rules);
  * Invalid quick_play()/quick_undo() combinations (missing undo for example)
  * are caught at next board_play() if BOARD_UNDO_CHECKS is defined.
  */
-int  board_quick_play(struct board *board, struct move *m, struct board_undo *u);
-void board_quick_undo(struct board *b, struct move *m, struct board_undo *u);
+int  board_quick_play(board_t *board, move_t *m, board_undo_t *u);
+void board_quick_undo(board_t *b, move_t *m, board_undo_t *u);
 
 /* quick_play() + quick_undo() combo.
  * Body is executed only if move is valid (silently ignored otherwise).
@@ -459,9 +458,9 @@ void board_quick_undo(struct board *b, struct move *m, struct board_undo *u);
  * though. */
 #define with_move(board_, coord_, color_, body_) \
        do { \
-	       struct board *board__ = (board_);  /* For with_move_return() */		\
-               struct move m_ = move((coord_), (color_));	  \
-               struct board_undo u_; \
+	       board_t *board__ = (board_);  /* For with_move_return() */		\
+               move_t m_ = move((coord_), (color_));	  \
+               board_undo_t u_; \
                if (board_quick_play(board__, &m_, &u_) >= 0) {	  \
 	               do { body_ } while(0);                     \
                        board_quick_undo(board__, &m_, &u_); \
@@ -476,9 +475,9 @@ void board_quick_undo(struct board *b, struct move *m, struct board_undo *u);
 /* Same as with_move() but assert out in case of invalid move. */
 #define with_move_strict(board_, coord_, color_, body_) \
        do { \
-	       struct board *board__ = (board_);  /* For with_move_return() */		\
-               struct move m_ = move((coord_), (color_));	  \
-               struct board_undo u_; \
+	       board_t *board__ = (board_);  /* For with_move_return() */		\
+               move_t m_ = move((coord_), (color_));	  \
+               board_undo_t u_; \
                assert (board_quick_play(board__, &m_, &u_) >= 0);  \
                do { body_ } while(0);                     \
                board_quick_undo(board__, &m_, &u_); \
@@ -509,7 +508,7 @@ void board_quick_undo(struct board *b, struct move *m, struct board_undo *u);
 
 #define foreach_in_group(board_, group_) \
 	do { \
-		struct board *board__ = board_; \
+		board_t *board__ = board_; \
 		for (coord_t c = group_base(group_); c; c = groupnext_at(board__, c))
 #define foreach_in_group_end \
 	} while (0)
@@ -518,7 +517,7 @@ void board_quick_undo(struct board *b, struct move *m, struct board_undo *u);
  * on S_OFFBOARD coordinates. */
 #define foreach_neighbor(board_, coord_, loop_body) \
 	do { \
-		struct board *board__ = board_; \
+		board_t *board__ = board_; \
 		coord_t coord__ = coord_; \
 		coord_t c; \
 		c = coord__ - board_size(board__); do { loop_body } while (0); \
@@ -549,7 +548,7 @@ void board_quick_undo(struct board *b, struct move *m, struct board_undo *u);
 
 
 static inline bool
-board_is_eyelike(struct board *board, coord_t coord, enum stone eye_color)
+board_is_eyelike(board_t *board, coord_t coord, enum stone eye_color)
 {
 	return (neighbor_count_at(board, coord, eye_color) +
 	        neighbor_count_at(board, coord, S_OFFBOARD)) == 4;
@@ -557,7 +556,7 @@ board_is_eyelike(struct board *board, coord_t coord, enum stone eye_color)
 
 /* Group suicides allowed */
 static inline bool
-board_is_valid_play(struct board *board, enum stone color, coord_t coord)
+board_is_valid_play(board_t *board, enum stone color, coord_t coord)
 {
 	if (board_at(board, coord) != S_NONE)
 		return false;
@@ -576,7 +575,7 @@ board_is_valid_play(struct board *board, enum stone color, coord_t coord)
 
 /* Check group suicides, slower than board_is_valid_play() */
 static inline bool
-board_is_valid_play_no_suicide(struct board *board, enum stone color, coord_t coord)
+board_is_valid_play_no_suicide(board_t *board, enum stone color, coord_t coord)
 {
 	if (board_at(board, coord) != S_NONE)
 		return false;
@@ -605,20 +604,20 @@ board_is_valid_play_no_suicide(struct board *board, enum stone color, coord_t co
 
 
 static inline bool
-board_is_valid_move(struct board *board, struct move *m)
+board_is_valid_move(board_t *board, move_t *m)
 {
 	return board_is_valid_play(board, m->color, m->coord);
 }
 
 static inline bool
-board_playing_ko_threat(struct board *b)
+board_playing_ko_threat(board_t *b)
 {
 	return !is_pass(b->ko.coord);
 }
 
 
 static inline bool
-board_safe_to_play(struct board *b, coord_t coord, enum stone color)
+board_safe_to_play(board_t *b, coord_t coord, enum stone color)
 {
 	/* number of free neighbors */
 	int libs = immediate_liberty_count(b, coord);
@@ -651,7 +650,7 @@ board_safe_to_play(struct board *b, coord_t coord, enum stone color)
 }
 
 static inline int
-group_stone_count(struct board *b, group_t group, int max)
+group_stone_count(board_t *b, group_t group, int max)
 {
 	int n = 0;
 	foreach_in_group(b, group) {
@@ -663,7 +662,7 @@ group_stone_count(struct board *b, group_t group, int max)
 
 #ifndef QUICK_BOARD_CODE
 static inline bool
-board_coord_in_symmetry(struct board *b, coord_t c)
+board_coord_in_symmetry(board_t *b, coord_t c)
 {
 	if (coord_y(c) < b->symmetry.y1 || coord_y(c) > b->symmetry.y2)
 		return false;

--- a/chat.c
+++ b/chat.c
@@ -88,7 +88,7 @@ generic_chat(struct board *b, bool opponent, char *from, char *cmd, enum stone c
 		if (color == S_NONE) return not_playing;
 
 		sbprintf(buf, "In %d playouts, %s %s can win with %.1f%% probability",
-			 playouts, stone2str(color), coord2sstr(move, b), 100*winrate);
+			 playouts, stone2str(color), coord2sstr(move), 100*winrate);
 		if (fabs(extra_komi) >= 0.5) {
 			sbprintf(buf, ", while self-imposing extra komi %.1f", extra_komi);
 		}

--- a/chat.c
+++ b/chat.c
@@ -48,7 +48,7 @@ void chat_init(char *chat_file) {
 		perror(chat_file);
 		return;
 	}
-	chat_table = calloc2(MAX_CHAT_PATTERNS, sizeof(*chat_table));
+	chat_table = calloc2(MAX_CHAT_PATTERNS, chat_t);
 	chat_t *entry = chat_table;
 	while (fscanf(f, "%lf;%lf;%20[^;];%100[^;];%300[^\n]\n", &entry->minwin, &entry->maxwin,
 		      entry->from, entry->regex, entry->reply ) == 5) {

--- a/chat.h
+++ b/chat.h
@@ -6,12 +6,10 @@
 #include "stone.h"
 #include "move.h"
 
-struct board;
-
 void chat_init(char *chat_file);
 void chat_done(void);
 
-char *generic_chat(struct board *b, bool opponent, char *from, char *cmd, enum stone color, coord_t move,
+char *generic_chat(board_t *b, bool opponent, char *from, char *cmd, enum stone color, coord_t move,
 		   int playouts, int machines, int threads, double winrate, double extra_komi, char *score_est);
 
 #endif

--- a/dcnn.c
+++ b/dcnn.c
@@ -15,16 +15,16 @@ static bool dcnn_required = false;
 void disable_dcnn(void)  {  dcnn_enabled = false;  }
 void require_dcnn(void)  {  dcnn_required = true;  }
 
-static void detlef54_dcnn_eval(struct board *b, enum stone color, float result[]);
+static void detlef54_dcnn_eval(board_t *b, enum stone color, float result[]);
 
 static bool
-dcnn_supported_board_size(struct board *b)
+dcnn_supported_board_size(board_t *b)
 {
 	return (real_board_size(b) >= 13);
 }
 
 bool
-using_dcnn(struct board *b)
+using_dcnn(board_t *b)
 {
 	bool r = dcnn_enabled && dcnn_supported_board_size(b) && caffe_ready();
 	if (dcnn_required && !r)  die("dcnn required but not used, aborting.\n");
@@ -32,7 +32,7 @@ using_dcnn(struct board *b)
 }
 
 void
-dcnn_init(struct board *b)
+dcnn_init(board_t *b)
 {
 	if (dcnn_enabled && dcnn_supported_board_size(b))
 		caffe_init(real_board_size(b));
@@ -40,13 +40,13 @@ dcnn_init(struct board *b)
 }
 
 void
-dcnn_evaluate_quiet(struct board *b, enum stone color, float result[])
+dcnn_evaluate_quiet(board_t *b, enum stone color, float result[])
 {
 	detlef54_dcnn_eval(b, color, result);
 }
 
 void
-dcnn_evaluate(struct board *b, enum stone color, float result[])
+dcnn_evaluate(board_t *b, enum stone color, float result[])
 {
 	double time_start = time_now();	
 	detlef54_dcnn_eval(b, color, result);
@@ -54,7 +54,7 @@ dcnn_evaluate(struct board *b, enum stone color, float result[])
 }
 
 static void
-detlef54_dcnn_eval(struct board *b, enum stone color, float result[])
+detlef54_dcnn_eval(board_t *b, enum stone color, float result[])
 {
 	assert(dcnn_supported_board_size(b));
 
@@ -96,7 +96,7 @@ detlef54_dcnn_eval(struct board *b, enum stone color, float result[])
 
 
 void
-get_dcnn_best_moves(struct board *b, float *r, coord_t *best_c, float *best_r, int nbest)
+get_dcnn_best_moves(board_t *b, float *r, coord_t *best_c, float *best_r, int nbest)
 {
 	for (int i = 0; i < nbest; i++) {
 		best_c[i] = pass;  best_r[i] = 0;
@@ -109,7 +109,7 @@ get_dcnn_best_moves(struct board *b, float *r, coord_t *best_c, float *best_r, i
 }
 
 void
-print_dcnn_best_moves(struct board *b, coord_t *best_c, float *best_r, int nbest)
+print_dcnn_best_moves(board_t *b, coord_t *best_c, float *best_r, int nbest)
 {
 	int cols = best_moves_print(b, "dcnn = ", best_c, nbest);
 

--- a/dcnn.c
+++ b/dcnn.c
@@ -68,7 +68,7 @@ detlef54_dcnn_eval(struct board *b, enum stone color, float result[])
 	for (int y = 0; y < size; y++) {
 		int p = y * size + x;
 
-		coord_t c = coord_xy(b, x+1, y+1);
+		coord_t c = coord_xy(x+1, y+1);
 		group_t g = group_at(b, c);
 		enum stone bc = board_at(b, c);
 		int libs = board_group_info(b, g).libs - 1;
@@ -103,7 +103,7 @@ get_dcnn_best_moves(struct board *b, float *r, coord_t *best_c, float *best_r, i
 	}
 
 	foreach_free_point(b) {
-		int k = coord2dcnn_idx(c, b);
+		int k = coord2dcnn_idx(c);
 		best_moves_add(c, r[k], best_c, best_r, nbest);
 	} foreach_free_point_end;
 }

--- a/dcnn.c
+++ b/dcnn.c
@@ -60,9 +60,7 @@ detlef54_dcnn_eval(board_t *b, enum stone color, float result[])
 
 	int size = real_board_size(b);
 	int dsize = 13 * size * size;
-	float *data = malloc(dsize * sizeof(float));
-	for (int i = 0; i < dsize; i++)  /* memset() not recommended for floats */
-		data[i] = 0;
+	float *data = calloc2(dsize, float);
 
 	for (int x = 0; x < size; x++)
 	for (int y = 0; y < size; y++) {

--- a/dcnn.h
+++ b/dcnn.h
@@ -10,12 +10,12 @@
 void require_dcnn(void);
 void disable_dcnn(void);
 
-void dcnn_evaluate(struct board *b, enum stone color, float result[]);
-void dcnn_evaluate_quiet(struct board *b, enum stone color, float result[]);
-bool using_dcnn(struct board *b);
-void dcnn_init(struct board *b);
-void get_dcnn_best_moves(struct board *b, float *r, coord_t *best_c, float *best_r, int nbest);
-void print_dcnn_best_moves(struct board *b, coord_t *best_c, float *best_r, int nbest);
+void dcnn_evaluate(board_t *b, enum stone color, float result[]);
+void dcnn_evaluate_quiet(board_t *b, enum stone color, float result[]);
+bool using_dcnn(board_t *b);
+void dcnn_init(board_t *b);
+void get_dcnn_best_moves(board_t *b, float *r, coord_t *best_c, float *best_r, int nbest);
+void print_dcnn_best_moves(board_t *b, coord_t *best_c, float *best_r, int nbest);
 
 /* Convert board coord to dcnn data index */
 static inline int coord2dcnn_idx(coord_t c);

--- a/dcnn.h
+++ b/dcnn.h
@@ -18,15 +18,15 @@ void get_dcnn_best_moves(struct board *b, float *r, coord_t *best_c, float *best
 void print_dcnn_best_moves(struct board *b, coord_t *best_c, float *best_r, int nbest);
 
 /* Convert board coord to dcnn data index */
-static inline int coord2dcnn_idx(coord_t c, struct board *b);
+static inline int coord2dcnn_idx(coord_t c);
 
 
 static inline int
-coord2dcnn_idx(coord_t c, struct board *b)
+coord2dcnn_idx(coord_t c)
 {
-	int size = real_board_size(b);
-	int x = coord_x(c, b) - 1;
-	int y = coord_y(c, b) - 1;
+	int size = the_real_board_size();
+	int x = coord_x(c) - 1;
+	int y = coord_y(c) - 1;
 	return (y * size + x);
 }
 

--- a/distributed/distributed.c
+++ b/distributed/distributed.c
@@ -104,11 +104,6 @@ struct distributed {
 /* Default number of simulations to perform per move.
  * Note that this is in total over all slaves! */
 #define DIST_GAMES	80000
-static const struct time_info default_ti = {
-	.period = TT_MOVE,
-	.dim = TD_GAMES,
-	.len = { .games = DIST_GAMES, .games_max = 0 },
-};
 
 #define get_value(value, color) \
 	((color) == S_BLACK ? (value) : 1 - (value))
@@ -310,7 +305,13 @@ distributed_genmove(struct engine *e, struct board *b, struct time_info *ti,
 	coord_t best;
 	int played, playouts, threads;
 
-	if (ti->period == TT_NULL) *ti = default_ti;
+	if (ti->period == TT_NULL) {
+		*ti = ti_none;
+		ti->period = TT_MOVE;
+		ti->dim = TD_GAMES;
+		ti->len.games = DIST_GAMES;
+		ti->len.games_max = 0;
+	}
 	struct time_stop stop;
 	time_stop_conditions(ti, b, FUSEKI_END, YOSE_START, MAX_MAINTIME_RATIO, &stop);
 	struct time_info saved_ti = *ti;

--- a/distributed/distributed.c
+++ b/distributed/distributed.c
@@ -457,7 +457,7 @@ distributed_dead_group_list(engine_t *e, board_t *b, move_queue_t *mq)
 static distributed_t *
 distributed_state_init(char *arg, board_t *b)
 {
-	distributed_t *dist = calloc2(1, sizeof(distributed_t));
+	distributed_t *dist = calloc2(1, distributed_t);
 
 	dist->stats_hbits = DEFAULT_STATS_HBITS;
 	dist->max_slaves = DEFAULT_MAX_SLAVES;
@@ -494,7 +494,7 @@ distributed_state_init(char *arg, board_t *b)
 		}
 	}
 
-	gtp_replies = calloc2(dist->max_slaves, sizeof(char *));
+	gtp_replies = calloc2(dist->max_slaves, char *);
 
 	if (!dist->slave_port)
 		die("distributed: missing slave_port\n");

--- a/distributed/distributed.c
+++ b/distributed/distributed.c
@@ -127,7 +127,7 @@ char *
 path2sstr(path_t path, struct board *b)
 {
 	/* Special case for pass and resign. */
-	if (path < 0) return coord2sstr((coord_t)path, b);
+	if (path < 0) return coord2sstr((coord_t)path);
 
 	static char buf[16][64];
 	static int bi = 0;
@@ -138,7 +138,7 @@ path2sstr(path_t path, struct board *b)
 	char *end = b2 + 64;
 	coord_t leaf;
 	while ((leaf = leaf_coord(path, b)) != 0) {
-		s += snprintf(s, end - s, "%s<", coord2sstr(leaf, b));
+		s += snprintf(s, end - s, "%s<", coord2sstr(leaf));
 		path = parent_path(path, b);
 	}
 	if (s != b2) s[-1] = '\0';
@@ -244,7 +244,7 @@ select_best_move(struct board *b, struct large_stats *stats, int *played,
 		char move[64];
 		struct move_stats s;
 		while (r && sscanf(++r, "%63s %d " PRIfloating, move, &s.playouts, &s.value) == 3) {
-			coord_t c = str2coord(move, board_size(b));
+			coord_t c = str2coord(move);
 			assert (c >= resign && c < board_size2(b) && s.playouts >= 0);
 
 			large_stats_add_result(&stats[c], s.value, (long)s.playouts);
@@ -349,7 +349,7 @@ distributed_genmove(struct engine *e, struct board *b, struct time_info *ti,
 			if (!keep_looking || played >= stop.worst.playouts) break;
 		}
 		if (DEBUGVV(2)) {
-			char *coord = coord2sstr(best, b);
+			char *coord = coord2sstr(best);
 			snprintf(buf, sizeof(buf),
 				 "temp winner is %s %s with score %1.4f (%d/%d games)"
 				 " %d slaves %d threads\n",
@@ -378,7 +378,7 @@ distributed_genmove(struct engine *e, struct board *b, struct time_info *ti,
 	 * the last "pachi-genmoves" in the command history. */
 	clear_receive_queue();
 	char coordbuf[4];
-	char *coord = coord2bstr(coordbuf, best, b);
+	char *coord = coord2bstr(coordbuf, best);
 	snprintf(args, sizeof(args), "%s %s\n", stone2str(color), coord);
 	update_cmd(b, "play", args, true);
 	protocol_unlock();
@@ -447,7 +447,7 @@ distributed_dead_group_list(struct engine *e, struct board *b, struct move_queue
 	char *dead = gtp_replies[best_reply];
 	dead = strchr(dead, ' '); // skip "id "
 	while (dead && *++dead != '\n') {
-		mq_add(mq, str2coord(dead, board_size(b)), 0);
+		mq_add(mq, str2coord(dead), 0);
 		dead = strchr(dead, '\n');
 	}
 	protocol_unlock();

--- a/distributed/distributed.c
+++ b/distributed/distributed.c
@@ -77,6 +77,7 @@
 #define DEBUG
 
 #include "engine.h"
+#include "gtp.h"
 #include "move.h"
 #include "timeinfo.h"
 #include "playout.h"
@@ -88,18 +89,18 @@
 #include "distributed/merge.h"
 
 /* Internal engine state. */
-struct distributed {
+typedef struct {
 	char *slave_port;
 	char *proxy_port;
 	int max_slaves;
 	int shared_nodes;
 	int stats_hbits;
 	bool slaves_quit;
-	struct move my_last_move;
-	struct move_stats my_last_stats;
+	move_t my_last_move;
+	move_stats_t my_last_stats;
 	int slaves;
 	int threads;
-};
+} distributed_t;
 
 /* Default number of simulations to perform per move.
  * Note that this is in total over all slaves! */
@@ -124,7 +125,7 @@ struct distributed {
  * Returns the path string in a static buffer; it is NOT safe for
  * anything but debugging - in particular, it is NOT thread-safe! */
 char *
-path2sstr(path_t path, struct board *b)
+path2sstr(path_t path, board_t *b)
 {
 	/* Special case for pass and resign. */
 	if (path < 0) return coord2sstr((coord_t)path);
@@ -149,9 +150,9 @@ path2sstr(path_t path, struct board *b)
  * The slave lock must not be held upon entry and is released upon return.
  * args is empty or ends with '\n' */
 static enum parse_code
-distributed_notify(struct engine *e, struct board *b, int id, char *cmd, char *args, char **reply)
+distributed_notify(engine_t *e, board_t *b, int id, char *cmd, char *args, char **reply)
 {
-	struct distributed *dist = e->data;
+	distributed_t *dist = e->data;
 
 	/* Commands that should not be sent to slaves.
 	 * time_left will be part of next pachi-genmoves,
@@ -192,13 +193,13 @@ distributed_notify(struct engine *e, struct board *b, int id, char *cmd, char *a
 /* The playouts sent by slaves for the children of the root node
  * include contributions from other slaves. To avoid 32-bit overflow on
  * large configurations with many slaves we must average the playouts. */
-struct large_stats {
+typedef struct {
 	long playouts; // # of playouts
 	floating_t value; // BLACK wins/playouts
-};
+} large_stats_t;
 
 static void
-large_stats_add_result(struct large_stats *s, floating_t result, long playouts)
+large_stats_add_result(large_stats_t *s, floating_t result, long playouts)
 {
 	s->playouts += playouts;
 	s->value += (result - s->value) * playouts / s->playouts;
@@ -215,7 +216,7 @@ large_stats_add_result(struct large_stats *s, floating_t result, long playouts)
  * Keep this code in sync with uct/slave.c:report_stats().
  * slave_lock is held on entry and on return. */
 static coord_t
-select_best_move(struct board *b, struct large_stats *stats, int *played,
+select_best_move(board_t *b, large_stats_t *stats, int *played,
 		 int *total_playouts, int *total_threads, bool *keep_looking)
 {
 	assert(reply_count > 0);
@@ -242,7 +243,7 @@ select_best_move(struct board *b, struct large_stats *stats, int *played,
 		r = strchr(r, '\n');
 
 		char move[64];
-		struct move_stats s;
+		move_stats_t s;
 		while (r && sscanf(++r, "%63s %d " PRIfloating, move, &s.playouts, &s.value) == 3) {
 			coord_t c = str2coord(move);
 			assert (c >= resign && c < board_size2(b) && s.playouts >= 0);
@@ -271,7 +272,7 @@ select_best_move(struct board *b, struct large_stats *stats, int *played,
  * rely on the lock here. */
 static void
 genmoves_args(char *args, enum stone color, int played,
-	      struct time_info *ti, bool binary_args)
+	      time_info_t *ti, bool binary_args)
 {
 	char *end = args + CMDS_SIZE;
 	char *s = args + snprintf(args, CMDS_SIZE, "%s %d", stone2str(color), played);
@@ -291,10 +292,10 @@ genmoves_args(char *args, enum stone color, int played,
 
 /* Regularly send genmoves command to the slaves, and select the best move. */
 static coord_t
-distributed_genmove(struct engine *e, struct board *b, struct time_info *ti,
+distributed_genmove(engine_t *e, board_t *b, time_info_t *ti,
 		    enum stone color, bool pass_all_alive)
 {
-	struct distributed *dist = e->data;
+	distributed_t *dist = e->data;
 	double now = time_now();
 	double first = now;
 	char buf[BSIZE]; // debug only
@@ -312,13 +313,13 @@ distributed_genmove(struct engine *e, struct board *b, struct time_info *ti,
 		ti->len.games = DIST_GAMES;
 		ti->len.games_max = 0;
 	}
-	struct time_stop stop;
+	time_stop_t stop;
 	time_stop_conditions(ti, b, FUSEKI_END, YOSE_START, MAX_MAINTIME_RATIO, &stop);
-	struct time_info saved_ti = *ti;
+	time_info_t saved_ti = *ti;
 
 	/* Combined move stats from all slaves, only for children
 	 * of the root node, plus 2 for pass and resign. */
-	struct large_stats stats_array[board_size2(b) + 2], *stats;
+	large_stats_t stats_array[board_size2(b) + 2], *stats;
 	stats = &stats_array[2];
 
 	protocol_lock();
@@ -403,9 +404,9 @@ distributed_genmove(struct engine *e, struct board *b, struct time_info *ti,
 }
 
 static char *
-distributed_chat(struct engine *e, struct board *b, bool opponent, char *from, char *cmd)
+distributed_chat(engine_t *e, board_t *b, bool opponent, char *from, char *cmd)
 {
-	struct distributed *dist = e->data;
+	distributed_t *dist = e->data;
 	double winrate = get_value(dist->my_last_stats.value, dist->my_last_move.color);
 
 	return generic_chat(b, opponent, from, cmd, dist->my_last_move.color, dist->my_last_move.coord,
@@ -419,7 +420,7 @@ scmp(const void *p1, const void *p2)
 }
 
 static void
-distributed_dead_group_list(struct engine *e, struct board *b, struct move_queue *mq)
+distributed_dead_group_list(engine_t *e, board_t *b, move_queue_t *mq)
 {
 	protocol_lock();
 
@@ -453,10 +454,10 @@ distributed_dead_group_list(struct engine *e, struct board *b, struct move_queue
 	protocol_unlock();
 }
 
-static struct distributed *
-distributed_state_init(char *arg, struct board *b)
+static distributed_t *
+distributed_state_init(char *arg, board_t *b)
 {
-	struct distributed *dist = calloc2(1, sizeof(struct distributed));
+	distributed_t *dist = calloc2(1, sizeof(distributed_t));
 
 	dist->stats_hbits = DEFAULT_STATS_HBITS;
 	dist->max_slaves = DEFAULT_MAX_SLAVES;
@@ -505,9 +506,9 @@ distributed_state_init(char *arg, struct board *b)
 }
 
 void
-engine_distributed_init(struct engine *e, char *arg, struct board *b)
+engine_distributed_init(engine_t *e, char *arg, board_t *b)
 {
-	struct distributed *dist = distributed_state_init(arg, b);
+	distributed_t *dist = distributed_state_init(arg, b);
 	e->name = "Distributed";
 	e->comment = "If you believe you have won but I am still playing, "
 		"please help me understand by capturing all dead stones. "

--- a/distributed/distributed.c
+++ b/distributed/distributed.c
@@ -152,7 +152,7 @@ path2sstr(path_t path, board_t *b)
 static enum parse_code
 distributed_notify(engine_t *e, board_t *b, int id, char *cmd, char *args, char **reply)
 {
-	distributed_t *dist = e->data;
+	distributed_t *dist = (distributed_t*)e->data;
 
 	/* Commands that should not be sent to slaves.
 	 * time_left will be part of next pachi-genmoves,
@@ -295,12 +295,12 @@ static coord_t
 distributed_genmove(engine_t *e, board_t *b, time_info_t *ti,
 		    enum stone color, bool pass_all_alive)
 {
-	distributed_t *dist = e->data;
+	distributed_t *dist = (distributed_t*)e->data;
 	double now = time_now();
 	double first = now;
 	char buf[BSIZE]; // debug only
 
-	char *cmd = pass_all_alive ? "pachi-genmoves_cleanup" : "pachi-genmoves";
+	const char *cmd = pass_all_alive ? "pachi-genmoves_cleanup" : "pachi-genmoves";
 	char args[CMDS_SIZE];
 
 	coord_t best;
@@ -406,7 +406,7 @@ distributed_genmove(engine_t *e, board_t *b, time_info_t *ti,
 static char *
 distributed_chat(engine_t *e, board_t *b, bool opponent, char *from, char *cmd)
 {
-	distributed_t *dist = e->data;
+	distributed_t *dist = (distributed_t*)e->data;
 	double winrate = get_value(dist->my_last_stats.value, dist->my_last_move.color);
 
 	return generic_chat(b, opponent, from, cmd, dist->my_last_move.color, dist->my_last_move.coord,

--- a/distributed/distributed.h
+++ b/distributed/distributed.h
@@ -26,12 +26,12 @@ typedef int64_t path_t;
 
 
 /* For debugging only */
-struct hash_counts {
+typedef struct {
 	long lookups;
 	long collisions;
 	long inserts;
 	long occupied;
-};
+} hash_counts_t;
 
 /* Find a hash table entry given its coord path from root.
  * Set found to false if the entry is empty.
@@ -60,10 +60,10 @@ struct hash_counts {
 
 /* Stats exchanged between master and slave. They are always
  * incremental values to be added to what was last sent. */
-struct incr_stats {
+typedef struct {
 	path_t coord_path;
-	struct move_stats incr;
-};
+	move_stats_t incr;
+} incr_stats_t;
 
 /* A slave machine updates at most 7 (19x19) or 9 (9x9) nodes for each
  * update of the root node. If we have at most 20 threads at 1500
@@ -98,7 +98,7 @@ struct incr_stats {
 #define move_number(id)    ((id) % DIST_GAMELEN)
 #define reply_disabled(id) ((id) < DIST_GAMELEN)
 
-char *path2sstr(path_t path, struct board *b);
-void engine_distributed_init(struct engine *e, char *arg, struct board *b);
+char *path2sstr(path_t path, board_t *b);
+void engine_distributed_init(engine_t *e, char *arg, board_t *b);
 
 #endif

--- a/distributed/merge.c
+++ b/distributed/merge.c
@@ -310,8 +310,8 @@ get_new_stats(incr_stats_t *buf, slave_state_t *sstate, int cmd_id)
 static void
 merge_state_alloc(slave_state_t *sstate)
 {
-	sstate->stats_htable = calloc2(1 << sstate->stats_hbits, sizeof(incr_stats_t));
-	sstate->merged = malloc2(sstate->max_merged_nodes * sizeof(int));
+	sstate->stats_htable = calloc2(1 << sstate->stats_hbits, incr_stats_t);
+	sstate->merged = calloc2(sstate->max_merged_nodes, int);
 	sstate->max_buf_size -= sizeof(incr_stats_t);
 }
 

--- a/distributed/merge.c
+++ b/distributed/merge.c
@@ -68,7 +68,7 @@ stats_tally(struct incr_stats *s, struct slave_state *sstate, int *bucket_count)
 	return h;
 }
 
-static struct incr_stats terminator = { .coord_path = INT64_MAX };
+static struct incr_stats terminator = { INT64_MAX };
 
 /* Initialize the next pointers (see merge_new_stats()).
  * Exclude invalid buffers and my own buffers by setting their next pointer
@@ -153,8 +153,7 @@ merge_new_stats(struct slave_state *sstate, int min, int max,
 	path_t min_c;
 	while ((min_c = min_coord(next, min, max)) != INT64_MAX) {
 
-		struct incr_stats sum = { .coord_path = min_c,
-					  .incr = { .playouts = 0, .value = 0.0 }};
+		struct incr_stats sum = { min_c, move_stats(0.0, 0) };
 		for (int q = min; q <= max; q++) {
 			struct incr_stats s = *(next[q]);
 

--- a/distributed/merge.h
+++ b/distributed/merge.h
@@ -4,6 +4,6 @@
 #include "distributed/protocol.h"
 
 void merge_print_stats(int total_hnodes);
-void merge_init(struct slave_state *sstate, int shared_nodes, int stats_hbits, int max_slaves);
+void merge_init(slave_state_t *sstate, int shared_nodes, int stats_hbits, int max_slaves);
 
 #endif

--- a/distributed/protocol.c
+++ b/distributed/protocol.c
@@ -278,7 +278,7 @@ static void
 slave_state_alloc(slave_state_t *sstate)
 {
 	for (int n = 0; n < BUFFERS_PER_SLAVE; n++) {
-		sstate->b[n].buf = malloc2(sstate->max_buf_size);
+		sstate->b[n].buf = cmalloc(sstate->max_buf_size);
 		sstate->b[n].owner = sstate->thread_id;
 	}
 	if (sstate->alloc_hook) sstate->alloc_hook(sstate);
@@ -666,7 +666,7 @@ protocol_init(char *slave_port, char *proxy_port, int max_slaves)
 	start_time = time_now();
 
 	queue_max_length = max_slaves * MAX_GENMOVES_PER_SLAVE;
-	receive_queue = calloc2(queue_max_length, sizeof(*receive_queue));
+	receive_queue = calloc2(queue_max_length, buf_state_t*);
 
 	default_sstate.slave_sock = port_listen(slave_port, max_slaves);
 	default_sstate.last_processed = -1;

--- a/distributed/protocol.c
+++ b/distributed/protocol.c
@@ -101,7 +101,7 @@ protocol_unlock(void)
 /* Write the time, client address, prefix, and string s to stderr atomically.
  * s should end with a \n */
 void
-logline(struct in_addr *client, char *prefix, char *s)
+logline(struct in_addr *client, const char *prefix, const char *s)
 {
 	double now = time_now();
 
@@ -557,7 +557,7 @@ slave_thread(void *arg)
  * if gtp_cmd points to a non-empty string. cmd is a single word;
  * args has all arguments and is empty or has a trailing \n */
 void
-update_cmd(board_t *b, char *cmd, char *args, bool new_id)
+update_cmd(board_t *b, const char *cmd, char *args, bool new_id)
 {
 	assert(gtp_cmd);
 	/* To make sure the slaves are in sync, we ignore the original id
@@ -596,7 +596,7 @@ update_cmd(board_t *b, char *cmd, char *args, bool new_id)
  * lock is released. cmd is a single word; args has all
  * arguments and is empty or has a trailing \n */
 void
-new_cmd(board_t *b, char *cmd, char *args)
+new_cmd(board_t *b, const char *cmd, char *args)
 {
 	// Clear the history when a new game starts:
 	if (!gtp_cmd || is_gamestart(cmd)) {

--- a/distributed/protocol.c
+++ b/distributed/protocol.c
@@ -18,6 +18,7 @@
 
 #define DEBUG
 
+#include "gtp.h"
 #include "random.h"
 #include "timeinfo.h"
 #include "playout.h"
@@ -40,10 +41,12 @@ static int cmd_count = 0;
 #define MAX_CMDS_PER_MOVE 10
 
 /* History of gtp commands sent for current game, indexed by move. */
-static struct cmd_history {
+typedef struct {
 	int gtp_id;
 	char *next_cmd;
-} history[MAX_GAMELEN][MAX_CMDS_PER_MOVE];
+} cmd_history_t;
+
+static cmd_history_t history[MAX_GAMELEN][MAX_CMDS_PER_MOVE];
 
 /* Number of active slave machines working for this master. */
 int active_slaves = 0;
@@ -55,7 +58,7 @@ int reply_count = 0;
 char **gtp_replies;
 
 
-struct buf_state **receive_queue;
+buf_state_t **receive_queue;
 int queue_length = 0;
 int queue_age = 0;
 static int queue_max_length;
@@ -78,7 +81,7 @@ static pthread_mutex_t log_lock = PTHREAD_MUTEX_INITIALIZER;
 static double start_time;
 
 /* Default slave state. */
-struct slave_state default_sstate;
+slave_state_t default_sstate;
 
 
 /* Get exclusive access to the threads and commands state. */
@@ -201,7 +204,7 @@ get_reply(FILE *f, struct in_addr client, char *reply, void *bin_reply, int *bin
  * slave_lock is held on both entry and exit of this function. */
 static int
 send_command(char *to_send, void *bin_buf, int *bin_size,
-	     FILE *f, struct slave_state *sstate, char *buf)
+	     FILE *f, slave_state_t *sstate, char *buf)
 {
 	assert(to_send && gtp_cmd && bin_buf && bin_size);
 	strncpy(buf, to_send, CMDS_SIZE);
@@ -272,7 +275,7 @@ next_command(int cmd_id)
  * initialized already as a copy of the default slave state.
  * slave_lock is not held on either entry or exit of this function. */
 static void
-slave_state_alloc(struct slave_state *sstate)
+slave_state_alloc(slave_state_t *sstate)
 {
 	for (int n = 0; n < BUFFERS_PER_SLAVE; n++) {
 		sstate->b[n].buf = malloc2(sstate->max_buf_size);
@@ -286,7 +289,7 @@ slave_state_alloc(struct slave_state *sstate)
  * before they are invalidated, if BUFFERS_PER_SLAVE is large enough.
  * slave_lock is held on both entry and exit of this function. */
 static void *
-get_free_buf(struct slave_state *sstate)
+get_free_buf(slave_state_t *sstate)
 {
 	int newest = (sstate->newest_buf + 1) & (BUFFERS_PER_SLAVE - 1);
 	sstate->newest_buf = newest;
@@ -318,7 +321,7 @@ get_free_buf(struct slave_state *sstate)
  * recent buffer allocated by the calling thread.
  * slave_lock is held on both entry and exit of this function. */
 static void
-insert_buf(struct slave_state *sstate, void *buf, int size)
+insert_buf(slave_state_t *sstate, void *buf, int size)
 {
 	assert(queue_length < queue_max_length);
 
@@ -366,7 +369,7 @@ clear_receive_queue(void)
 static bool
 process_reply(int reply_id, char *reply, char *reply_buf,
 	      void *bin_reply, int bin_size, int *last_reply_id,
-	      int *reply_slot, struct slave_state *sstate)
+	      int *reply_slot, slave_state_t *sstate)
 {
 	/* Resend everything if slave returned an error. */
 	/* FIXME: this often results in infinite loops on errors
@@ -408,7 +411,7 @@ process_reply(int reply_id, char *reply, char *reply_buf,
  * in future commits.
  * slave_lock is held on both entry and exit of this function. */
 void *
-get_binary_arg(struct slave_state *sstate, char *cmd, int cmd_size, int *bin_size)
+get_binary_arg(slave_state_t *sstate, char *cmd, int cmd_size, int *bin_size)
 {
 	int cmd_id = atoi(gtp_cmd);
 	void *buf = get_free_buf(sstate);
@@ -437,7 +440,7 @@ get_binary_arg(struct slave_state *sstate, char *cmd, int cmd_size, int *bin_siz
  * Returns when the connection with the slave machine is cut.
  * slave_lock is held on both entry and exit of this function. */
 static void
-slave_loop(FILE *f, char *reply_buf, struct slave_state *sstate, bool resend)
+slave_loop(FILE *f, char *reply_buf, slave_state_t *sstate, bool resend)
 {
 	char *to_send;
 	int last_cmd_count = 0;
@@ -507,7 +510,7 @@ is_pachi_slave(FILE *f, struct in_addr *client)
 static void * __attribute__((noreturn))
 slave_thread(void *arg)
 {
-	struct slave_state sstate = default_sstate;
+	slave_state_t sstate = default_sstate;
 	sstate.thread_id = (intptr_t)arg;
 
 	assert(sstate.slave_sock >= 0);
@@ -554,7 +557,7 @@ slave_thread(void *arg)
  * if gtp_cmd points to a non-empty string. cmd is a single word;
  * args has all arguments and is empty or has a trailing \n */
 void
-update_cmd(struct board *b, char *cmd, char *args, bool new_id)
+update_cmd(board_t *b, char *cmd, char *args, bool new_id)
 {
 	assert(gtp_cmd);
 	/* To make sure the slaves are in sync, we ignore the original id
@@ -575,7 +578,7 @@ update_cmd(struct board *b, char *cmd, char *args, bool new_id)
 
 	/* Remember history for out-of-sync slaves. */
 	static int slot = 0;
-	static struct cmd_history *last = NULL;
+	static cmd_history_t *last = NULL;
 	if (new_id) {
 		if (last) last->next_cmd = gtp_cmd;
 		slot = (slot + 1) % MAX_CMDS_PER_MOVE;
@@ -593,7 +596,7 @@ update_cmd(struct board *b, char *cmd, char *args, bool new_id)
  * lock is released. cmd is a single word; args has all
  * arguments and is empty or has a trailing \n */
 void
-new_cmd(struct board *b, char *cmd, char *args)
+new_cmd(board_t *b, char *cmd, char *args)
 {
 	// Clear the history when a new game starts:
 	if (!gtp_cmd || is_gamestart(cmd)) {

--- a/distributed/protocol.h
+++ b/distributed/protocol.h
@@ -69,11 +69,11 @@ extern slave_state_t default_sstate;
 void protocol_lock(void);
 void protocol_unlock(void);
 
-void logline(struct in_addr *client, char *prefix, char *s);
+void logline(struct in_addr *client, const char *prefix, const char *s);
 
 void clear_receive_queue(void);
-void update_cmd(board_t *b, char *cmd, char *args, bool new_id);
-void new_cmd(board_t *b, char *cmd, char *args);
+void update_cmd(board_t *b, const char *cmd, char *args, bool new_id);
+void new_cmd(board_t *b, const char *cmd, char *args);
 void get_replies(double time_limit, int min_replies);
 void protocol_init(char *slave_port, char *proxy_port, int max_slaves);
 

--- a/distributed/protocol.h
+++ b/distributed/protocol.h
@@ -19,12 +19,13 @@
 #define BUFFERS_PER_SLAVE_BITS 8
 #define BUFFERS_PER_SLAVE (1 << BUFFERS_PER_SLAVE_BITS)
 
-struct slave_state;
+typedef struct slave_state slave_state_t;
+
 typedef void (*buffer_hook)(void *buf, int size);
 typedef void (*state_alloc_hook)(struct slave_state *sstate);
 typedef int (*getargs_hook)(void *buf, struct slave_state *sstate, int cmd_id);
 
-struct buf_state {
+typedef struct {
 	void *buf;
 	/* All buffers have the same physical size. size is the
 	 * number of valid bytes. It is set only when the buffer
@@ -32,7 +33,7 @@ struct buf_state {
 	int size;
 	int queue_index;
 	int owner;
-};
+} buf_state_t;
 
 struct slave_state {
 	int max_buf_size;
@@ -48,14 +49,14 @@ struct slave_state {
 
 	/* --- PRIVATE DATA for protocol.c --- */
 
-	struct buf_state b[BUFFERS_PER_SLAVE];
+	buf_state_t b[BUFFERS_PER_SLAVE];
 	int newest_buf;
 	int slave_sock;
 
 	/* --- PRIVATE DATA for merge.c --- */
 
 	/* Hash table of incremental stats. */
-	struct incr_stats *stats_htable;
+	incr_stats_t *stats_htable;
 	int stats_hbits;
 	int stats_id;
 
@@ -63,7 +64,7 @@ struct slave_state {
 	int *merged;
 	int max_merged_nodes;
 };
-extern struct slave_state default_sstate;
+extern slave_state_t default_sstate;
 
 void protocol_lock(void);
 void protocol_unlock(void);
@@ -71,8 +72,8 @@ void protocol_unlock(void);
 void logline(struct in_addr *client, char *prefix, char *s);
 
 void clear_receive_queue(void);
-void update_cmd(struct board *b, char *cmd, char *args, bool new_id);
-void new_cmd(struct board *b, char *cmd, char *args);
+void update_cmd(board_t *b, char *cmd, char *args, bool new_id);
+void new_cmd(board_t *b, char *cmd, char *args);
 void get_replies(double time_limit, int min_replies);
 void protocol_init(char *slave_port, char *proxy_port, int max_slaves);
 
@@ -82,7 +83,7 @@ extern int active_slaves;
 
 /* All binary buffers received from all slaves in current move are in
  * receive_queue[0..queue_length-1] */
-extern struct buf_state **receive_queue;
+extern buf_state_t **receive_queue;
 extern int queue_length;
 /* Queue age is incremented each time the queue is emptied. */
 extern int queue_age;

--- a/engine.c
+++ b/engine.c
@@ -1,30 +1,31 @@
 #define DEBUG
 #include "engine.h"
+#include "pachi.h"
 
 
 void
-engine_init(struct engine *e, int id, char *e_arg, struct board *b)
+engine_init(engine_t *e, int id, char *e_arg, board_t *b)
 {
 	pachi_engine_init(e, id, e_arg, b);
 }
 
 void
-engine_done(struct engine *e)
+engine_done(engine_t *e)
 {
 	if (e->done) e->done(e);
 	if (e->data) free(e->data);
 }
 
-struct engine*
-new_engine(int id, char *e_arg, struct board *b)
+engine_t*
+new_engine(int id, char *e_arg, board_t *b)
 {
-	struct engine *e = malloc2(sizeof(*e));
+	engine_t *e = malloc2(sizeof(*e));
 	engine_init(e, id, e_arg, b);
 	return e;
 }
 
 void
-engine_reset(struct engine *e, struct board *b, char *e_arg)
+engine_reset(engine_t *e, board_t *b, char *e_arg)
 {
 	int engine_id = e->id;
 	b->es = NULL;
@@ -33,13 +34,13 @@ engine_reset(struct engine *e, struct board *b, char *e_arg)
 }
 
 void
-engine_board_print(struct engine *e, struct board *b, FILE *f)
+engine_board_print(engine_t *e, board_t *b, FILE *f)
 {
 	(e->board_print ? e->board_print(e, b, f) : board_print(b, f));
 }
 
 void
-engine_best_moves(struct engine *e, struct board *b, struct time_info *ti, enum stone color, 
+engine_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color, 
 		  coord_t *best_c, float *best_r, int nbest)
 {
 	for (int i = 0; i < nbest; i++) {
@@ -48,8 +49,8 @@ engine_best_moves(struct engine *e, struct board *b, struct time_info *ti, enum 
 	e->best_moves(e, b, ti, color, best_c, best_r, nbest);
 }
 
-struct ownermap*
-engine_ownermap(struct engine *e, struct board *b)
+ownermap_t*
+engine_ownermap(engine_t *e, board_t *b)
 {
 	return (e->ownermap ? e->ownermap(e, b) : NULL);
 }
@@ -88,7 +89,7 @@ best_moves_add_full(coord_t c, float r, void *d, coord_t *best_c, float *best_r,
 }
 
 int
-best_moves_print(struct board *b, char *str, coord_t *best_c, int nbest)
+best_moves_print(board_t *b, char *str, coord_t *best_c, int nbest)
 {
 	fprintf(stderr, "%s[ ", str);
 	for (int i = 0; i < nbest; i++) {

--- a/engine.c
+++ b/engine.c
@@ -92,7 +92,7 @@ best_moves_print(struct board *b, char *str, coord_t *best_c, int nbest)
 {
 	fprintf(stderr, "%s[ ", str);
 	for (int i = 0; i < nbest; i++) {
-		char *str = (is_pass(best_c[i]) ? "" : coord2sstr(best_c[i], b));
+		char *str = (is_pass(best_c[i]) ? "" : coord2sstr(best_c[i]));
 		fprintf(stderr, "%-3s ", str);
 	}
 	fprintf(stderr, "]\n");

--- a/engine.c
+++ b/engine.c
@@ -93,7 +93,7 @@ best_moves_print(board_t *b, char *str, coord_t *best_c, int nbest)
 {
 	fprintf(stderr, "%s[ ", str);
 	for (int i = 0; i < nbest; i++) {
-		char *str = (is_pass(best_c[i]) ? "" : coord2sstr(best_c[i]));
+		const char *str = (is_pass(best_c[i]) ? "" : coord2sstr(best_c[i]));
 		fprintf(stderr, "%-3s ", str);
 	}
 	fprintf(stderr, "]\n");

--- a/engine.c
+++ b/engine.c
@@ -19,7 +19,7 @@ engine_done(engine_t *e)
 engine_t*
 new_engine(int id, char *e_arg, board_t *b)
 {
-	engine_t *e = malloc2(sizeof(*e));
+	engine_t *e = malloc2(engine_t);
 	engine_init(e, id, e_arg, b);
 	return e;
 }

--- a/engine.h
+++ b/engine.h
@@ -1,12 +1,8 @@
 #ifndef PACHI_ENGINE_H
 #define PACHI_ENGINE_H
 
-#include "pachi.h"
-#include "board.h"
-#include "move.h"
 #include "gtp.h"
-
-struct move_queue;
+#include "ownermap.h"
 
 enum engine_id {
 	E_RANDOM,
@@ -26,25 +22,26 @@ enum engine_id {
 	E_MAX,
 };
 
+typedef struct engine engine_t;
 
-typedef void (*engine_init_t)(struct engine *e, char *arg, struct board *b);
-typedef enum parse_code (*engine_notify_t)(struct engine *e, struct board *b, int id, char *cmd, char *args, char **reply);
-typedef void (*engine_board_print_t)(struct engine *e, struct board *b, FILE *f);
-typedef char *(*engine_notify_play_t)(struct engine *e, struct board *b, struct move *m, char *enginearg);
-typedef char *(*engine_result_t)(struct engine *e, struct board *b);
-typedef char *(*engine_chat_t)(struct engine *e, struct board *b, bool in_game, char *from, char *cmd);
-typedef coord_t (*engine_genmove_t)(struct engine *e, struct board *b, struct time_info *ti, enum stone color, bool pass_all_alive);
-typedef void  (*engine_best_moves_t)(struct engine *e, struct board *b, struct time_info *ti, enum stone color, 
+typedef void (*engine_init_t)(engine_t *e, char *arg, board_t *b);
+typedef enum parse_code (*engine_notify_t)(engine_t *e, board_t *b, int id, char *cmd, char *args, char **reply);
+typedef void (*engine_board_print_t)(engine_t *e, board_t *b, FILE *f);
+typedef char *(*engine_notify_play_t)(engine_t *e, board_t *b, move_t *m, char *enginearg);
+typedef char *(*engine_result_t)(engine_t *e, board_t *b);
+typedef char *(*engine_chat_t)(engine_t *e, board_t *b, bool in_game, char *from, char *cmd);
+typedef coord_t (*engine_genmove_t)(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive);
+typedef void  (*engine_best_moves_t)(engine_t *e, board_t *b, time_info_t *ti, enum stone color, 
 				     coord_t *best_c, float *best_r, int nbest);
-typedef char *(*engine_genmoves_t)(struct engine *e, struct board *b, struct time_info *ti, enum stone color,
+typedef char *(*engine_genmoves_t)(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 				 char *args, bool pass_all_alive, void **stats_buf, int *stats_size);
-typedef void (*engine_evaluate_t)(struct engine *e, struct board *b, struct time_info *ti, floating_t *vals, enum stone color);
-typedef void (*engine_analyze_t)(struct engine *e, struct board *b, enum stone color, int start);
-typedef void (*engine_dead_group_list_t)(struct engine *e, struct board *b, struct move_queue *mq);
-typedef void (*engine_stop_t)(struct engine *e);
-typedef void (*engine_done_t)(struct engine *e);
-typedef struct ownermap* (*engine_ownermap_t)(struct engine *e, struct board *b);
-typedef void (*engine_livegfx_hook_t)(struct engine *e);
+typedef void (*engine_evaluate_t)(engine_t *e, board_t *b, time_info_t *ti, floating_t *vals, enum stone color);
+typedef void (*engine_analyze_t)(engine_t *e, board_t *b, enum stone color, int start);
+typedef void (*engine_dead_group_list_t)(engine_t *e, board_t *b, move_queue_t *mq);
+typedef void (*engine_stop_t)(engine_t *e);
+typedef void (*engine_done_t)(engine_t *e);
+typedef ownermap_t* (*engine_ownermap_t)(engine_t *e, board_t *b);
+typedef void (*engine_livegfx_hook_t)(engine_t *e);
 
 /* This is engine data structure. A new engine instance is spawned
  * for each new game during the program lifetime. */
@@ -103,24 +100,24 @@ struct engine {
 
 
 /* Initialize engine. Call engine_done() later when finished with it. */
-void engine_init(struct engine *e, int id, char *e_arg, struct board *b);
+void engine_init(engine_t *e, int id, char *e_arg, board_t *b);
 
 /* Clean up what engine_init() did. */
-void engine_done(struct engine *e);
+void engine_done(engine_t *e);
 
 /* Allocate and initialize a new engine.
  * You are responsible for calling engine_done() and free() on it when done. */
-struct engine* new_engine(int id, char *e_arg, struct board *b);
+engine_t* new_engine(int id, char *e_arg, board_t *b);
 
 /* engine_done() + engine_init(), more or less. */
-void engine_reset(struct engine *e, struct board *b, char *e_arg);
+void engine_reset(engine_t *e, board_t *b, char *e_arg);
 
 
 /* Convenience functions for engine actions: */
-void engine_board_print(struct engine *e, struct board *b, FILE *f);
-void engine_best_moves(struct engine *e, struct board *b, struct time_info *ti, enum stone color,
+void engine_board_print(engine_t *e, board_t *b, FILE *f);
+void engine_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 		       coord_t *best_c, float *best_r, int nbest);
-struct ownermap* engine_ownermap(struct engine *e, struct board *b);
+struct ownermap* engine_ownermap(engine_t *e, board_t *b);
 
 
 /* Engines best moves common code */
@@ -128,7 +125,7 @@ struct ownermap* engine_ownermap(struct engine *e, struct board *b);
 /* For engines best_move(): Add move @c with prob @r to best moves @best_c, @best_r */
 void best_moves_add(coord_t c, float r, coord_t *best_c, float *best_r, int nbest);
 void best_moves_add_full(coord_t c, float r, void *d, coord_t *best_c, float *best_r, void **best_d, int nbest);
-int  best_moves_print(struct board *b, char *str, coord_t *best_c, int nbest);
+int  best_moves_print(board_t *b, char *str, coord_t *best_c, int nbest);
 
 
 #endif

--- a/engines/dcnn.c
+++ b/engines/dcnn.c
@@ -24,7 +24,7 @@ dcnn_genmove(struct engine *e, struct board *b, struct time_info *ti, enum stone
 	for (int i = 0; i < DCNN_BEST_N; i++) {
 		if (board_is_valid_play_no_suicide(b, color, best_moves[i]))
 			return best_moves[i];
-		fprintf(stderr, "dcnn suggests invalid move %s !\n", coord2sstr(best_moves[i], b));
+		fprintf(stderr, "dcnn suggests invalid move %s !\n", coord2sstr(best_moves[i]));
 	}
 	
 	assert(0);

--- a/engines/dcnn.c
+++ b/engines/dcnn.c
@@ -11,7 +11,7 @@
 
 
 static coord_t
-dcnn_genmove(struct engine *e, struct board *b, struct time_info *ti, enum stone color, bool pass_all_alive)
+dcnn_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
 {
 	float r[19 * 19];
 	float best_r[DCNN_BEST_N];
@@ -32,7 +32,7 @@ dcnn_genmove(struct engine *e, struct board *b, struct time_info *ti, enum stone
 }
 
 static void
-dcnn_best_moves(struct engine *e, struct board *b, struct time_info *ti, enum stone color, 
+dcnn_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color, 
 		coord_t *best_c, float *best_r, int nbest)
 {
 	float r[19 * 19];
@@ -42,7 +42,7 @@ dcnn_best_moves(struct engine *e, struct board *b, struct time_info *ti, enum st
 }	
 
 void
-engine_dcnn_init(struct engine *e, char *arg, struct board *b)
+engine_dcnn_init(engine_t *e, char *arg, board_t *b)
 {
 	dcnn_init(b);
 	if (!caffe_ready()) {

--- a/engines/dcnn.h
+++ b/engines/dcnn.h
@@ -1,6 +1,6 @@
 #ifndef PACHI_ENGINES_DCNN_H
 #define PACHI_ENGINES_DCNN_H
 
-void engine_dcnn_init(struct engine *e, char *arg, struct board *b);
+void engine_dcnn_init(engine_t *e, char *arg, board_t *b);
 
 #endif /* PACHI_ENGINES_DCNN_H */

--- a/engines/josekiplay.c
+++ b/engines/josekiplay.c
@@ -10,7 +10,7 @@
 #include "engines/josekiplay.h"
 
 static void
-josekiplay_best_moves(struct engine *e, struct board *b, struct time_info *ti, enum stone color,
+josekiplay_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 		      coord_t *best_c, float *best_r, int nbest)
 {
 	coord_t coords[BOARD_MAX_COORDS];
@@ -22,7 +22,7 @@ josekiplay_best_moves(struct engine *e, struct board *b, struct time_info *ti, e
 }
 
 static coord_t
-josekiplay_genmove(struct engine *e, struct board *b, struct time_info *ti, enum stone color, bool pass_all_alive)
+josekiplay_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
 {
 	coord_t best_c[20];
 	float   best_r[20];
@@ -32,7 +32,7 @@ josekiplay_genmove(struct engine *e, struct board *b, struct time_info *ti, enum
 }
 
 void
-engine_josekiplay_init(struct engine *e, char *arg, struct board *b)
+engine_josekiplay_init(engine_t *e, char *arg, board_t *b)
 {
 	e->name = "JosekiPlay Engine";
 	e->comment = "I select joseki moves blindly, if there are none i just pass.";

--- a/engines/josekiplay.h
+++ b/engines/josekiplay.h
@@ -1,7 +1,9 @@
 #ifndef PACHI_ENGINES_JOSEKIPLAY_H
 #define PACHI_ENGINES_JOSEKIPLAY_H
 
-void josekiplay_set_jdict(struct engine *e, struct joseki_dict *jdict);
-void engine_josekiplay_init(struct engine *e, char *arg, struct board *b);
+#include "joseki.h"
+
+void josekiplay_set_jdict(engine_t *e, joseki_dict_t *jdict);
+void engine_josekiplay_init(engine_t *e, char *arg, board_t *b);
 
 #endif

--- a/engines/josekiscan.c
+++ b/engines/josekiscan.c
@@ -82,7 +82,7 @@ josekiscan_play(struct engine *e, struct board *board, struct move *m, char *mov
 		else               j->prev[i] = joseki_add(joseki_dict, b, coord, color, j->prev[i], flags);
 
 		int captures = board_captures(b);
-		struct move m2 = { .coord = coord, .color = color };
+		struct move m2 = move(coord, color);
 		int r = board_play(b, &m2);  assert(r >= 0);
 
 		/* update prev pattern if stones were captured, board configuration changed ! */

--- a/engines/josekiscan.c
+++ b/engines/josekiscan.c
@@ -26,7 +26,7 @@ typedef struct {
 static char *
 josekiscan_play(engine_t *e, board_t *board, move_t *m, char *move_tags)
 {
-	josekiscan_t *j = e->data;
+	josekiscan_t *j = (josekiscan_t*)e->data;
 
 	if (!board->moves) {
 		/* New game, reset state. */
@@ -137,7 +137,7 @@ josekiscan_state_init(char *arg)
 static void
 josekiscan_done(engine_t *e)
 {
-	josekiscan_t *j = e->data;
+	josekiscan_t *j = (josekiscan_t*)e->data;
 
 	for (int i = 0; i < 16; i++)
 		board_done(j->b[i]);

--- a/engines/josekiscan.c
+++ b/engines/josekiscan.c
@@ -102,7 +102,7 @@ josekiscan_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, b
 static josekiscan_t *
 josekiscan_state_init(char *arg)
 {
-	josekiscan_t *j = calloc2(1, sizeof(josekiscan_t));
+	josekiscan_t *j = calloc2(1, josekiscan_t);
 
 	for (int i = 0; i < 16; i++)
 		j->b[i] = board_new(19+2, NULL);

--- a/engines/josekiscan.c
+++ b/engines/josekiscan.c
@@ -42,7 +42,7 @@ josekiscan_play(struct engine *e, struct board *board, struct move *m, char *mov
 	}
 
 	//board_print(board, stderr);
-	//fprintf(stderr, "move: %s %s\n", stone2str(m->color), coord2sstr(m->coord, board));
+	//fprintf(stderr, "move: %s %s\n", stone2str(m->color), coord2sstr(m->coord));
 	
 	assert(!is_resign(m->coord));
 	/* pass -> tag next move <later> */
@@ -66,14 +66,14 @@ josekiscan_play(struct engine *e, struct board *board, struct move *m, char *mov
 	       joseki_spatial_hash(board,   m->coord, m->color));
 
 	coord_t last = board->last_move.coord;
-	if (last != pass && coord_gridcular_distance(m->coord, last, board) >= 30)
+	if (last != pass && coord_gridcular_distance(m->coord, last) >= 30)
 		fprintf(stderr, "warning: josekiscan %s %s: big distance to prev move, use pass / setup stones for tenuki\n",
-			coord2sstr(last, board), coord2sstr(m->coord, board));
+			coord2sstr(last), coord2sstr(m->coord));
 
 	/* Record next move in all rotations and add joseki pattern. */
 	for (int i = 0; i < 16; i++) {
 		struct board *b = j->b[i];
-		coord_t coord = rotate_coord(b, m->coord, i);
+		coord_t coord = rotate_coord(m->coord, i);
 		enum stone color = m->color;
 		if (i & 8) color = stone_other(color);
 

--- a/engines/josekiscan.h
+++ b/engines/josekiscan.h
@@ -2,8 +2,7 @@
 #define PACHI_ENGINE_JOSEKISCAN_H
 
 #include "engine.h"
-struct joseki_dict;
 
-void engine_josekiscan_init(struct engine *e, char *arg, struct board *b);
+void engine_josekiscan_init(engine_t *e, char *arg, board_t *b);
 
 #endif

--- a/engines/montecarlo.c
+++ b/engines/montecarlo.c
@@ -38,19 +38,19 @@
 
 
 /* Internal engine state. */
-struct montecarlo {
+typedef struct {
 	int debug_level;
 	int gamelen;
 	floating_t resign_ratio;
 	int loss_threshold;
-	struct playout_policy *playout;
-};
+	playout_policy_t *playout;
+} montecarlo_t;
 
 /* Per-move playout statistics. */
-struct move_stat {
+typedef struct {
 	int games;
 	int wins;
-};
+} move_stat_t;
 
 
 /* FIXME: Cutoff rule for simulations. Currently we are so fast that this
@@ -62,7 +62,7 @@ struct move_stat {
 
 
 static void
-board_stats_print(struct board *board, struct move_stat *moves, FILE *f)
+board_stats_print(board_t *board, move_stat_t *moves, FILE *f)
 {
 	fprintf(f, "\n       ");
 	int x, y;
@@ -93,9 +93,9 @@ board_stats_print(struct board *board, struct move_stat *moves, FILE *f)
 
 
 static coord_t
-montecarlo_genmove(struct engine *e, struct board *b, struct time_info *ti, enum stone color, bool pass_all_alive)
+montecarlo_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
 {
-	struct montecarlo *mc = e->data;
+	montecarlo_t *mc = e->data;
 
 	if (ti->dim == TD_WALLTIME) {
 		fprintf(stderr, "Warning: TD_WALLTIME time mode not supported, resetting to defaults.\n");
@@ -107,7 +107,7 @@ montecarlo_genmove(struct engine *e, struct board *b, struct time_info *ti, enum
 		ti->len.games = MC_GAMES;
 		ti->len.games_max = 0;
 	}
-	struct time_stop stop;
+	time_stop_t stop;
 	time_stop_conditions(ti, b, 20, 40, 3.0, &stop);
 
 	/* resign when the hope for win vanishes */
@@ -116,7 +116,7 @@ montecarlo_genmove(struct engine *e, struct board *b, struct time_info *ti, enum
 
 	/* We use [0] for pass. Normally, this is an inaccessible corner
 	 * of board margin. */
-	struct move_stat moves[board_size2(b)];
+	move_stat_t moves[board_size2(b)];
 	memset(moves, 0, sizeof(moves));
 
 	int losses = 0;
@@ -124,7 +124,7 @@ montecarlo_genmove(struct engine *e, struct board *b, struct time_info *ti, enum
 	for (i = 0; i < stop.desired.playouts; i++) {
 		assert(!b->superko_violation);
 
-		struct board b2;
+		board_t b2;
 		board_copy(&b2, b);
 
 		coord_t coord;
@@ -143,7 +143,7 @@ montecarlo_genmove(struct engine *e, struct board *b, struct time_info *ti, enum
 		if (DEBUGL(3))
 			fprintf(stderr, "[%d,%d color %d] playing random game\n", coord_x(coord), coord_y(coord), color);
 
-		struct playout_setup ps = playout_setup(mc->gamelen, 0);
+		playout_setup_t ps = playout_setup(mc->gamelen, 0);
 		int result = playout_play_game(&ps, &b2, color, NULL, NULL, mc->playout);
 
 		board_done_noalloc(&b2);
@@ -224,16 +224,16 @@ move_found:
 }
 
 static void
-montecarlo_done(struct engine *e)
+montecarlo_done(engine_t *e)
 {
-	struct montecarlo *mc = e->data;
+	montecarlo_t *mc = e->data;
 	playout_policy_done(mc->playout);
 }
 
-struct montecarlo *
-montecarlo_state_init(char *arg, struct board *b)
+montecarlo_t *
+montecarlo_state_init(char *arg, board_t *b)
 {
-	struct montecarlo *mc = calloc2(1, sizeof(struct montecarlo));
+	montecarlo_t *mc = calloc2(1, sizeof(montecarlo_t));
 
 	mc->debug_level = 1;
 	mc->gamelen = MC_GAMELEN;
@@ -286,9 +286,9 @@ montecarlo_state_init(char *arg, struct board *b)
 
 
 void
-engine_montecarlo_init(struct engine *e, char *arg, struct board *b)
+engine_montecarlo_init(engine_t *e, char *arg, board_t *b)
 {
-	struct montecarlo *mc = montecarlo_state_init(arg, b);
+	montecarlo_t *mc = montecarlo_state_init(arg, b);
 	e->name = "MonteCarlo";
 	e->comment = "I'm playing in Monte Carlo. When we both pass, I will consider all the stones on the board alive. If you are reading this, write 'yes'. Please bear with me at the game end, I need to fill the whole board; if you help me, we will both be happier. Filling the board will not lose points (NZ rules).";
 	e->genmove = montecarlo_genmove;

--- a/engines/montecarlo.c
+++ b/engines/montecarlo.c
@@ -143,7 +143,7 @@ montecarlo_genmove(struct engine *e, struct board *b, struct time_info *ti, enum
 		if (DEBUGL(3))
 			fprintf(stderr, "[%d,%d color %d] playing random game\n", coord_x(coord, b), coord_y(coord, b), color);
 
-		struct playout_setup ps = { .gamelen = mc->gamelen };
+		struct playout_setup ps = playout_setup(mc->gamelen, 0);
 		int result = playout_play_game(&ps, &b2, color, NULL, NULL, mc->playout);
 
 		board_done_noalloc(&b2);

--- a/engines/montecarlo.c
+++ b/engines/montecarlo.c
@@ -134,14 +134,14 @@ montecarlo_genmove(struct engine *e, struct board *b, struct time_info *ti, enum
 			 * so we can't consider this. (Note that we
 			 * unfortunately still consider this in playouts.) */
 			if (DEBUGL(4)) {
-				fprintf(stderr, "SUICIDE DETECTED at %d,%d:\n", coord_x(coord, b), coord_y(coord, b));
+				fprintf(stderr, "SUICIDE DETECTED at %d,%d:\n", coord_x(coord), coord_y(coord));
 				board_print(b, stderr);
 			}
 			continue;
 		}
 
 		if (DEBUGL(3))
-			fprintf(stderr, "[%d,%d color %d] playing random game\n", coord_x(coord, b), coord_y(coord, b), color);
+			fprintf(stderr, "[%d,%d color %d] playing random game\n", coord_x(coord), coord_y(coord), color);
 
 		struct playout_setup ps = playout_setup(mc->gamelen, 0);
 		int result = playout_play_game(&ps, &b2, color, NULL, NULL, mc->playout);
@@ -198,8 +198,8 @@ pass_wins:
 			/* Simple heuristic: avoid opening too low. Do not
 			 * play on second or first line as first white or
 			 * first two black moves.*/
-			if (coord_x(c, b) < 3 || coord_x(c, b) > board_size(b) - 4
-			    || coord_y(c, b) < 3 || coord_y(c, b) > board_size(b) - 4)
+			if (coord_x(c) < 3 || coord_x(c) > board_size(b) - 4
+			    || coord_y(c) < 3 || coord_y(c) > board_size(b) - 4)
 				continue;
 		}
 
@@ -218,7 +218,7 @@ pass_wins:
 
 move_found:
 	if (MCDEBUGL(1))
-		fprintf(stderr, "*** WINNER is %d,%d with score %1.4f (%d games, %d superko)\n", coord_x(top_coord, b), coord_y(top_coord, b), top_ratio, i, superko);
+		fprintf(stderr, "*** WINNER is %d,%d with score %1.4f (%d games, %d superko)\n", coord_x(top_coord), coord_y(top_coord), top_ratio, i, superko);
 
 	return top_coord;
 }

--- a/engines/montecarlo.c
+++ b/engines/montecarlo.c
@@ -233,7 +233,7 @@ montecarlo_done(engine_t *e)
 montecarlo_t *
 montecarlo_state_init(char *arg, board_t *b)
 {
-	montecarlo_t *mc = calloc2(1, sizeof(montecarlo_t));
+	montecarlo_t *mc = calloc2(1, montecarlo_t);
 
 	mc->debug_level = 1;
 	mc->gamelen = MC_GAMELEN;

--- a/engines/montecarlo.c
+++ b/engines/montecarlo.c
@@ -95,7 +95,7 @@ board_stats_print(board_t *board, move_stat_t *moves, FILE *f)
 static coord_t
 montecarlo_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
 {
-	montecarlo_t *mc = e->data;
+	montecarlo_t *mc = (montecarlo_t*)e->data;
 
 	if (ti->dim == TD_WALLTIME) {
 		fprintf(stderr, "Warning: TD_WALLTIME time mode not supported, resetting to defaults.\n");
@@ -226,7 +226,7 @@ move_found:
 static void
 montecarlo_done(engine_t *e)
 {
-	montecarlo_t *mc = e->data;
+	montecarlo_t *mc = (montecarlo_t*)e->data;
 	playout_policy_done(mc->playout);
 }
 

--- a/engines/montecarlo.h
+++ b/engines/montecarlo.h
@@ -3,6 +3,6 @@
 
 #include "engine.h"
 
-void engine_montecarlo_init(struct engine *e, char *arg, struct board *b);
+void engine_montecarlo_init(engine_t *e, char *arg, board_t *b);
 
 #endif

--- a/engines/patternplay.c
+++ b/engines/patternplay.c
@@ -54,7 +54,7 @@ debug_pattern_best_moves(struct patternplay *pp, struct board *b, enum stone col
 		char buffer[512];  strbuf_t strbuf;
 		strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
 		dump_gammas(buf, &pp->pc, &p);
-		fprintf(stderr, "%3s gamma %s\n", coord2sstr(m.coord, b), buf->str);
+		fprintf(stderr, "%3s gamma %s\n", coord2sstr(m.coord), buf->str);
 	}
 	fprintf(stderr, "\n");
 }
@@ -84,7 +84,7 @@ patternplay_genmove(struct engine *e, struct board *b, struct time_info *ti, enu
 	for (int f = 0; f < b->flen; f++) {
 		if (pp->debug_level >= 5 && probs[f] >= 0.001) {
 			char s[256]; pattern2str(s, &pats[f]);
-			fprintf(stderr, "\t%s: %.3f %s\n", coord2sstr(b->f[f], b), probs[f], s);
+			fprintf(stderr, "\t%s: %.3f %s\n", coord2sstr(b->f[f]), probs[f], s);
 		}
 		if (probs[f] > probs[best])
 			best = f;
@@ -136,7 +136,7 @@ patternplay_evaluate(struct engine *e, struct board *b, struct time_info *ti, fl
 		for (int f = 0; f < b->flen; f++) {
 			if (vals[f] >= 0.001) {
 				char s[256]; pattern2str(s, &pats[f]);
-				fprintf(stderr, "\t%s: %.3f %s\n", coord2sstr(b->f[f], b), vals[f], s);
+				fprintf(stderr, "\t%s: %.3f %s\n", coord2sstr(b->f[f]), vals[f], s);
 			}
 		}
 	}

--- a/engines/patternplay.c
+++ b/engines/patternplay.c
@@ -47,7 +47,7 @@ debug_pattern_best_moves(struct patternplay *pp, struct board *b, enum stone col
 	
 	fprintf(stderr, "\n");
 	for (int i = 0; i < nbest; i++) {
-		struct move m = { .coord = best_c[i], .color = color };
+		struct move m = move(best_c[i], color);
 		struct pattern p;
 		pattern_match(&pp->pc, &p, b, &m, &ownermap, locally);
 

--- a/engines/patternplay.c
+++ b/engines/patternplay.c
@@ -24,14 +24,14 @@ typedef struct {
 pattern_config_t*
 patternplay_get_pc(engine_t *e)
 {
-	patternplay_t *pp = e->data;
+	patternplay_t *pp = (patternplay_t*)e->data;
 	return &pp->pc;
 }
 
 bool
 patternplay_matched_locally(engine_t *e)
 {
-	patternplay_t *pp = e->data;
+	patternplay_t *pp = (patternplay_t*)e->data;
 	assert(pp->matched_locally != -1);
 	return pp->matched_locally;
 }
@@ -63,7 +63,7 @@ debug_pattern_best_moves(patternplay_t *pp, board_t *b, enum stone color,
 static coord_t
 patternplay_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
 {
-	patternplay_t *pp = e->data;
+	patternplay_t *pp = (patternplay_t*)e->data;
 
 	pattern_t pats[b->flen];
 	floating_t probs[b->flen];
@@ -97,7 +97,7 @@ static void
 patternplay_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 		       coord_t *best_c, float *best_r, int nbest)
 {
-	patternplay_t *pp = e->data;
+	patternplay_t *pp = (patternplay_t*)e->data;
 
 	pattern_t pats[b->flen];
 	floating_t probs[b->flen];
@@ -114,7 +114,7 @@ patternplay_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone colo
 void
 patternplay_evaluate(engine_t *e, board_t *b, time_info_t *ti, floating_t *vals, enum stone color)
 {
-	patternplay_t *pp = e->data;
+	patternplay_t *pp = (patternplay_t*)e->data;
 
 	pattern_t pats[b->flen];
 	ownermap_t ownermap;

--- a/engines/patternplay.c
+++ b/engines/patternplay.c
@@ -146,7 +146,7 @@ patternplay_evaluate(engine_t *e, board_t *b, time_info_t *ti, floating_t *vals,
 patternplay_t *
 patternplay_state_init(char *arg)
 {
-	patternplay_t *pp = calloc2(1, sizeof(patternplay_t));
+	patternplay_t *pp = calloc2(1, patternplay_t);
 	bool pat_setup = false;
 
 	pp->debug_level = debug_level;

--- a/engines/patternplay.c
+++ b/engines/patternplay.c
@@ -14,41 +14,41 @@
 
 
 /* Internal engine state. */
-struct patternplay {
+typedef struct {
 	int debug_level;
-	struct pattern_config pc;
+	pattern_config_t pc;
 	bool mcowner_fast;
 	int  matched_locally;
-};
+} patternplay_t;
 
-struct pattern_config*
-patternplay_get_pc(struct engine *e)
+pattern_config_t*
+patternplay_get_pc(engine_t *e)
 {
-	struct patternplay *pp = e->data;
+	patternplay_t *pp = e->data;
 	return &pp->pc;
 }
 
 bool
-patternplay_matched_locally(struct engine *e)
+patternplay_matched_locally(engine_t *e)
 {
-	struct patternplay *pp = e->data;
+	patternplay_t *pp = e->data;
 	assert(pp->matched_locally != -1);
 	return pp->matched_locally;
 }
 
 static void
-debug_pattern_best_moves(struct patternplay *pp, struct board *b, enum stone color,
+debug_pattern_best_moves(patternplay_t *pp, board_t *b, enum stone color,
 			 coord_t *best_c, int nbest)
 {
-	struct ownermap ownermap;
+	ownermap_t ownermap;
 	if (pp->mcowner_fast)  mcowner_playouts_fast(b, color, &ownermap);
 	else                   mcowner_playouts(b, color, &ownermap);
 	bool locally = pattern_matching_locally(&pp->pc, b, color, &ownermap);
 	
 	fprintf(stderr, "\n");
 	for (int i = 0; i < nbest; i++) {
-		struct move m = move(best_c[i], color);
-		struct pattern p;
+		move_t m = move(best_c[i], color);
+		pattern_t p;
 		pattern_match(&pp->pc, &p, b, &m, &ownermap, locally);
 
 		char buffer[512];  strbuf_t strbuf;
@@ -61,13 +61,13 @@ debug_pattern_best_moves(struct patternplay *pp, struct board *b, enum stone col
 
 
 static coord_t
-patternplay_genmove(struct engine *e, struct board *b, struct time_info *ti, enum stone color, bool pass_all_alive)
+patternplay_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
 {
-	struct patternplay *pp = e->data;
+	patternplay_t *pp = e->data;
 
-	struct pattern pats[b->flen];
+	pattern_t pats[b->flen];
 	floating_t probs[b->flen];
-	struct ownermap ownermap;
+	ownermap_t ownermap;
 	if (pp->mcowner_fast)  mcowner_playouts_fast(b, color, &ownermap);
 	else		       mcowner_playouts(b, color, &ownermap);
 	pp->matched_locally = -1;  // Invalidate
@@ -94,14 +94,14 @@ patternplay_genmove(struct engine *e, struct board *b, struct time_info *ti, enu
 }
 
 static void
-patternplay_best_moves(struct engine *e, struct board *b, struct time_info *ti, enum stone color,
+patternplay_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 		       coord_t *best_c, float *best_r, int nbest)
 {
-	struct patternplay *pp = e->data;
+	patternplay_t *pp = e->data;
 
-	struct pattern pats[b->flen];
+	pattern_t pats[b->flen];
 	floating_t probs[b->flen];
-	struct ownermap ownermap;
+	ownermap_t ownermap;
 	if (pp->mcowner_fast)  mcowner_playouts_fast(b, color, &ownermap);
 	else		       mcowner_playouts(b, color, &ownermap);
 	pp->matched_locally = pattern_matching_locally(&pp->pc, b, color, &ownermap);
@@ -112,12 +112,12 @@ patternplay_best_moves(struct engine *e, struct board *b, struct time_info *ti, 
 }
 
 void
-patternplay_evaluate(struct engine *e, struct board *b, struct time_info *ti, floating_t *vals, enum stone color)
+patternplay_evaluate(engine_t *e, board_t *b, time_info_t *ti, floating_t *vals, enum stone color)
 {
-	struct patternplay *pp = e->data;
+	patternplay_t *pp = e->data;
 
-	struct pattern pats[b->flen];
-	struct ownermap ownermap;
+	pattern_t pats[b->flen];
+	ownermap_t ownermap;
 	if (pp->mcowner_fast)  mcowner_playouts_fast(b, color, &ownermap);
 	else                   mcowner_playouts(b, color, &ownermap);
 	pp->matched_locally = -1;  // Invalidate
@@ -143,10 +143,10 @@ patternplay_evaluate(struct engine *e, struct board *b, struct time_info *ti, fl
 }
 
 
-struct patternplay *
+patternplay_t *
 patternplay_state_init(char *arg)
 {
-	struct patternplay *pp = calloc2(1, sizeof(struct patternplay));
+	patternplay_t *pp = calloc2(1, sizeof(patternplay_t));
 	bool pat_setup = false;
 
 	pp->debug_level = debug_level;
@@ -194,9 +194,9 @@ patternplay_state_init(char *arg)
 }
 
 void
-engine_patternplay_init(struct engine *e, char *arg, struct board *b)
+engine_patternplay_init(engine_t *e, char *arg, board_t *b)
 {
-	struct patternplay *pp = patternplay_state_init(arg);
+	patternplay_t *pp = patternplay_state_init(arg);
 	e->name = "PatternPlay Engine";
 	e->comment = "I select moves blindly according to learned patterns. I won't pass as long as there is a place on the board where I can play. When we both pass, I will consider all the stones on the board alive.";
 	e->genmove = patternplay_genmove;

--- a/engines/patternplay.h
+++ b/engines/patternplay.h
@@ -2,9 +2,10 @@
 #define PACHI_PATTERNPLAY_PATTERNPLAY_H
 
 #include "engine.h"
+#include "pattern.h"
 
-void engine_patternplay_init(struct engine *e, char *arg, struct board *b);
-struct pattern_config *patternplay_get_pc(struct engine *e);
-bool patternplay_matched_locally(struct engine *e);
+void engine_patternplay_init(engine_t *e, char *arg, board_t *b);
+pattern_config_t *patternplay_get_pc(engine_t *e);
+bool patternplay_matched_locally(engine_t *e);
 
 #endif

--- a/engines/patternscan.c
+++ b/engines/patternscan.c
@@ -126,7 +126,7 @@ mm_table(struct patternscan *ps)
 	FILE *file = fopen("mm-pachi.table", "w");  assert(file);
 	
 	for (int i = 0; i < FEAT_MAX; i++) {
-		struct feature f = {  .id = i  };
+		struct feature f = feature(i, 0);
 		int gamma = ps->feature2mm[i];
 		
 		if (i >= FEAT_SPATIAL) {  /* Spatial feature */
@@ -201,7 +201,7 @@ process_pattern(struct patternscan *ps, struct board *b, struct move *m,
 	/* Go through other moves as well */
 	if (game_move) {
 		foreach_free_point(b) {
-			struct move m2 = { .coord = c, .color = m->color };
+			struct move m2 = move(c, m->color);
 			if (c == m->coord)                                           continue;
 			if (!board_is_valid_play_no_suicide(b, m2.color, m2.coord))  continue;
 			process_pattern(ps, b, &m2, false, callback, data);

--- a/engines/patternscan.c
+++ b/engines/patternscan.c
@@ -171,7 +171,7 @@ patternscan_mm_init(patternscan_t *ps)
 	init_feature_numbers(ps);
 	
 	/* Assign mm number to each spatial */
-	ps->spatial2mm = malloc(spat_dict->nspatials * sizeof(ps->spatial2mm[0]));
+	ps->spatial2mm = calloc2(spat_dict->nspatials, unsigned int);
 	unsigned int nspatials_by_dist[MAX_PATTERN_DIST+1] = { 0, };
 	for (unsigned int i = 0; i < spat_dict->nspatials; i++) {
 		spatial_t *s = &spat_dict->spatials[i];
@@ -390,7 +390,7 @@ patternscan_done(engine_t *e)
 static patternscan_t *
 patternscan_state_init(char *arg)
 {
-	patternscan_t *ps = global_ps = calloc2(1, sizeof(patternscan_t));
+	patternscan_t *ps = global_ps = calloc2(1, patternscan_t);
 	bool pat_setup = false;
 
 	ps->debug_level = 1;

--- a/engines/patternscan.c
+++ b/engines/patternscan.c
@@ -213,7 +213,7 @@ static void
 mm_process_move(patternscan_t *ps, board_t *b, move_t *m, strbuf_t *buf,
 		bool game_move, void *data)
 {
-	ownermap_t *ownermap = data;
+	ownermap_t *ownermap = (ownermap_t*)data;
 	
 	/* Now, match the pattern. */
 	pattern_t p;
@@ -253,7 +253,7 @@ genspatial_process_move(patternscan_t *ps, board_t *b, move_t *m, strbuf_t *buf,
 #define SCOUNTS_ALLOC 1048576 // Allocate space in 1M*4 blocks.
 		if (sid >= ps->nscounts) {
 			int newnsc = (sid / SCOUNTS_ALLOC + 1) * SCOUNTS_ALLOC;
-			ps->scounts = realloc(ps->scounts, newnsc * sizeof(*ps->scounts));
+			ps->scounts = (int*)realloc(ps->scounts, newnsc * sizeof(*ps->scounts));
 			memset(&ps->scounts[ps->nscounts], 0, (newnsc - ps->nscounts) * sizeof(*ps->scounts));
 			//ps->sgameno = realloc(ps->sgameno, newnsc * sizeof(*ps->sgameno));
 			//memset(&ps->sgameno[ps->nscounts], 0, (newnsc - ps->nscounts) * sizeof(*ps->sgameno));
@@ -283,7 +283,7 @@ genspatial_process_move(patternscan_t *ps, board_t *b, move_t *m, strbuf_t *buf,
 static char *
 patternscan_play(engine_t *e, board_t *b, move_t *m, char *enginearg)
 {
-	patternscan_t *ps = e->data;
+	patternscan_t *ps = (patternscan_t*)e->data;
 
 	if (is_pass(m->coord))
 		return NULL;
@@ -349,7 +349,7 @@ genspatial_done(patternscan_t *ps)
 		assert(i < ps->nscounts && ps->scounts[i] > 0);
 		if (ps->scounts[i] >= ps->spat_threshold) {
 			if (!(nmatches % MATCHES_ALLOC))
-				matches = realloc(matches, (nmatches + MATCHES_ALLOC) * sizeof(*matches));
+				matches = (unsigned int*)realloc(matches, (nmatches + MATCHES_ALLOC) * sizeof(*matches));
 			matches[nmatches++] = i;
 		}
 	}
@@ -378,7 +378,7 @@ genspatial_done(patternscan_t *ps)
 static void
 patternscan_done(engine_t *e)
 {
-	patternscan_t *ps = e->data;
+	patternscan_t *ps = (patternscan_t*)e->data;
 	
 	if (ps->gen_spat_dict)
 		genspatial_done(ps);

--- a/engines/patternscan.h
+++ b/engines/patternscan.h
@@ -3,6 +3,6 @@
 
 #include "engine.h"
 
-void engine_patternscan_init(struct engine *e, char *arg, struct board *b);
+void engine_patternscan_init(engine_t *e, char *arg, board_t *b);
 
 #endif

--- a/engines/random.c
+++ b/engines/random.c
@@ -7,7 +7,7 @@
 #include "engines/random.h"
 
 static coord_t
-random_genmove(struct engine *e, struct board *b, struct time_info *ti, enum stone color, bool pass_all_alive)
+random_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
 {
 	/* Play a random coordinate. However, we must also guard
 	 * against suicide moves; repeat playing while it's a suicide
@@ -20,7 +20,7 @@ random_genmove(struct engine *e, struct board *b, struct time_info *ti, enum sto
 		/* board_play_random() actually plays the move too;
 		 * this is desirable for MC simulations but not within
 		 * the genmove. Make a scratch new board for it. */
-		struct board b2;
+		board_t b2;
 		board_copy(&b2, b);
 
 		board_play_random(&b2, color, &coord, NULL, NULL);
@@ -33,7 +33,7 @@ random_genmove(struct engine *e, struct board *b, struct time_info *ti, enum sto
 }
 
 void
-engine_random_init(struct engine *e, char *arg, struct board *b)
+engine_random_init(engine_t *e, char *arg, board_t *b)
 {
 	e->name = "RandomMove";
 	e->comment = "I just make random moves. I won't pass as long as there is a place on the board where I can play. When we both pass, I will consider all the stones on the board alive.";

--- a/engines/random.h
+++ b/engines/random.h
@@ -3,6 +3,6 @@
 
 #include "engine.h"
 
-void engine_random_init(struct engine *e, char *arg, struct board *b);
+void engine_random_init(engine_t *e, char *arg, board_t *b);
 
 #endif

--- a/engines/replay.c
+++ b/engines/replay.c
@@ -52,7 +52,7 @@ replay_sample_moves(struct engine *e, struct board *b, enum stone color,
 		if (DEBUGL(4))  fprintf(stderr, "---------------------------------\n");		
 		coord_t c = playout_play_move(&setup, &b2, color, r->playout);		
 		assert(!is_resign(c));
-		if (DEBUGL(4))  fprintf(stderr, "-> %s\n", coord2sstr(c, &b2));
+		if (DEBUGL(4))  fprintf(stderr, "-> %s\n", coord2sstr(c));
 		
 		played[c]++;
 		if (played[c] > most_played) {
@@ -84,14 +84,14 @@ replay_genmove(struct engine *e, struct board *b, struct time_info *ti, enum sto
 		for (int k = most_played; k > 0; k--)
 			for (coord_t c = pass; c < b->size2; c++)
 				if (played[c] == k)
-					fprintf(stderr, "%3s: %.2f%%\n", coord2str(c, b), (float)k * 100 / r->runs);
+					fprintf(stderr, "%3s: %.2f%%\n", coord2sstr(c), (float)k * 100 / r->runs);
 		fprintf(stderr, "\n");
 	}
 
 	if (DEBUGL(2))
 		fprintf(stderr, "genmove: %s %s    %.2f%%  (%i runs)\n\n",
 			(color == S_BLACK ? "B" : "W"),
-			coord2str(m.coord, b), (float)most_played * 100 / r->runs, r->runs);
+			coord2sstr(m.coord), (float)most_played * 100 / r->runs, r->runs);
 	
 	if (r->no_suicide) {  /* Check group suicides */
 		struct board b2;  board_copy(&b2, b);

--- a/engines/replay.c
+++ b/engines/replay.c
@@ -35,7 +35,7 @@ coord_t
 replay_sample_moves(engine_t *e, board_t *b, enum stone color, 
 		    int *played, int *pmost_played)
 {
-	replay_t *r = e->data;
+	replay_t *r = (replay_t*)e->data;
 	playout_policy_t *policy = r->playout;
 	playout_setup_t setup;	        memset(&setup, 0, sizeof(setup));
 	move_t m = move(pass, color);
@@ -69,7 +69,7 @@ replay_sample_moves(engine_t *e, board_t *b, enum stone color,
 static coord_t
 replay_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
 {
-	replay_t *r = e->data;
+	replay_t *r = (replay_t*)e->data;
 	move_t m = move(pass, color);
 	
 	if (DEBUGL(3))
@@ -115,7 +115,7 @@ static void
 replay_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 		  coord_t *best_c, float *best_r, int nbest)
 {
-	replay_t *r = e->data;
+	replay_t *r = (replay_t*)e->data;
 	
 	if (DEBUGL(3))
 		printf("best_moves: %s to play. Sampling moves (%i runs)\n", stone2str(color), r->runs);
@@ -132,7 +132,7 @@ replay_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 static void
 replay_done(engine_t *e)
 {
-	replay_t *r = e->data;
+	replay_t *r = (replay_t*)e->data;
 	playout_policy_done(r->playout);
 }
 

--- a/engines/replay.c
+++ b/engines/replay.c
@@ -139,7 +139,7 @@ replay_done(engine_t *e)
 replay_t *
 replay_state_init(char *arg, board_t *b)
 {
-	replay_t *r = calloc2(1, sizeof(replay_t));
+	replay_t *r = calloc2(1, replay_t);
 	
 	r->debug_level = 1;
 	r->runs = 1000;

--- a/engines/replay.c
+++ b/engines/replay.c
@@ -38,7 +38,7 @@ replay_sample_moves(struct engine *e, struct board *b, enum stone color,
 	struct replay *r = e->data;
 	struct playout_policy *policy = r->playout;
 	struct playout_setup setup;	        memset(&setup, 0, sizeof(setup));
-	struct move m = { .coord = pass, .color = color };
+	struct move m = move(pass, color);
 	int most_played = 0;
 	
 	/* Find out what moves policy plays most in this situation */
@@ -70,7 +70,7 @@ static coord_t
 replay_genmove(struct engine *e, struct board *b, struct time_info *ti, enum stone color, bool pass_all_alive)
 {
 	struct replay *r = e->data;
-	struct move m = { .coord = pass, .color = color };
+	struct move m = move(pass, color);
 	
 	if (DEBUGL(3))
 		printf("genmove: %s to play. Sampling moves (%i runs)\n", stone2str(color), r->runs);

--- a/engines/replay.h
+++ b/engines/replay.h
@@ -3,8 +3,8 @@
 
 #include "engine.h"
 
-coord_t replay_sample_moves(struct engine *e, struct board *b, enum stone color, 
+coord_t replay_sample_moves(engine_t *e, board_t *b, enum stone color, 
 			    int *played, int *pmost_played);
-void engine_replay_init(struct engine *e, char *arg, struct board *b);
+void engine_replay_init(engine_t *e, char *arg, board_t *b);
 
 #endif

--- a/fbook.c
+++ b/fbook.c
@@ -18,13 +18,13 @@ coord_transform(struct board *b, coord_t coord, int i)
 #define HASH_HMIRROR     2
 #define HASH_XYFLIP      4
 	if (i & HASH_VMIRROR) {
-		coord = coord_xy(b, coord_x(coord, b), board_size(b) - 1 - coord_y(coord, b));
+		coord = coord_xy(coord_x(coord), board_size(b) - 1 - coord_y(coord));
 	}
 	if (i & HASH_HMIRROR) {
-		coord = coord_xy(b, board_size(b) - 1 - coord_x(coord, b), coord_y(coord, b));
+		coord = coord_xy(board_size(b) - 1 - coord_x(coord), coord_y(coord));
 	}
 	if (i & HASH_XYFLIP) {
-		coord = coord_xy(b, coord_y(coord, b), coord_x(coord, b));
+		coord = coord_xy(coord_y(coord), coord_x(coord));
 	}
 	return coord;
 }
@@ -117,7 +117,7 @@ fbook_init(char *filename, struct board *b)
 		}
 
 		while (*line != '|') {
-			coord_t c = str2coord(line, fbook->bsize);
+			coord_t c = str2coord(line);
 
 			for (int i = 0; i < 8; i++) {
 				coord_t coord = coord_transform(b, c, i);
@@ -141,7 +141,7 @@ fbook_init(char *filename, struct board *b)
 			// fprintf(stderr, "<%s> skip to %s\n", linebuf, line);
 		}
 
-		coord_t c = str2coord(line, fbook->bsize);
+		coord_t c = str2coord(line);
 		for (int i = 0; i < 8; i++) {
 			coord_t coord = coord_transform(b, c, i);
 #if 0

--- a/fbook.c
+++ b/fbook.c
@@ -121,7 +121,7 @@ fbook_init(char *filename, struct board *b)
 
 			for (int i = 0; i < 8; i++) {
 				coord_t coord = coord_transform(b, c, i);
-				struct move m = { .coord = coord, .color = stone_other(bs[i]->last_move.color) };
+				struct move m = move(coord, stone_other(bs[i]->last_move.color));
 				int ret = board_play(bs[i], &m);
 				assert(ret >= 0);
 			}

--- a/fbook.c
+++ b/fbook.c
@@ -47,12 +47,12 @@ fbook_check(board_t *board)
 	}
 	if (!is_pass(cf)) {
 		if (DEBUGL(1))
-			fprintf(stderr, "fbook match %"PRIhash":%"PRIhash"\n", board->hash, board->hash & fbook_hash_mask);
+			fprintf(stderr, "fbook match %" PRIhash ":%" PRIhash "\n", board->hash, board->hash & fbook_hash_mask);
 	} else {
 		/* No match, also prevent further fbook usage
 		 * until the next clear_board. */
 		if (DEBUGL(4))
-			fprintf(stderr, "fbook out %"PRIhash":%"PRIhash"\n", board->hash, board->hash & fbook_hash_mask);
+			fprintf(stderr, "fbook out %" PRIhash ":%" PRIhash "\n", board->hash, board->hash & fbook_hash_mask);
 		fbook_done(board->fbook);
 		board->fbook = NULL;
 	}
@@ -157,7 +157,7 @@ fbook_init(char *filename, board_t *b)
 				if (fbook->hashes[hi & fbook_hash_mask] == bs[i]->hash)
 					hi = 'c';
 			}
-			fprintf(stderr, "%c %"PRIhash":%"PRIhash" (<%d> %s)\n", conflict,
+			fprintf(stderr, "%c %" PRIhash ":%" PRIhash " (<%d> %s)\n", conflict,
 			        bs[i]->hash & fbook_hash_mask, bs[i]->hash, i, linebuf);
 #endif
 			hash_t hi = bs[i]->hash;

--- a/fbook.c
+++ b/fbook.c
@@ -12,7 +12,7 @@
 
 
 static coord_t
-coord_transform(struct board *b, coord_t coord, int i)
+coord_transform(board_t *b, coord_t coord, int i)
 {
 #define HASH_VMIRROR     1
 #define HASH_HMIRROR     2
@@ -32,7 +32,7 @@ coord_transform(struct board *b, coord_t coord, int i)
 /* Check if we can make a move along the fbook right away.
  * Otherwise return pass. */
 coord_t
-fbook_check(struct board *board)
+fbook_check(board_t *board)
 {
 	if (!board->fbook) return pass;
 
@@ -59,10 +59,10 @@ fbook_check(struct board *board)
 	return cf;
 }
 
-static struct fbook *fbcache;
+static fbook_t *fbcache;
 
-struct fbook *
-fbook_init(char *filename, struct board *b)
+fbook_t *
+fbook_init(char *filename, board_t *b)
 {
 	if (fbcache && fbcache->bsize == board_size(b)
 	    && fbcache->handicap == b->handicap)
@@ -74,7 +74,7 @@ fbook_init(char *filename, struct board *b)
 		return NULL;
 	}
 
-	struct fbook *fbook = calloc(1, sizeof(*fbook));
+	fbook_t *fbook = calloc(1, sizeof(*fbook));
 	fbook->bsize = board_size(b);
 	fbook->handicap = b->handicap;
 	/* We do not set handicap=1 in case of too low komi on purpose;
@@ -87,7 +87,7 @@ fbook_init(char *filename, struct board *b)
 
 	/* Scratch board where we lay out the sequence;
 	 * one for each transposition. */
-	struct board *bs[8];
+	board_t *bs[8];
 	for (int i = 0; i < 8; i++)
 		bs[i] = board_new(fbook->bsize, NULL);
 	
@@ -121,7 +121,7 @@ fbook_init(char *filename, struct board *b)
 
 			for (int i = 0; i < 8; i++) {
 				coord_t coord = coord_transform(b, c, i);
-				struct move m = move(coord, stone_other(bs[i]->last_move.color));
+				move_t m = move(coord, stone_other(bs[i]->last_move.color));
 				int ret = board_play(bs[i], &m);
 				assert(ret >= 0);
 			}
@@ -181,7 +181,7 @@ fbook_init(char *filename, struct board *b)
 		return NULL;
 	}
 
-	struct fbook *fbold = fbcache;
+	fbook_t *fbold = fbcache;
 	fbcache = fbook;
 	if (fbold)
 		fbook_done(fbold);
@@ -189,7 +189,7 @@ fbook_init(char *filename, struct board *b)
 	return fbook;
 }
 
-void fbook_done(struct fbook *fbook)
+void fbook_done(fbook_t *fbook)
 {
 	if (fbook != fbcache)
 		free(fbook);

--- a/fbook.c
+++ b/fbook.c
@@ -74,7 +74,7 @@ fbook_init(char *filename, board_t *b)
 		return NULL;
 	}
 
-	fbook_t *fbook = calloc(1, sizeof(*fbook));
+	fbook_t *fbook = calloc2(1, fbook_t);
 	fbook->bsize = board_size(b);
 	fbook->handicap = b->handicap;
 	/* We do not set handicap=1 in case of too low komi on purpose;

--- a/fbook.h
+++ b/fbook.h
@@ -3,12 +3,10 @@
 
 #include "move.h"
 
-struct board;
-
 /* Opening book (fbook as in "forcing book" since the move is just
  * played unconditionally if found, or possibly "fuseki book"). */
 
-struct fbook {
+typedef struct fbook {
 	int bsize;
 	int handicap;
 
@@ -19,10 +17,10 @@ struct fbook {
 	/* pass == no move in this position */
 	coord_t moves[1<<fbook_hash_bits];
 	hash_t hashes[1<<fbook_hash_bits];
-};
+} fbook_t;
 
-coord_t fbook_check(struct board *board);
-struct fbook *fbook_init(char *filename, struct board *b);
-void fbook_done(struct fbook *fbook);
+coord_t  fbook_check(board_t *board);
+fbook_t* fbook_init(char *filename, board_t *b);
+void     fbook_done(fbook_t *fbook);
 
 #endif

--- a/fifo.c
+++ b/fifo.c
@@ -48,7 +48,7 @@
 #define PACHI_FIFO_ALLOW_MULTIPLE_USERS 1
 
 
-typedef struct ticket_lock {
+typedef struct {
 	pthread_mutex_t mutex;
 } ticket_lock_t;
 
@@ -107,7 +107,7 @@ ticket_unlock(ticket_lock_t *ticket, int me)
 #define SHM_NAME    "pachi_fifo"
 #define SHM_MAGIC   ((int)0xf1f0c0de)
 
-struct sched_shm {
+typedef struct {
 	unsigned int size;
 	int	     magic;
 	int          ready;
@@ -115,10 +115,10 @@ struct sched_shm {
 	
 	/* sched stuff */
 	ticket_lock_t queue;
-};
+} sched_shm_t;
 
-static unsigned int shm_size = sizeof(struct sched_shm);
-static struct sched_shm *shm = 0;
+static unsigned int shm_size = sizeof(sched_shm_t);
+static sched_shm_t *shm = 0;
 
 
 /* Create new shared memory segment */
@@ -160,7 +160,7 @@ attach_shm()
 	/* Sanity check, make sure it has the right size ... */
 	struct stat st;
 	if (stat("/dev/shm/" SHM_NAME, &st) != 0)  fail("/dev/shm/" SHM_NAME);
-	assert(st.st_size == sizeof(struct sched_shm));	
+	assert(st.st_size == sizeof(sched_shm_t));
 	
 	shm = mmap(0, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	if (shm == MAP_FAILED)  fail("mmap");	

--- a/fifo.c
+++ b/fifo.c
@@ -137,7 +137,7 @@ create_shm()
 	void *pt = mmap(0, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	assert(pt != MAP_FAILED);
        
-	shm = pt;
+	shm = (sched_shm_t*)pt;
 	memset(shm, 0, sizeof(*shm));
 	shm->size = shm_size;
 	shm->magic = SHM_MAGIC;
@@ -162,7 +162,7 @@ attach_shm()
 	if (stat("/dev/shm/" SHM_NAME, &st) != 0)  fail("/dev/shm/" SHM_NAME);
 	assert(st.st_size == sizeof(sched_shm_t));
 	
-	shm = mmap(0, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	shm = (sched_shm_t*)mmap(0, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	if (shm == MAP_FAILED)  fail("mmap");	
 	assert(shm->magic == SHM_MAGIC);
 	assert(shm->size == shm_size);

--- a/gogui.c
+++ b/gogui.c
@@ -435,7 +435,7 @@ cmd_gogui_final_score(struct board *b, struct engine *e, struct time_info *ti, g
 		return P_OK;
 	}
 
-	struct move_queue q = { .moves = 0 };
+	struct move_queue q;  mq_init(&q);
 	if (e->dead_group_list)  e->dead_group_list(e, b, &q);
 	
 	int dame, seki;
@@ -701,7 +701,7 @@ cmd_gogui_pattern_features(struct board *b, struct engine *e, struct time_info *
 	
 	struct ownermap ownermap;
 	struct pattern p;
-	struct move m = { .coord = coord, .color = color };
+	struct move m = move(coord, color);
 	struct pattern_config *pc = patternplay_get_pc(pattern_engine);
 	mcowner_playouts(b, color, &ownermap);
 	bool locally = pattern_matching_locally(pc, b, color, &ownermap);
@@ -737,7 +737,7 @@ cmd_gogui_pattern_gammas(struct board *b, struct engine *e, struct time_info *ti
 	
 	struct ownermap ownermap;
 	struct pattern p;
-	struct move m = { .coord = coord, .color = color };
+	struct move m = move(coord, color);
 	struct pattern_config *pc = patternplay_get_pc(pattern_engine);
 	mcowner_playouts(b, color, &ownermap);
 	bool locally = pattern_matching_locally(pc, b, color, &ownermap);
@@ -769,7 +769,7 @@ cmd_gogui_show_spatial(struct board *b, struct engine *e, struct time_info *ti, 
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
 	gogui_show_pattern(b, buf, coord, spatial_dist);
 	
-	struct move m = { .coord = coord, .color = stone_other(b->last_move.color) };
+	struct move m = move(coord, stone_other(b->last_move.color));
 	struct spatial s;
 	spatial_from_board(pc, &s, b, &m);
 	s.dist = spatial_dist;

--- a/gogui.c
+++ b/gogui.c
@@ -33,7 +33,7 @@ typedef enum {
 
 
 enum parse_code
-cmd_gogui_analyze_commands(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_analyze_commands(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char buffer[2000];  strbuf_t strbuf;
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
@@ -159,7 +159,7 @@ value2color(float val, int *r, int *g, int *b)
 }
 
 static void
-gogui_paint_pattern(struct board *b, int colors[BOARD_MAX_COORDS][4],
+gogui_paint_pattern(board_t *b, int colors[BOARD_MAX_COORDS][4],
 		    coord_t coord, unsigned int maxd,
 		    int rr, int gg, int bb)
 {
@@ -181,7 +181,7 @@ gogui_paint_pattern(struct board *b, int colors[BOARD_MAX_COORDS][4],
 
 /* Display spatial pattern */
 static void
-gogui_show_pattern(struct board *b, strbuf_t *buf, coord_t coord, int maxd)
+gogui_show_pattern(board_t *b, strbuf_t *buf, coord_t coord, int maxd)
 {
 	assert(!is_pass(coord));
 	int colors[BOARD_MAX_COORDS][4];  memset(colors, 0, sizeof(colors));
@@ -204,7 +204,7 @@ gogui_show_pattern(struct board *b, strbuf_t *buf, coord_t coord, int maxd)
 enum gogui_reporting gogui_livegfx = 0;
 
 static void
-gogui_set_livegfx(struct engine *e, char *arg)
+gogui_set_livegfx(engine_t *e, char *arg)
 {
 	gogui_livegfx = 0;
 	if (!strcmp(arg, "best_moves"))  gogui_livegfx = UR_GOGUI_BEST;
@@ -223,7 +223,7 @@ gogui_show_livegfx(char *str)
 }
 
 void
-gogui_show_winrates(strbuf_t *buf, struct board *b, enum stone color, coord_t *best_c, float *best_r, int nbest)
+gogui_show_winrates(strbuf_t *buf, board_t *b, enum stone color, coord_t *best_c, float *best_r, int nbest)
 {
 	/* best move */
 	if (best_c[0] != pass)
@@ -238,7 +238,7 @@ gogui_show_winrates(strbuf_t *buf, struct board *b, enum stone color, coord_t *b
 }
 
 void
-gogui_show_best_seq(strbuf_t *buf, struct board *b, enum stone color, coord_t *seq, int n)
+gogui_show_best_seq(strbuf_t *buf, board_t *b, enum stone color, coord_t *seq, int n)
 {	
 	char *col = "bw";
 	sbprintf(buf, "VAR ");
@@ -251,7 +251,7 @@ gogui_show_best_seq(strbuf_t *buf, struct board *b, enum stone color, coord_t *s
 
 /* Display best moves graphically in GoGui. */
 void
-gogui_show_best_moves(strbuf_t *buf, struct board *b, enum stone color, coord_t *best_c, float *best_r, int n)
+gogui_show_best_moves(strbuf_t *buf, board_t *b, enum stone color, coord_t *best_c, float *best_r, int n)
 {
         /* best move */
         if (best_c[0] != pass)
@@ -266,7 +266,7 @@ gogui_show_best_moves(strbuf_t *buf, struct board *b, enum stone color, coord_t 
 
 /* Display best moves graphically in GoGui. */
 void
-gogui_show_best_moves_colors(strbuf_t *buf, struct board *b, enum stone color,
+gogui_show_best_moves_colors(strbuf_t *buf, board_t *b, enum stone color,
 			     coord_t *best_c, float *best_r, int n)
 {
 	float vals[BOARD_MAX_COORDS];
@@ -314,11 +314,11 @@ rescale_best_moves(coord_t *best_c, float *best_r, int n, int rescale)
 }
 
 static void
-gogui_best_moves(strbuf_t *buf, struct engine *e, struct board *b, struct time_info *ti,
+gogui_best_moves(strbuf_t *buf, engine_t *e, board_t *b, time_info_t *ti,
 		 enum stone color, int n, gogui_gfx_t gfx_type, gogui_rescale_t rescale)
 {
 	assert(color != S_NONE);
-	struct time_info *ti_genmove = time_info_genmove(b, ti, color);
+	time_info_t *ti_genmove = time_info_genmove(b, ti, color);
 	
 	coord_t best_c[n];
 	float   best_r[n];
@@ -342,7 +342,7 @@ gogui_best_moves(strbuf_t *buf, struct engine *e, struct board *b, struct time_i
 }
 
 enum parse_code
-cmd_gogui_color_palette(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_color_palette(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	enum stone color = S_BLACK;
 	if (b->last_move.color)  color = stone_other(b->last_move.color);
@@ -362,7 +362,7 @@ cmd_gogui_color_palette(struct board *b, struct engine *e, struct time_info *ti,
 
 
 enum parse_code
-cmd_gogui_livegfx(struct board *board, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_livegfx(board_t *board, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
 	next_tok(arg);
@@ -371,9 +371,9 @@ cmd_gogui_livegfx(struct board *board, struct engine *e, struct time_info *ti, g
 }
 
 enum parse_code
-cmd_gogui_influence(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_influence(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	struct ownermap *ownermap = engine_ownermap(e, b);
+	ownermap_t *ownermap = engine_ownermap(e, b);
 	if (!ownermap)  {  gtp_error(gtp, "no ownermap", NULL);  return P_OK;  }
 	
 	char buffer[5000];  strbuf_t strbuf;
@@ -402,9 +402,9 @@ cmd_gogui_influence(struct board *b, struct engine *e, struct time_info *ti, gtp
 }
 
 enum parse_code
-cmd_gogui_score_est(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_score_est(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	struct ownermap *ownermap = engine_ownermap(e, b);
+	ownermap_t *ownermap = engine_ownermap(e, b);
 	if (!ownermap)  {  gtp_error(gtp, "no ownermap", NULL);  return P_OK;  }
 	
 	char buffer[5000];  strbuf_t strbuf;
@@ -426,16 +426,16 @@ cmd_gogui_score_est(struct board *b, struct engine *e, struct time_info *ti, gtp
 }
 
 enum parse_code
-cmd_gogui_final_score(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_final_score(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *msg = NULL;
-	struct ownermap *o = engine_ownermap(e, b);
+	ownermap_t *o = engine_ownermap(e, b);
 	if (o && !board_position_final(b, o, &msg)) {
 		gtp_error(gtp, msg, NULL);
 		return P_OK;
 	}
 
-	struct move_queue q;  mq_init(&q);
+	move_queue_t q;  mq_init(&q);
 	if (e->dead_group_list)  e->dead_group_list(e, b, &q);
 	
 	int dame, seki;
@@ -463,7 +463,7 @@ cmd_gogui_final_score(struct board *b, struct engine *e, struct time_info *ti, g
 }
 
 enum parse_code
-cmd_gogui_winrates(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_winrates(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	enum stone color = S_BLACK;
 	if (b->last_move.color)  color = stone_other(b->last_move.color);
@@ -481,7 +481,7 @@ cmd_gogui_winrates(struct board *b, struct engine *e, struct time_info *ti, gtp_
 }
 
 enum parse_code
-cmd_gogui_best_moves(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_best_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	enum stone color = S_BLACK;
 	if (b->last_move.color)  color = stone_other(b->last_move.color);
@@ -503,10 +503,10 @@ cmd_gogui_best_moves(struct board *b, struct engine *e, struct time_info *ti, gt
 /********************************************************************************************/
 /* dcnn */
 
-static struct engine *dcnn_engine = NULL;
+static engine_t *dcnn_engine = NULL;
 
 enum parse_code
-cmd_gogui_dcnn_best(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_dcnn_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn", NULL);  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
@@ -523,7 +523,7 @@ cmd_gogui_dcnn_best(struct board *b, struct engine *e, struct time_info *ti, gtp
 }
 
 enum parse_code
-cmd_gogui_dcnn_colors(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_dcnn_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn", NULL);  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
@@ -540,7 +540,7 @@ cmd_gogui_dcnn_colors(struct board *b, struct engine *e, struct time_info *ti, g
 }
 
 enum parse_code
-cmd_gogui_dcnn_rating(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_dcnn_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn", NULL);  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
@@ -562,10 +562,10 @@ cmd_gogui_dcnn_rating(struct board *b, struct engine *e, struct time_info *ti, g
 /********************************************************************************************/
 /* joseki */
 
-static struct engine *joseki_engine = NULL;
+static engine_t *joseki_engine = NULL;
 
 enum parse_code
-cmd_gogui_joseki_moves(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_joseki_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!using_joseki(b)) {  gtp_reply(gtp, "TEXT Not using joseki", NULL);  return P_OK;  }
 	if (!joseki_engine)   joseki_engine = new_engine(E_JOSEKIPLAY, NULL, b);
@@ -605,7 +605,7 @@ cmd_gogui_joseki_moves(struct board *b, struct engine *e, struct time_info *ti, 
 }
 
 enum parse_code
-cmd_gogui_joseki_show_pattern(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_joseki_show_pattern(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;  next_tok(arg);
 	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
@@ -622,17 +622,17 @@ cmd_gogui_joseki_show_pattern(struct board *b, struct engine *e, struct time_inf
 /********************************************************************************************/
 /* pattern */
 
-static struct engine *pattern_engine = NULL;
+static engine_t *pattern_engine = NULL;
 
 static void
-init_patternplay_engine(struct board *b)
+init_patternplay_engine(board_t *b)
 {
 	char args[] = "mcowner_fast=0";
 	pattern_engine = new_engine(E_PATTERNPLAY, args, b);
 }
 
 enum parse_code
-cmd_gogui_pattern_best(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_pattern_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
 	
@@ -650,7 +650,7 @@ cmd_gogui_pattern_best(struct board *b, struct engine *e, struct time_info *ti, 
 }
 
 enum parse_code
-cmd_gogui_pattern_colors(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_pattern_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
 	
@@ -668,7 +668,7 @@ cmd_gogui_pattern_colors(struct board *b, struct engine *e, struct time_info *ti
 }
 
 enum parse_code
-cmd_gogui_pattern_rating(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_pattern_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
 	
@@ -687,7 +687,7 @@ cmd_gogui_pattern_rating(struct board *b, struct engine *e, struct time_info *ti
 
 /* Show pattern features on point selected by user. */
 enum parse_code
-cmd_gogui_pattern_features(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_pattern_features(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
 	
@@ -699,10 +699,10 @@ cmd_gogui_pattern_features(struct board *b, struct engine *e, struct time_info *
 	coord_t coord = str2coord(arg);
 	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...", NULL);  return P_OK;  }
 	
-	struct ownermap ownermap;
-	struct pattern p;
-	struct move m = move(coord, color);
-	struct pattern_config *pc = patternplay_get_pc(pattern_engine);
+	ownermap_t ownermap;
+	pattern_t p;
+	move_t m = move(coord, color);
+	pattern_config_t *pc = patternplay_get_pc(pattern_engine);
 	mcowner_playouts(b, color, &ownermap);
 	bool locally = pattern_matching_locally(pc, b, color, &ownermap);
 	pattern_match(pc, &p, b, &m, &ownermap, locally);
@@ -723,7 +723,7 @@ cmd_gogui_pattern_features(struct board *b, struct engine *e, struct time_info *
 
 /* Show pattern gammas on point selected by user. */
 enum parse_code
-cmd_gogui_pattern_gammas(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_pattern_gammas(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
 	
@@ -735,10 +735,10 @@ cmd_gogui_pattern_gammas(struct board *b, struct engine *e, struct time_info *ti
 	coord_t coord = str2coord(arg);
 	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...", NULL);  return P_OK;  }
 	
-	struct ownermap ownermap;
-	struct pattern p;
-	struct move m = move(coord, color);
-	struct pattern_config *pc = patternplay_get_pc(pattern_engine);
+	ownermap_t ownermap;
+	pattern_t p;
+	move_t m = move(coord, color);
+	pattern_config_t *pc = patternplay_get_pc(pattern_engine);
 	mcowner_playouts(b, color, &ownermap);
 	bool locally = pattern_matching_locally(pc, b, color, &ownermap);
 	pattern_match(pc, &p, b, &m, &ownermap, locally);
@@ -756,10 +756,10 @@ cmd_gogui_pattern_gammas(struct board *b, struct engine *e, struct time_info *ti
 static int spatial_dist = 6;
 
 enum parse_code
-cmd_gogui_show_spatial(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
-	struct pattern_config *pc = patternplay_get_pc(pattern_engine);
+	pattern_config_t *pc = patternplay_get_pc(pattern_engine);
 
 	char *arg;  next_tok(arg);
 	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
@@ -769,8 +769,8 @@ cmd_gogui_show_spatial(struct board *b, struct engine *e, struct time_info *ti, 
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
 	gogui_show_pattern(b, buf, coord, spatial_dist);
 	
-	struct move m = move(coord, stone_other(b->last_move.color));
-	struct spatial s;
+	move_t m = move(coord, stone_other(b->last_move.color));
+	spatial_t s;
 	spatial_from_board(pc, &s, b, &m);
 	s.dist = spatial_dist;
 	spatial_t *s2 = spatial_dict_lookup(spat_dict, s.dist, spatial_hash(0, &s));
@@ -784,7 +784,7 @@ cmd_gogui_show_spatial(struct board *b, struct engine *e, struct time_info *ti, 
 }
 
 enum parse_code
-cmd_gogui_spatial_size(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
+cmd_gogui_spatial_size(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;  next_tok(arg);
 	/* Return current value */

--- a/gogui.c
+++ b/gogui.c
@@ -201,12 +201,12 @@ gogui_show_pattern(board_t *b, strbuf_t *buf, coord_t coord, int maxd)
 
 /****************************************************************************************/
 
-enum gogui_reporting gogui_livegfx = 0;
+enum gogui_reporting gogui_livegfx = UR_GOGUI_NONE;
 
 static void
 gogui_set_livegfx(engine_t *e, char *arg)
 {
-	gogui_livegfx = 0;
+	gogui_livegfx = UR_GOGUI_NONE;
 	if (!strcmp(arg, "best_moves"))  gogui_livegfx = UR_GOGUI_BEST;
 	if (!strcmp(arg, "best_seq"))    gogui_livegfx = UR_GOGUI_SEQ;
 	if (!strcmp(arg, "winrates"))    gogui_livegfx = UR_GOGUI_WR;
@@ -471,9 +471,9 @@ cmd_gogui_winrates(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	char buffer[5000];  strbuf_t strbuf;
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
 
-	int prev = gogui_livegfx;
+	gogui_reporting_t prev = gogui_livegfx;
 	gogui_set_livegfx(e, "winrates");
-	gogui_best_moves(buf, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, 0);
+	gogui_best_moves(buf, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 	gogui_livegfx = prev;
 
 	gtp_reply(gtp, buf->str, NULL);
@@ -489,9 +489,9 @@ cmd_gogui_best_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	char buffer[10000];  strbuf_t strbuf;
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
 	
-	int prev = gogui_livegfx;
+	gogui_reporting_t prev = gogui_livegfx;
 	gogui_set_livegfx(e, "best_moves");
-	gogui_best_moves(buf, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_MOVES, 0);
+	gogui_best_moves(buf, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 	gogui_livegfx = prev;
 	
 	gtp_reply(gtp, buf->str, NULL);
@@ -516,7 +516,7 @@ cmd_gogui_dcnn_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	
 	char buffer[10000];  strbuf_t strbuf;
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-	gogui_best_moves(buf, dcnn_engine, b, ti, color, 10, GOGUI_BEST_MOVES, 0);
+	gogui_best_moves(buf, dcnn_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 
 	gtp_reply(gtp, buf->str, NULL);
 	return P_OK;
@@ -550,7 +550,7 @@ cmd_gogui_dcnn_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	
 	char buffer[5000];  strbuf_t strbuf;
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-	gogui_best_moves(buf, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, 0);
+	gogui_best_moves(buf, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 
 	gtp_reply(gtp, buf->str, NULL);
 	return P_OK;
@@ -641,7 +641,7 @@ cmd_gogui_pattern_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	
 	char buffer[10000];  strbuf_t strbuf;
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-	gogui_best_moves(buf, pattern_engine, b, ti, color, 10, GOGUI_BEST_MOVES, 0);
+	gogui_best_moves(buf, pattern_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
 	sbprintf(buf, "TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
@@ -677,7 +677,7 @@ cmd_gogui_pattern_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	
 	char buffer[5000];  strbuf_t strbuf;
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-	gogui_best_moves(buf, pattern_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, 0);
+	gogui_best_moves(buf, pattern_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
 	sbprintf(buf, "TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));

--- a/gogui.c
+++ b/gogui.c
@@ -165,8 +165,8 @@ gogui_paint_pattern(struct board *b, int colors[BOARD_MAX_COORDS][4],
 {
 	for (unsigned int d = 2; d <= maxd; d++)
 	for (unsigned int j = ptind[d]; j < ptind[d + 1]; j++) {
-			ptcoords_at(x, y, coord, b, j);
-		        coord_t c  = coord_xy(b, x, y);
+			ptcoords_at(x, y, coord, j);
+		        coord_t c  = coord_xy(x, y);
 			if (board_at(b, c) == S_OFFBOARD)  continue;
 
 /* Just lighten if already something */
@@ -194,7 +194,7 @@ gogui_show_pattern(struct board *b, strbuf_t *buf, coord_t coord, int maxd)
 		int rr = MIN(colors[c][0], 255);
 		int gg = MIN(colors[c][1], 255);
 		int bb = MIN(colors[c][2], 255);
-		sbprintf(buf, "COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c, b));
+		sbprintf(buf, "COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c));
 	} foreach_point_end;
 }
 
@@ -229,11 +229,11 @@ gogui_show_winrates(strbuf_t *buf, struct board *b, enum stone color, coord_t *b
 	if (best_c[0] != pass)
 		sbprintf(buf, "VAR %s %s\n", 
 			 (color == S_WHITE ? "w" : "b"),
-			 coord2sstr(best_c[0], b) );
+			 coord2sstr(best_c[0]) );
 	
 	for (int i = 0; i < nbest; i++)
 		if (best_c[i] != pass)
-			sbprintf(buf, "LABEL %s %i\n", coord2sstr(best_c[i], b),
+			sbprintf(buf, "LABEL %s %i\n", coord2sstr(best_c[i]),
 				 (int)(roundf(best_r[i] * 100)));
 }
 
@@ -245,7 +245,7 @@ gogui_show_best_seq(strbuf_t *buf, struct board *b, enum stone color, coord_t *s
 	for (int i = 0; i < n && seq[i] != pass; i++)
 		sbprintf(buf, "%c %3s ",
 			 col[(i + (color == S_WHITE)) % 2],
-			 coord2sstr(seq[i], b));
+			 coord2sstr(seq[i]));
 	sbprintf(buf, "\n");
 }
 
@@ -257,11 +257,11 @@ gogui_show_best_moves(strbuf_t *buf, struct board *b, enum stone color, coord_t 
         if (best_c[0] != pass)
                 sbprintf(buf, "VAR %s %s\n",
                          (color == S_WHITE ? "w" : "b"),
-                         coord2sstr(best_c[0], b) );
+                         coord2sstr(best_c[0]) );
         
         for (int i = 1; i < n; i++)
                 if (best_c[i] != pass)
-                        sbprintf(buf, "LABEL %s %i\n", coord2sstr(best_c[i], b), i + 1);
+                        sbprintf(buf, "LABEL %s %i\n", coord2sstr(best_c[i]), i + 1);
 }
 
 /* Display best moves graphically in GoGui. */
@@ -279,12 +279,12 @@ gogui_show_best_moves_colors(strbuf_t *buf, struct board *b, enum stone color,
 
 	for (int y = 19; y >= 1; y--)
 	for (int x = 1; x <= 19; x++) {		
-		coord_t c = coord_xy(b, x, y);			
+		coord_t c = coord_xy(x, y);			
 		int rr, gg, bb;
 		value2color(vals[c], &rr, &gg, &bb);
 		
-		//fprintf(stderr, "COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c, b));
-		sbprintf(buf,   "COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c, b));
+		//fprintf(stderr, "COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c));
+		sbprintf(buf,   "COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c));
 	}
 }
 
@@ -327,7 +327,7 @@ gogui_best_moves(strbuf_t *buf, struct engine *e, struct board *b, struct time_i
 #if 0
 	fprintf(stderr, "best: [");
 	for (int i = 0; i < n; i++)
-		fprintf(stderr, "%s ", coord2sstr(best_c[i], b));
+		fprintf(stderr, "%s ", coord2sstr(best_c[i]));
 	fprintf(stderr, "]\n");
 #endif
 	
@@ -352,7 +352,7 @@ cmd_gogui_color_palette(struct board *b, struct engine *e, struct time_info *ti,
 	float   best_r[GOGUI_CANDIDATES] = { 0.0, };
 	coord_t best_c[GOGUI_CANDIDATES];
 	for (int i = 0; i < GOGUI_CANDIDATES; i++)
-		best_c[i] = coord_xy(b, i%19 +1, 18 - i/19 + 1);
+		best_c[i] = coord_xy(i%19 +1, 18 - i/19 + 1);
 
 	rescale_best_moves(best_c, best_r, GOGUI_CANDIDATES, GOGUI_RESCALE_LINEAR);	
 	gogui_show_best_moves_colors(buf, b, color, best_c, best_r, GOGUI_CANDIDATES);
@@ -393,7 +393,7 @@ cmd_gogui_influence(struct board *b, struct engine *e, struct time_info *ti, gtp
 		else if (p < 0.5)  p = 0.4;
 		else if (p < 0.8)  p = 0.7;
 		else               p = 1.0;
-		sbprintf(buf, " %3s %.1lf", coord2sstr(c, b), p);
+		sbprintf(buf, " %3s %.1lf", coord2sstr(c), p);
 	} foreach_point_end;
 
 	sbprintf(buf, "\nTEXT Score Est: %s", ownermap_score_est_str(b, ownermap));
@@ -417,7 +417,7 @@ cmd_gogui_score_est(struct board *b, struct engine *e, struct time_info *ti, gtp
 		float p = 0;
 		if (j == PJ_BLACK)  p = 0.5;
 		if (j == PJ_WHITE)  p = -0.5;
-		sbprintf(buf, " %3s %.1lf", coord2sstr(c, b), p);
+		sbprintf(buf, " %3s %.1lf", coord2sstr(c), p);
 	} foreach_point_end;
 
 	sbprintf(buf, "\nTEXT Score Est: %s", ownermap_score_est_str(b, ownermap));
@@ -450,7 +450,7 @@ cmd_gogui_final_score(struct board *b, struct engine *e, struct time_info *ti, g
 		float p = 0;
 		if (ownermap[c] == S_BLACK)  p = 0.5;
 		if (ownermap[c] == S_WHITE)  p = -0.5;
-		sbprintf(buf, " %3s %.1lf", coord2sstr(c, b), p);
+		sbprintf(buf, " %3s %.1lf", coord2sstr(c), p);
 	} foreach_point_end;
 	sbprintf(buf, "\n");
 	
@@ -582,12 +582,12 @@ cmd_gogui_joseki_moves(struct board *b, struct engine *e, struct time_info *ti, 
 	/* Show relaxed / ignored moves */
 	foreach_free_point(b) {
 		josekipat_t *p = joseki_lookup_ignored(joseki_dict, b, c, color);
-		if (p)  sbprintf(buf, "MARK %s\n", coord2sstr(c, b));
+		if (p)  sbprintf(buf, "MARK %s\n", coord2sstr(c));
 		if (p && (p->flags & JOSEKI_FLAGS_3X3))
-			sbprintf(buf, "CIRCLE %s\n", coord2sstr(c, b));
+			sbprintf(buf, "CIRCLE %s\n", coord2sstr(c));
 		
 		p = joseki_lookup_3x3(joseki_dict, b, c, color);
-		if (p)  sbprintf(buf, "CIRCLE %s\n", coord2sstr(c, b));
+		if (p)  sbprintf(buf, "CIRCLE %s\n", coord2sstr(c));
 	} foreach_free_point_end;
 
 	gogui_best_moves(buf, joseki_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
@@ -597,7 +597,7 @@ cmd_gogui_joseki_moves(struct board *b, struct engine *e, struct time_info *ti, 
 		if (joseki_map[c]) continue;  /* Don't clobber valid moves ! */
 		josekipat_t *p = joseki_lookup_ignored(joseki_dict, b, c, color);
 		if (!p)  continue;
-		sbprintf(buf, "COLOR #0000a0 %s\n", coord2sstr(c, b));
+		sbprintf(buf, "COLOR #0000a0 %s\n", coord2sstr(c));
 	} foreach_free_point_end;
 
 	gtp_reply(gtp, buf->str, NULL);
@@ -609,7 +609,7 @@ cmd_gogui_joseki_show_pattern(struct board *b, struct engine *e, struct time_inf
 {
 	char *arg;  next_tok(arg);
 	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
-	coord_t coord = str2coord(arg, board_size(b));
+	coord_t coord = str2coord(arg);
 
 	char buffer[10000];  strbuf_t strbuf;
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
@@ -696,7 +696,7 @@ cmd_gogui_pattern_features(struct board *b, struct engine *e, struct time_info *
 	
 	char *arg;  next_tok(arg);
 	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
-	coord_t coord = str2coord(arg, board_size(b));	
+	coord_t coord = str2coord(arg);
 	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...", NULL);  return P_OK;  }
 	
 	struct ownermap ownermap;
@@ -732,7 +732,7 @@ cmd_gogui_pattern_gammas(struct board *b, struct engine *e, struct time_info *ti
 	
 	char *arg;  next_tok(arg);
 	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
-	coord_t coord = str2coord(arg, board_size(b));	
+	coord_t coord = str2coord(arg);
 	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...", NULL);  return P_OK;  }
 	
 	struct ownermap ownermap;
@@ -763,7 +763,7 @@ cmd_gogui_show_spatial(struct board *b, struct engine *e, struct time_info *ti, 
 
 	char *arg;  next_tok(arg);
 	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
-	coord_t coord = str2coord(arg, board_size(b));
+	coord_t coord = str2coord(arg);
 
 	char buffer[10000];  strbuf_t strbuf;
 	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));

--- a/gogui.h
+++ b/gogui.h
@@ -6,12 +6,12 @@
 /* How many candidates to display */
 #define GOGUI_CANDIDATES 30
 
-enum gogui_reporting {
-	UR_GOGUI_ZERO,
+typedef enum gogui_reporting {
+	UR_GOGUI_NONE,
 	UR_GOGUI_BEST,
 	UR_GOGUI_SEQ,
 	UR_GOGUI_WR,
-};
+} gogui_reporting_t;
 
 extern enum gogui_reporting gogui_livegfx;
 

--- a/gogui.h
+++ b/gogui.h
@@ -1,6 +1,8 @@
 #ifndef PACHI_GOGUI_H
 #define PACHI_GOGUI_H
 
+#include "gtp.h"
+
 /* How many candidates to display */
 #define GOGUI_CANDIDATES 30
 
@@ -16,31 +18,31 @@ extern enum gogui_reporting gogui_livegfx;
 extern char gogui_gfx_buf[];
 
 
-enum parse_code cmd_gogui_analyze_commands(struct board *board, struct engine *engine, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_livegfx(struct board *board, struct engine *engine, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_best_moves(struct board *board, struct engine *engine, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_winrates(struct board *board, struct engine *engine, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_influence(struct board *board, struct engine *engine, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_score_est(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_final_score(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_dcnn_best(struct board *board, struct engine *engine, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_dcnn_colors(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_dcnn_rating(struct board *board, struct engine *engine, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_color_palette(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_joseki_moves(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_joseki_show_pattern(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_pattern_best(struct board *board, struct engine *engine, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_pattern_colors(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_pattern_rating(struct board *board, struct engine *engine, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_pattern_features(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_pattern_gammas(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_show_spatial(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
-enum parse_code cmd_gogui_spatial_size(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_analyze_commands(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_livegfx(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_best_moves(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_winrates(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_influence(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_score_est(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_final_score(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_dcnn_best(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_dcnn_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_dcnn_rating(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_color_palette(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_joseki_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_joseki_show_pattern(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_pattern_best(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_pattern_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_pattern_rating(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_pattern_features(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_pattern_gammas(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
+enum parse_code cmd_gogui_spatial_size(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
 
-void gogui_show_best_moves(strbuf_t *buf, struct board *b, enum stone color, coord_t *best_c, float *best_r, int n);
-void gogui_show_best_moves_colors(strbuf_t *buf, struct board *b, enum stone color, coord_t *best_c, float *best_r, int n);
-void gogui_show_winrates(strbuf_t *buf, struct board *b, enum stone color, coord_t *best_c, float *best_r, int nbest);
-void gogui_show_best_seq(strbuf_t *buf, struct board *b, enum stone color, coord_t *seq, int n);
+void gogui_show_best_moves(strbuf_t *buf, board_t *b, enum stone color, coord_t *best_c, float *best_r, int n);
+void gogui_show_best_moves_colors(strbuf_t *buf, board_t *b, enum stone color, coord_t *best_c, float *best_r, int n);
+void gogui_show_winrates(strbuf_t *buf, board_t *b, enum stone color, coord_t *best_c, float *best_r, int nbest);
+void gogui_show_best_seq(strbuf_t *buf, board_t *b, enum stone color, coord_t *seq, int n);
 void gogui_show_livegfx(char *str);
 
 #endif

--- a/gtp.c
+++ b/gtp.c
@@ -47,7 +47,7 @@ typedef struct
 	gtp_func_t f;
 } gtp_command_t;
 
-static gtp_command_t commands[];
+static gtp_command_t *commands;
 
 void
 gtp_prefix(char prefix, gtp_t *gtp)
@@ -206,7 +206,7 @@ static enum parse_code
 cmd_version(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	/* kgs hijacks 'version' gtp command for game start message. */	
-	char *version = (gtp->kgs ? e->comment : "%s");
+	const char *version = (gtp->kgs ? e->comment : "%s");
 
 	/* Custom gtp version ? */
 	if (gtp->custom_version)  version = gtp->custom_version;
@@ -825,7 +825,7 @@ static enum parse_code
 cmd_pachi_tunit(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	int res = unit_test_cmd(board, gtp->next);
-	char *str = (res ? "passed" : "failed");
+	const char *str = (res ? "passed" : "failed");
 	gtp_reply(gtp, str, NULL);
 	return P_OK;
 }
@@ -917,7 +917,7 @@ cmd_kgs_time_settings(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *
 }
 
 
-static gtp_command_t commands[] =
+static gtp_command_t gtp_commands[] =
 {
 	{ "protocol_version",       cmd_protocol_version },
 	{ "name",                   cmd_name },
@@ -990,6 +990,11 @@ static gtp_command_t commands[] =
 	{ 0, 0 }
 };
 
+static __attribute__((constructor)) void
+gtp_internal_init()
+{
+	commands = gtp_commands;  /* c++ madness */
+}
 
 /* XXX: THIS IS TOTALLY INSECURE!!!!
  * Even basic input checking is missing. */
@@ -1050,3 +1055,6 @@ gtp_parse(gtp_t *gtp, board_t *b, engine_t *e, char *e_arg, time_info_t *ti, cha
 	gtp_error(gtp, "unknown command", NULL);
 	return P_UNKNOWN_COMMAND;
 }
+
+
+

--- a/gtp.c
+++ b/gtp.c
@@ -340,7 +340,7 @@ cmd_play(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
 	next_tok(arg);
 	m.color = str2stone(arg);
 	next_tok(arg);
-	m.coord = str2coord(arg, board_size(b));
+	m.coord = str2coord(arg);
 	arg = gtp->next;
 	char *enginearg = arg;
 	char *reply = NULL;
@@ -354,7 +354,7 @@ cmd_play(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
 	
 	if (gtp_board_play(gtp, b, &m) < 0) {
 		if (DEBUGL(0)) {
-			fprintf(stderr, "! ILLEGAL MOVE %s %s\n", stone2str(m.color), coord2sstr(m.coord, b));
+			fprintf(stderr, "! ILLEGAL MOVE %s %s\n", stone2str(m.color), coord2sstr(m.coord));
 			board_print(b, stderr);
 		}
 		gtp_error(gtp, "illegal move", NULL);
@@ -376,7 +376,7 @@ cmd_pachi_predict(struct board *board, struct engine *engine, struct time_info *
 	next_tok(arg);
 	m.color = str2stone(arg);
 	next_tok(arg);
-	m.coord = str2coord(arg, board_size(board));
+	m.coord = str2coord(arg);
 	next_tok(arg);
 
 	char *str = predict_move(board, engine, ti, &m, gtp->played_games);
@@ -420,10 +420,10 @@ cmd_genmove(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
 	if (!is_resign(c)) {
 		struct move m = move(c, color);
 		if (gtp_board_play(gtp, b, &m) < 0)
-			die("Attempted to generate an illegal move: %s %s\n", stone2str(m.color), coord2sstr(m.coord, b));
+			die("Attempted to generate an illegal move: %s %s\n", stone2str(m.color), coord2sstr(m.coord));
 	}
 	
-	char *str = coord2sstr(c, b);
+	char *str = coord2sstr(c);
 	if (DEBUGL(4))                      fprintf(stderr, "playing move %s\n", str);
 	if (DEBUGL(1) && debug_boardprint)  engine_board_print(e, b, stderr);
 	gtp_reply(gtp, str, NULL);
@@ -508,7 +508,7 @@ cmd_set_free_handicap(struct board *b, struct engine *e, struct time_info *ti, g
 	char *arg;
 	next_tok(arg);
 	do {
-		struct move m = move(str2coord(arg, board_size(b)), S_BLACK);
+		struct move m = move(str2coord(arg), S_BLACK);
 		if (DEBUGL(4))  fprintf(stderr, "setting handicap %s\n", arg);
 
 		// XXX board left in inconsistent state if illegal move comes in
@@ -547,7 +547,7 @@ cmd_fixed_handicap(struct board *b, struct engine *engine, struct time_info *ti,
 
 	for (unsigned int i = 0; i < q.moves; i++) {
 		struct move m = move(q.move[i], S_BLACK);
-		sbprintf(buf, "%s ", coord2sstr(m.coord, b));
+		sbprintf(buf, "%s ", coord2sstr(m.coord));
 
 		/* Add to gtp move history. */
 		gtp_add_move(gtp, &m);
@@ -601,7 +601,7 @@ cmd_final_status_list_dead(char *arg, struct board *b, struct engine *e, gtp_t *
 	gtp_prefix('=', gtp);
 	for (unsigned int i = 0; i < q.moves; i++) {
 		foreach_in_group(b, q.move[i]) {
-			printf("%s ", coord2sstr(c, b));
+			printf("%s ", coord2sstr(c));
 		} foreach_in_group_end;
 		putchar('\n');
 	}
@@ -624,7 +624,7 @@ cmd_final_status_list_alive(char *arg, struct board *b, struct engine *e, gtp_t 
 			if (q.move[i] == g)  goto next_group;
 			
 		foreach_in_group(b, g) {
-			printf("%s ", coord2sstr(c, b));
+			printf("%s ", coord2sstr(c));
 		} foreach_in_group_end;
 		putchar('\n');  printed++;
 	next_group:;
@@ -655,7 +655,7 @@ cmd_final_status_list_seki(char *arg, struct board *b, struct engine *e, gtp_t *
 
 	for (unsigned int i = 0; i < sekis.moves; i++) {
 		foreach_in_group(b, sekis.move[i]) {
-			printf("%s ", coord2sstr(c, b));
+			printf("%s ", coord2sstr(c));
 		} foreach_in_group_end;
 		putchar('\n');  printed++;
 	}
@@ -674,7 +674,7 @@ cmd_final_status_list_territory(char *arg, struct board *b, struct engine *e, gt
 	foreach_point(b) {
 		if (board_at(b, c) != S_NONE)  continue;
 		if (ownermap_color(ownermap, c, 0.67) != color)  continue;
-		printf("%s ", coord2sstr(c, b));
+		printf("%s ", coord2sstr(c));
 	} foreach_point_end;
 	putchar('\n');
 	return 1;
@@ -708,7 +708,7 @@ cmd_undo(struct board *b, struct engine *e, struct time_info *ti, gtp_t *gtp)
 {
 	/* --noundo: undo only allowed for pass. */
 	if (gtp->noundo && !is_pass(b->last_move.coord)) {
-		if (DEBUGL(1))  fprintf(stderr, "undo on non-pass move %s\n", coord2sstr(b->last_move.coord, b));
+		if (DEBUGL(1))  fprintf(stderr, "undo on non-pass move %s\n", coord2sstr(b->last_move.coord));
 		gtp_error(gtp, "cannot undo", NULL);
 		return P_OK;
 	}
@@ -799,7 +799,7 @@ cmd_pachi_evaluate(struct board *board, struct engine *engine, struct time_info 
 			if (!board_coord_in_symmetry(board, board->f[i])
 			    || isnan(vals[i]) || vals[i] < 0.001)
 				continue;
-			printf("%s %.3f\n", coord2sstr(board->f[i], board), (double) vals[i]);
+			printf("%s %.3f\n", coord2sstr(board->f[i]), (double) vals[i]);
 		}
 		gtp_flush();
 	}

--- a/gtp.h
+++ b/gtp.h
@@ -1,9 +1,10 @@
 #ifndef PACHI_GTP_H
 #define PACHI_GTP_H
 
-struct board;
+#include "board.h"
+#include "timeinfo.h"
+
 struct engine;
-struct time_info;
 
 enum parse_code {
 	P_OK,
@@ -23,15 +24,15 @@ typedef struct
 	int   replied;
 
 	/* Global fields: */
-	int         played_games;
-	struct move move[1500];     /* move history, for undo */
-	int         moves;
-	bool        undo_pending;
-	bool        noundo;           /* undo only allowed for pass */
-	bool        kgs;
-	bool        analyze_running;
-	char*       custom_name;
-	char*       custom_version;
+	int     played_games;
+	move_t  move[1500];     /* move history, for undo */
+	int     moves;
+	bool    undo_pending;
+	bool    noundo;           /* undo only allowed for pass */
+	bool    kgs;
+	bool    analyze_running;
+	char*   custom_name;
+	char*   custom_version;
 } gtp_t;
 
 #define next_tok(to_) \
@@ -44,7 +45,7 @@ typedef struct
 
 void   gtp_init(gtp_t *gtp);
 
-enum parse_code gtp_parse(gtp_t *gtp, struct board *b, struct engine *e, char *e_arg, struct time_info *ti, char *buf);
+enum parse_code gtp_parse(gtp_t *gtp, board_t *b, struct engine *e, char *e_arg, time_info_t *ti, char *buf);
 bool gtp_is_valid(struct engine *e, const char *cmd);
 void gtp_reply(gtp_t *gtp, ...);
 void gtp_reply_printf(gtp_t *gtp, const char *format, ...);

--- a/joseki.c
+++ b/joseki.c
@@ -159,7 +159,7 @@ joseki_add_3x3(struct joseki_dict *jd, struct board *b, coord_t coord, enum ston
 {
 	assert(!is_pass(coord));
 	if (!prev)  die("joseki: [ %s %s ] adding 3x3 match with no previous move, this is bad.\n",
-			coord2sstr(b->last_move.coord, b), coord2sstr(coord, b));
+			coord2sstr(b->last_move.coord), coord2sstr(coord));
 	josekipat_t *p = joseki_lookup_3x3_prev(jd, b, coord, color, prev, flags);
 	if (p)  return p;
 
@@ -226,7 +226,7 @@ convert_coords(int bsize, char *buf)
 		char *arg = buf + 7;  assert(buf[6] == ' ');
 		if (str_prefix("pass", arg))  return 0;
 		
-		coord_t c = str2coord(arg, 19+2);
+		coord_t c = str2coord_for(arg, 19+2);
 		int offset = 21 - bsize;  assert(offset >= 0);
 		int x = (c % 21) - offset,  y = (c / 21) - offset;		
 		if (x < 1 || y < 1)           return -1;	/* Offboard, discard rest of sequence */

--- a/joseki.c
+++ b/joseki.c
@@ -35,7 +35,7 @@ using_joseki(board_t *b)
 static joseki_dict_t *
 joseki_init(int bsize)
 {
-	joseki_dict_t *jd = calloc(1, sizeof(*jd));
+	joseki_dict_t *jd = calloc2(1, joseki_dict_t);
 	jd->bsize = bsize;
 	return jd;
 }
@@ -43,7 +43,7 @@ joseki_init(int bsize)
 static josekipat_t *
 joseki_pattern_new(board_t *b, coord_t coord, enum stone color, josekipat_t *prev, int flags)
 {
-	josekipat_t *p = calloc(1, sizeof(*p));
+	josekipat_t *p = calloc2(1, josekipat_t);
 	p->coord = coord;
 	p->color = color;
 	p->flags = flags;

--- a/joseki.h
+++ b/joseki.h
@@ -24,6 +24,8 @@ typedef struct josekipat {
 	struct josekipat *next;  /* next hash table entry */
 } josekipat_t;
 
+#define josekipat(coord, color, h, prev, flags)  \
+	{  coord, color, flags, h, prev  }
 
 #define joseki_hash_bits 18  /* 1Mb w/ 32-bit pointers */
 #define joseki_hash_mask ((1 << joseki_hash_bits) - 1)

--- a/joseki.h
+++ b/joseki.h
@@ -7,8 +7,8 @@
 
 #define JOSEKI_PATTERN_DIST	     9
 
-#define joseki_spatial_hash(b, coord, color)         (outer_spatial_hash_from_board_rot_d((b), (coord), (color), 0, JOSEKI_PATTERN_DIST))
-#define joseki_3x3_spatial_hash(b, coord, color) (outer_spatial_hash_from_board_rot_d((b), (coord), (color), 0, 3))
+#define joseki_spatial_hash(b, coord, color)         (outer_spatial_hash_from_board_rot_d((b), (coord), (enum stone)(color), 0, JOSEKI_PATTERN_DIST))
+#define joseki_3x3_spatial_hash(b, coord, color)     (outer_spatial_hash_from_board_rot_d((b), (coord), (enum stone)(color), 0, 3))
 
 #define JOSEKI_FLAGS_IGNORE  (1 << 0)
 #define JOSEKI_FLAGS_3X3     (1 << 1)
@@ -24,8 +24,8 @@ typedef struct josekipat {
 	struct josekipat *next;  /* next hash table entry */
 } josekipat_t;
 
-#define josekipat(coord, color, h, prev, flags)  \
-	{  coord, color, flags, h, prev  }
+#define josekipat(coord, color, h, prev, flags) \
+	{  (short)(coord), (color), (uint8_t)(flags), (h), (prev)  }
 
 #define joseki_hash_bits 18  /* 1Mb w/ 32-bit pointers */
 #define joseki_hash_mask ((1 << joseki_hash_bits) - 1)
@@ -65,7 +65,7 @@ void print_joseki_moves(joseki_dict_t *jd, board_t *b, enum stone color);
 		for (josekipat_t *p = (jd)->hash[id]; p; p = p->next)
 
 #define forall_3x3_joseki_patterns(jd) \
-	for (enum stone _color = S_BLACK; _color <= S_WHITE; _color++) \
+	for (int _color = S_BLACK; _color <= S_WHITE; _color++) \
 		for (josekipat_t *p = jd->pat_3x3[_color]; p; p = p->next)
 
 #define forall_ignored_joseki_patterns(jd) \

--- a/joseki.h
+++ b/joseki.h
@@ -31,31 +31,31 @@ typedef struct josekipat {
 #define joseki_hash_mask ((1 << joseki_hash_bits) - 1)
 
 /* The joseki dictionary for given board size. */
-struct joseki_dict {
+typedef struct {
 	int bsize;
 	josekipat_t *hash[1 << joseki_hash_bits];  /* regular patterns hashtable */
 	josekipat_t *pat_3x3[S_MAX];               /* 3x3 only patterns */
 	josekipat_t *ignored;                      /* ignored patterns (linked list) */
-};
+} joseki_dict_t;
 
-extern struct joseki_dict *joseki_dict;
+extern joseki_dict_t *joseki_dict;
 
 /* Enable / disable joseki component */
 void disable_joseki();
 void require_joseki();
 
-bool using_joseki(struct board *b);
+bool using_joseki(board_t *b);
 void joseki_load(int bsize);
 void joseki_done();
-josekipat_t *joseki_add(struct joseki_dict *jd, struct board *b, coord_t coord, enum stone color, josekipat_t *prev, int flags);
-josekipat_t *joseki_lookup(struct joseki_dict *jd, struct board *b, coord_t coord, enum stone color);
-josekipat_t *joseki_lookup_ignored(struct joseki_dict *jd, struct board *b, coord_t coord, enum stone color);
-josekipat_t *joseki_lookup_3x3(struct joseki_dict *jd, struct board *b, coord_t coord, enum stone color);
-int  joseki_list_moves(struct joseki_dict *jd, struct board *b, enum stone color, coord_t *coords, float *ratings);
-void joseki_rate_moves(struct joseki_dict *jd, struct board *b, enum stone color, float *map);
-void get_joseki_best_moves(struct board *b, coord_t *coords, float *ratings, int matches, coord_t *best_c, float *best_r, int nbest);
-void print_joseki_best_moves(struct board *b, coord_t *best_c, float *best_r, int nbest);
-void print_joseki_moves(struct joseki_dict *jd, struct board *b, enum stone color);
+josekipat_t *joseki_add(joseki_dict_t *jd, board_t *b, coord_t coord, enum stone color, josekipat_t *prev, int flags);
+josekipat_t *joseki_lookup(joseki_dict_t *jd, board_t *b, coord_t coord, enum stone color);
+josekipat_t *joseki_lookup_ignored(joseki_dict_t *jd, board_t *b, coord_t coord, enum stone color);
+josekipat_t *joseki_lookup_3x3(joseki_dict_t *jd, board_t *b, coord_t coord, enum stone color);
+int  joseki_list_moves(joseki_dict_t *jd, board_t *b, enum stone color, coord_t *coords, float *ratings);
+void joseki_rate_moves(joseki_dict_t *jd, board_t *b, enum stone color, float *map);
+void get_joseki_best_moves(board_t *b, coord_t *coords, float *ratings, int matches, coord_t *best_c, float *best_r, int nbest);
+void print_joseki_best_moves(board_t *b, coord_t *best_c, float *best_r, int nbest);
+void print_joseki_moves(joseki_dict_t *jd, board_t *b, enum stone color);
 
 
 

--- a/move.c
+++ b/move.c
@@ -12,63 +12,64 @@
 static char asdf[] = "abcdefghjklmnopqrstuvwxyz";
 
 char *
-coord2bstr(char *buf, coord_t c, struct board *board)
+coord2bstr(char *buf, coord_t c)
 {
-	if (is_pass(c)) {
-		return "pass";
-	} else if (is_resign(c)) {
-		return "resign";
-	} else {
-		/* Some GTP servers are broken and won't grok lowercase coords */
-		snprintf(buf, 4, "%c%u", toupper(asdf[coord_x(c, board) - 1]), coord_y(c, board));
-		return buf;
-	}
+	if (is_pass(c))   return "pass";
+	if (is_resign(c)) return "resign";
+	
+	/* Some GTP servers are broken and won't grok lowercase coords */
+	snprintf(buf, 4, "%c%u", toupper(asdf[coord_x(c) - 1]), coord_y(c));
+	return buf;
 }
 
 /* Return coordinate in dynamically allocated buffer. */
 char *
-coord2str(coord_t c, struct board *board)
+coord2str(coord_t c)
 {
 	char buf[256];
-	return strdup(coord2bstr(buf, c, board));
+	return strdup(coord2bstr(buf, c));
 }
 
 /* Return coordinate in statically allocated buffer, with some backlog for
  * multiple independent invocations. Useful for debugging. */
 char *
-coord2sstr(coord_t c, struct board *board)
+coord2sstr(coord_t c)
 {
 	static char *b;
 	static char bl[10][4];
 	static int bi;
 	b = bl[bi]; bi = (bi + 1) % 10;
-	return coord2bstr(b, c, board);
+	return coord2bstr(b, c);
 }
 
 /* No sanity checking */
 coord_t
-str2coord(char *str, int size)
+str2coord_for(char *str, int size)
 {
-	if (!strcasecmp(str, "pass"))
-		return pass;
-	if (!strcasecmp(str, "resign"))
-		return resign;
+	if (!strcasecmp(str, "pass"))    return pass;
+	if (!strcasecmp(str, "resign"))	 return resign;
 	
 	char xc = tolower(str[0]);
 	return xc - 'a' - (xc > 'i') + 1 + atoi(str + 1) * size;
 }
 
+coord_t
+str2coord(char *str)
+{
+	return str2coord_for(str, the_board_size());
+}
+
 /* Must match rotations in pthashes_init() */
 coord_t
-rotate_coord(struct board *b, coord_t c, int rot)
+rotate_coord(coord_t c, int rot)
 {
 	assert(c != pass);
-	int size = real_board_size(b);
-	int x = coord_x(c, b);
-	int y = coord_y(c, b);
+	int size = the_real_board_size();
+	int x = coord_x(c);
+	int y = coord_y(c);
 	
 	if (rot & 1)  y = size - y + 1;
 	if (rot & 2)  x = size - x + 1;
 	if (rot & 4)  {  int tmp = x;  x = size - y + 1;  y = tmp;  }
-	return coord_xy(b, x, y);
+	return coord_xy(x, y);
 }

--- a/move.h
+++ b/move.h
@@ -42,6 +42,7 @@ struct move {
 	enum stone color;
 };
 
+#define move(coord, color)  { coord, color }
 
 static inline int 
 move_cmp(struct move *m1, struct move *m2)

--- a/move.h
+++ b/move.h
@@ -10,32 +10,33 @@
 
 typedef int coord_t;
 
-#define coord_xy(board, x, y) ((x) + (y) * board_size(board))
-#define coord_x(c, b) (board_statics.coord[c][0])
-#define coord_y(c, b) (board_statics.coord[c][1])
+// XXX board_size() instead of board_statics.size
+#define coord_xy(x, y) ((x) + (y) * the_board_size())
+#define coord_x(c) (board_statics.coord[c][0])
+#define coord_y(c) (board_statics.coord[c][1])
 /* TODO: Smarter way to do this? */
-#define coord_dx(c1, c2, b) (coord_x(c1, b) - coord_x(c2, b))
-#define coord_dy(c1, c2, b) (coord_y(c1, b) - coord_y(c2, b))
+#define coord_dx(c1, c2) (coord_x(c1) - coord_x(c2))
+#define coord_dy(c1, c2) (coord_y(c1) - coord_y(c2))
 
 #define pass   -1
 #define resign -2
 #define is_pass(c)   (c == pass)
 #define is_resign(c) (c == resign)
 
-#define coord_is_adjecent(c1, c2, b) (abs(c1 - c2) == 1 || abs(c1 - c2) == board_size(b))
-#define coord_is_8adjecent(c1, c2, b) (abs(c1 - c2) == 1 || abs(abs(c1 - c2) - board_size(b)) < 2)
+#define coord_is_adjecent(c1, c2) (abs(c1 - c2) == 1 || abs(c1 - c2) == the_board_size())
+#define coord_is_8adjecent(c1, c2) (abs(c1 - c2) == 1 || abs(abs(c1 - c2) - the_board_size()) < 2)
 
-struct board;
-char *coord2bstr(char *buf, coord_t c, struct board *board);
+char *coord2bstr(char *buf, coord_t c);
 /* Return coordinate string in a dynamically allocated buffer. Thread-safe. */
-char *coord2str(coord_t c, struct board *b);
+char *coord2str(coord_t c);
 /* Return coordinate string in a static buffer; multiple buffers are shuffled
  * to enable use for multiple printf() parameters, but it is NOT safe for
  * anything but debugging - in particular, it is NOT thread-safe! */
-char *coord2sstr(coord_t c, struct board *b);
-coord_t str2coord(char *str, int board_size);
+char *coord2sstr(coord_t c);
+coord_t str2coord(char *str);
+coord_t str2coord_for(char *str, int size);
 /* Rotate coordinate according to rot: [0-7] for 8 board symmetries. */
-coord_t rotate_coord(struct board *b, coord_t c, int rot);
+coord_t rotate_coord(coord_t c, int rot);
 
 struct move {
 	coord_t coord;

--- a/move.h
+++ b/move.h
@@ -38,15 +38,15 @@ coord_t str2coord_for(char *str, int size);
 /* Rotate coordinate according to rot: [0-7] for 8 board symmetries. */
 coord_t rotate_coord(coord_t c, int rot);
 
-struct move {
+typedef struct {
 	coord_t coord;
 	enum stone color;
-};
+} move_t;
 
 #define move(coord, color)  { coord, color }
 
 static inline int 
-move_cmp(struct move *m1, struct move *m2)
+move_cmp(move_t *m1, move_t *m2)
 {
 	if (m1->color != m2->color)
 		return m1->color - m2->color;

--- a/mq.h
+++ b/mq.h
@@ -12,34 +12,34 @@
 #include "random.h"
 
 #define MQL 512 /* XXX: On larger board this might not be enough. */
-struct move_queue {
+typedef struct {
 	unsigned int moves;
 	coord_t move[MQL];
 	/* Each move can have an optional tag or set of tags.
 	 * The usage of these is user-dependent. */
 	unsigned char tag[MQL];
-};
+} move_queue_t;
 
-static void mq_init(struct move_queue *q);
+static void mq_init(move_queue_t *q);
 
 /* Pick a random move from the queue. */
-static coord_t mq_pick(struct move_queue *q);
+static coord_t mq_pick(move_queue_t *q);
 
 /* Add a move to the queue. */
-static void mq_add(struct move_queue *q, coord_t c, unsigned char tag);
+static void mq_add(move_queue_t *q, coord_t c, unsigned char tag);
 
 /* Is move in the queue ? */
-static bool mq_has(struct move_queue *q, coord_t c);
+static bool mq_has(move_queue_t *q, coord_t c);
 
 /* Cat two queues together. */
-static void mq_append(struct move_queue *qd, struct move_queue *qs);
+static void mq_append(move_queue_t *qd, move_queue_t *qs);
 
 /* Check if the last move in queue is not a dupe, and remove it
  * in that case. */
-static void mq_nodup(struct move_queue *q);
+static void mq_nodup(move_queue_t *q);
 
 /* Print queue contents on stderr. */
-static void mq_print(struct move_queue *q, char *label);
+static void mq_print(move_queue_t *q, char *label);
 
 
 /* Variations of the above that allow move weighting. */
@@ -48,25 +48,25 @@ static void mq_print(struct move_queue *q, char *label);
  * At least rewrite it to be less hacky and maybe make a move_gamma_queue
  * that encapsulates move_queue. */
 
-static coord_t mq_gamma_pick(struct move_queue *q, fixp_t *gammas);
-static void mq_gamma_add(struct move_queue *q, fixp_t *gammas, coord_t c, double gamma, unsigned char tag);
-static void mq_gamma_print(struct move_queue *q, fixp_t *gammas, char *label);
+static coord_t mq_gamma_pick(move_queue_t *q, fixp_t *gammas);
+static void mq_gamma_add(move_queue_t *q, fixp_t *gammas, coord_t c, double gamma, unsigned char tag);
+static void mq_gamma_print(move_queue_t *q, fixp_t *gammas, char *label);
 
 
 static inline void
-mq_init(struct move_queue *q)
+mq_init(move_queue_t *q)
 {
 	q->moves = 0;
 }
 
 static inline coord_t
-mq_pick(struct move_queue *q)
+mq_pick(move_queue_t *q)
 {
 	return q->moves ? q->move[fast_random(q->moves)] : pass;
 }
 
 static inline void
-mq_add(struct move_queue *q, coord_t c, unsigned char tag)
+mq_add(move_queue_t *q, coord_t c, unsigned char tag)
 {
 	assert(q->moves < MQL);
 	q->tag[q->moves] = tag;
@@ -74,7 +74,7 @@ mq_add(struct move_queue *q, coord_t c, unsigned char tag)
 }
 
 static inline bool
-mq_has(struct move_queue *q, coord_t c)
+mq_has(move_queue_t *q, coord_t c)
 {
 	for (unsigned int i = 0; i < q->moves; i++)
 		if (q->move[i] == c)
@@ -83,7 +83,7 @@ mq_has(struct move_queue *q, coord_t c)
 }
 
 static inline void
-mq_append(struct move_queue *qd, struct move_queue *qs)
+mq_append(move_queue_t *qd, move_queue_t *qs)
 {
 	assert(qd->moves + qs->moves < MQL);
 	memcpy(&qd->tag[qd->moves], qs->tag, qs->moves * sizeof(*qs->tag));
@@ -92,7 +92,7 @@ mq_append(struct move_queue *qd, struct move_queue *qs)
 }
 
 static inline void
-mq_nodup(struct move_queue *q)
+mq_nodup(move_queue_t *q)
 {
 	unsigned int n = q->moves;
 	for (unsigned int i = 0; i < n - 1; i++) {
@@ -105,7 +105,7 @@ mq_nodup(struct move_queue *q)
 }
 
 static inline void
-mq_print(struct move_queue *q, char *label)
+mq_print(move_queue_t *q, char *label)
 {
 	fprintf(stderr, "%s candidate moves: ", label);
 	for (unsigned int i = 0; i < q->moves; i++)
@@ -114,7 +114,7 @@ mq_print(struct move_queue *q, char *label)
 }
 
 static inline coord_t
-mq_gamma_pick(struct move_queue *q, fixp_t *gammas)
+mq_gamma_pick(move_queue_t *q, fixp_t *gammas)
 {
 	if (!q->moves)  return pass;
 
@@ -134,14 +134,14 @@ mq_gamma_pick(struct move_queue *q, fixp_t *gammas)
 }
 
 static inline void
-mq_gamma_add(struct move_queue *q, fixp_t *gammas, coord_t c, double gamma, unsigned char tag)
+mq_gamma_add(move_queue_t *q, fixp_t *gammas, coord_t c, double gamma, unsigned char tag)
 {
 	mq_add(q, c, tag);
 	gammas[q->moves - 1] = double_to_fixp(gamma);
 }
 
 static inline void
-mq_gamma_print(struct move_queue *q, fixp_t *gammas, char *label)
+mq_gamma_print(move_queue_t *q, fixp_t *gammas, char *label)
 {
 	fprintf(stderr, "%s candidate moves: ", label);
 	for (unsigned int i = 0; i < q->moves; i++)

--- a/mq.h
+++ b/mq.h
@@ -39,7 +39,7 @@ static void mq_append(struct move_queue *qd, struct move_queue *qs);
 static void mq_nodup(struct move_queue *q);
 
 /* Print queue contents on stderr. */
-static void mq_print(struct move_queue *q, struct board *b, char *label);
+static void mq_print(struct move_queue *q, char *label);
 
 
 /* Variations of the above that allow move weighting. */
@@ -50,7 +50,7 @@ static void mq_print(struct move_queue *q, struct board *b, char *label);
 
 static coord_t mq_gamma_pick(struct move_queue *q, fixp_t *gammas);
 static void mq_gamma_add(struct move_queue *q, fixp_t *gammas, coord_t c, double gamma, unsigned char tag);
-static void mq_gamma_print(struct move_queue *q, fixp_t *gammas, struct board *b, char *label);
+static void mq_gamma_print(struct move_queue *q, fixp_t *gammas, char *label);
 
 
 static inline void
@@ -105,26 +105,24 @@ mq_nodup(struct move_queue *q)
 }
 
 static inline void
-mq_print(struct move_queue *q, struct board *b, char *label)
+mq_print(struct move_queue *q, char *label)
 {
 	fprintf(stderr, "%s candidate moves: ", label);
-	for (unsigned int i = 0; i < q->moves; i++) {
-		fprintf(stderr, "%s ", coord2sstr(q->move[i], b));
-	}
+	for (unsigned int i = 0; i < q->moves; i++)
+		fprintf(stderr, "%s ", coord2sstr(q->move[i]));
 	fprintf(stderr, "\n");
 }
 
 static inline coord_t
 mq_gamma_pick(struct move_queue *q, fixp_t *gammas)
 {
-	if (!q->moves)
-		return pass;
+	if (!q->moves)  return pass;
+
 	fixp_t total = 0;
-	for (unsigned int i = 0; i < q->moves; i++) {
+	for (unsigned int i = 0; i < q->moves; i++)
 		total += gammas[i];
-	}
-	if (!total)
-		return pass;
+	if (!total)     return pass;
+
 	fixp_t stab = fast_irandom(total);
 	for (unsigned int i = 0; i < q->moves; i++) {
 		if (stab < gammas[i])
@@ -143,12 +141,11 @@ mq_gamma_add(struct move_queue *q, fixp_t *gammas, coord_t c, double gamma, unsi
 }
 
 static inline void
-mq_gamma_print(struct move_queue *q, fixp_t *gammas, struct board *b, char *label)
+mq_gamma_print(struct move_queue *q, fixp_t *gammas, char *label)
 {
 	fprintf(stderr, "%s candidate moves: ", label);
-	for (unsigned int i = 0; i < q->moves; i++) {
-		fprintf(stderr, "%s(%.3f) ", coord2sstr(q->move[i], b), fixp_to_double(gammas[i]));
-	}
+	for (unsigned int i = 0; i < q->moves; i++)
+		fprintf(stderr, "%s(%.3f) ", coord2sstr(q->move[i]), fixp_to_double(gammas[i]));
 	fprintf(stderr, "\n");
 }
 

--- a/mq.h
+++ b/mq.h
@@ -20,6 +20,8 @@ struct move_queue {
 	unsigned char tag[MQL];
 };
 
+static void mq_init(struct move_queue *q);
+
 /* Pick a random move from the queue. */
 static coord_t mq_pick(struct move_queue *q);
 
@@ -50,6 +52,12 @@ static coord_t mq_gamma_pick(struct move_queue *q, fixp_t *gammas);
 static void mq_gamma_add(struct move_queue *q, fixp_t *gammas, coord_t c, double gamma, unsigned char tag);
 static void mq_gamma_print(struct move_queue *q, fixp_t *gammas, struct board *b, char *label);
 
+
+static inline void
+mq_init(struct move_queue *q)
+{
+	q->moves = 0;
+}
 
 static inline coord_t
 mq_pick(struct move_queue *q)

--- a/network.c
+++ b/network.c
@@ -128,6 +128,8 @@ struct port_info {
 	char *port;
 };
 
+#define port_info_none()  { -1, 0 }
+
 /* Wait at most 30s between connection attempts. */
 #define MAX_WAIT 30
 
@@ -201,7 +203,7 @@ void
 open_log_port(char *port)
 {
 	pthread_t thread;
-	static struct port_info log_info = { .socket = -1 };
+	static struct port_info log_info = port_info_none();
 	log_info.port = port;
 	open_log_connection(&log_info);
 
@@ -214,7 +216,7 @@ open_log_port(char *port)
 void
 open_gtp_connection(int *socket, char *port)
 {
-	static struct port_info gtp_info = { .socket = -1 };
+	static struct port_info gtp_info = port_info_none();
 	gtp_info.port = port;
 	int gtp_conn = open_connection(&gtp_info);
 	for (int d = STDIN; d <= STDOUT; d++) {

--- a/network.c
+++ b/network.c
@@ -145,11 +145,11 @@ open_connection(port_info_t *info)
 	int conn;
 	char *p = strchr(info->port, ':');
 	if (p) {
-		for (int try = 1;; ) {
+		for (int tries = 1;; ) {
 			conn = open_client_connection(info->port);
 			if (conn >= 0) break;
-			sleep(try);
-			if (try < MAX_WAIT) try++;
+			sleep(tries);
+			if (tries < MAX_WAIT) tries++;
 		}
 		info->socket = conn;
 	} else {
@@ -178,7 +178,7 @@ open_log_connection(port_info_t *info)
 static void * __attribute__((noreturn))
 log_thread(void *arg)
 {
-	port_info_t *info = arg;
+	port_info_t *info = (port_info_t*)arg;
 	assert(info && info->port);
 	for (;;) {
 		char buf[BSIZE];

--- a/network.c
+++ b/network.c
@@ -123,10 +123,10 @@ open_client_connection(char *port_name)
 /* Allow connexion queue > 1 to avoid race conditions. */
 #define MAX_CONNEXIONS 5
 
-struct port_info {
+typedef struct {
 	int socket;
 	char *port;
-};
+} port_info_t;
 
 #define port_info_none()  { -1, 0 }
 
@@ -140,7 +140,7 @@ struct port_info {
  * Block until the connection succeeds.
  * Return a file descriptor for the new connection. */
 static int
-open_connection(struct port_info *info)
+open_connection(port_info_t *info)
 {
 	int conn;
 	char *p = strchr(info->port, ':');
@@ -162,7 +162,7 @@ open_connection(struct port_info *info)
 
 /* Open the log connection on the given port, redirect stderr to it. */
 static void
-open_log_connection(struct port_info *info)
+open_log_connection(port_info_t *info)
 {
 	int log_conn = open_connection(info);
 	if (dup2(log_conn, STDERR) < 0)
@@ -178,7 +178,7 @@ open_log_connection(struct port_info *info)
 static void * __attribute__((noreturn))
 log_thread(void *arg)
 {
-	struct port_info *info = arg;
+	port_info_t *info = arg;
 	assert(info && info->port);
 	for (;;) {
 		char buf[BSIZE];
@@ -203,7 +203,7 @@ void
 open_log_port(char *port)
 {
 	pthread_t thread;
-	static struct port_info log_info = port_info_none();
+	static port_info_t log_info = port_info_none();
 	log_info.port = port;
 	open_log_connection(&log_info);
 
@@ -216,7 +216,7 @@ open_log_port(char *port)
 void
 open_gtp_connection(int *socket, char *port)
 {
-	static struct port_info gtp_info = port_info_none();
+	static port_info_t gtp_info = port_info_none();
 	gtp_info.port = port;
 	int gtp_conn = open_connection(&gtp_info);
 	for (int d = STDIN; d <= STDOUT; d++) {

--- a/ownermap.c
+++ b/ownermap.c
@@ -288,7 +288,7 @@ board_position_final_full(struct board *b, struct ownermap *ownermap,
 		if (around[S_BLACK] + around[3] == 4 ||
 		    around[S_WHITE] + around[3] == 4) {
 			static char buf[100];
-			sprintf(buf, "non-final position at %s", coord2sstr(dame, b));
+			sprintf(buf, "non-final position at %s", coord2sstr(dame));
 			*msg = buf;
 			return false;
 		}

--- a/ownermap.c
+++ b/ownermap.c
@@ -18,7 +18,7 @@ ownermap_init(ownermap_t *ownermap)
 static void
 printhook(board_t *board, coord_t c, strbuf_t *buf, void *data)
 {
-        ownermap_t *ownermap = data;
+        ownermap_t *ownermap = (ownermap_t*)data;
 
 	if (c == pass) { /* Stuff to display in header */
 		if (!ownermap || !ownermap->playouts) return;
@@ -120,13 +120,13 @@ ownermap_judge_groups(board_t *b, ownermap_t *ownermap, group_judgement_t *judge
 		
 		/* Update group state.
 		 * Comparing enum types, casting (int) avoids compiler warnings */
-		enum gj_state new;
-		if      ((int)pj == (int)color)               new = GS_ALIVE;
-		else if ((int)pj == (int)stone_other(color))  new = GS_DEAD;
-		else                { assert(pj == PJ_SEKI);  new = GS_UNKNOWN;  /* Exotic! */  }
+		enum gj_state newst;
+		if      ((int)pj == (int)color)               newst = GS_ALIVE;
+		else if ((int)pj == (int)stone_other(color))  newst = GS_DEAD;
+		else                { assert(pj == PJ_SEKI);  newst = GS_UNKNOWN;  /* Exotic! */  }
 		
-		if      (judge->gs[g] == GS_NONE)  judge->gs[g] = new;
-		else if (judge->gs[g] != new)      judge->gs[g] = GS_UNKNOWN;  /* Contradiction. :( */
+		if      (judge->gs[g] == GS_NONE)  judge->gs[g] = newst;
+		else if (judge->gs[g] != newst)    judge->gs[g] = GS_UNKNOWN;  /* Contradiction. :( */
 	} foreach_point_end;
 }
 

--- a/ownermap.c
+++ b/ownermap.c
@@ -147,7 +147,7 @@ void
 get_dead_groups(struct board *b, struct ownermap *ownermap, struct move_queue *dead, struct move_queue *unclear)
 {
 	enum gj_state gs_array[board_size2(b)];
-	struct group_judgement gj = { .thres = 0.67, .gs = gs_array };
+	struct group_judgement gj = { 0.67, gs_array };
 	ownermap_judge_groups(b, ownermap, &gj);
 	if (dead)     {  dead->moves = 0;     groups_of_status(b, &gj, GS_DEAD, dead);  }
 	if (unclear)  {  unclear->moves = 0;  groups_of_status(b, &gj, GS_UNKNOWN, unclear);  }

--- a/ownermap.c
+++ b/ownermap.c
@@ -10,15 +10,15 @@
 #include "ownermap.h"
 
 void
-ownermap_init(struct ownermap *ownermap)
+ownermap_init(ownermap_t *ownermap)
 {
 	memset(ownermap, 0, sizeof(*ownermap));
 }
 
 static void
-printhook(struct board *board, coord_t c, strbuf_t *buf, void *data)
+printhook(board_t *board, coord_t c, strbuf_t *buf, void *data)
 {
-        struct ownermap *ownermap = data;
+        ownermap_t *ownermap = data;
 
 	if (c == pass) { /* Stuff to display in header */
 		if (!ownermap || !ownermap->playouts) return;
@@ -37,13 +37,13 @@ printhook(struct board *board, coord_t c, strbuf_t *buf, void *data)
 }
 
 void
-board_print_ownermap(struct board *b, FILE *f, struct ownermap *ownermap)
+board_print_ownermap(board_t *b, FILE *f, ownermap_t *ownermap)
 {
         board_print_custom(b, stderr, printhook, ownermap);
 }
 
 void
-ownermap_fill(struct ownermap *ownermap, struct board *b)
+ownermap_fill(ownermap_t *ownermap, board_t *b)
 {
 	ownermap->playouts++;
 	foreach_point(b) {
@@ -55,7 +55,7 @@ ownermap_fill(struct ownermap *ownermap, struct board *b)
 }
 
 void
-ownermap_merge(int bsize2, struct ownermap *dst, struct ownermap *src)
+ownermap_merge(int bsize2, ownermap_t *dst, ownermap_t *src)
 {
 	dst->playouts += src->playouts;
 	for (int i = 0; i < bsize2; i++)
@@ -64,7 +64,7 @@ ownermap_merge(int bsize2, struct ownermap *dst, struct ownermap *src)
 }
 
 float
-ownermap_estimate_point(struct ownermap *ownermap, coord_t c)
+ownermap_estimate_point(ownermap_t *ownermap, coord_t c)
 {
 	assert(ownermap->map);
 	assert(!is_pass(c));
@@ -75,7 +75,7 @@ ownermap_estimate_point(struct ownermap *ownermap, coord_t c)
 }
 
 enum point_judgement
-ownermap_judge_point(struct ownermap *ownermap, coord_t c, floating_t thres)
+ownermap_judge_point(ownermap_t *ownermap, coord_t c, floating_t thres)
 {
 	assert(ownermap->map);
 	assert(!is_pass(c));
@@ -90,7 +90,7 @@ ownermap_judge_point(struct ownermap *ownermap, coord_t c, floating_t thres)
 }
 
 enum stone
-ownermap_color(struct ownermap *ownermap, coord_t c, floating_t thres)
+ownermap_color(ownermap_t *ownermap, coord_t c, floating_t thres)
 {
 	enum stone colors[4] = {S_NONE, S_BLACK, S_WHITE, S_NONE };
 	enum point_judgement pj = ownermap_judge_point(ownermap, c, thres);
@@ -98,7 +98,7 @@ ownermap_color(struct ownermap *ownermap, coord_t c, floating_t thres)
 }
 
 void
-ownermap_judge_groups(struct board *b, struct ownermap *ownermap, struct group_judgement *judge)
+ownermap_judge_groups(board_t *b, ownermap_t *ownermap, group_judgement_t *judge)
 {
 	assert(ownermap->map);
 	assert(judge->gs);
@@ -131,7 +131,7 @@ ownermap_judge_groups(struct board *b, struct ownermap *ownermap, struct group_j
 }
 
 void
-groups_of_status(struct board *b, struct group_judgement *judge, enum gj_state s, struct move_queue *mq)
+groups_of_status(board_t *b, group_judgement_t *judge, enum gj_state s, move_queue_t *mq)
 {
 	foreach_point(b) { /* foreach_group, effectively */
 		group_t g = group_at(b, c);
@@ -144,17 +144,17 @@ groups_of_status(struct board *b, struct group_judgement *judge, enum gj_state s
 }
 
 void
-get_dead_groups(struct board *b, struct ownermap *ownermap, struct move_queue *dead, struct move_queue *unclear)
+get_dead_groups(board_t *b, ownermap_t *ownermap, move_queue_t *dead, move_queue_t *unclear)
 {
 	enum gj_state gs_array[board_size2(b)];
-	struct group_judgement gj = { 0.67, gs_array };
+	group_judgement_t gj = { 0.67, gs_array };
 	ownermap_judge_groups(b, ownermap, &gj);
 	if (dead)     {  dead->moves = 0;     groups_of_status(b, &gj, GS_DEAD, dead);  }
 	if (unclear)  {  unclear->moves = 0;  groups_of_status(b, &gj, GS_UNKNOWN, unclear);  }
 }
 
 void
-ownermap_scores(struct board *b, struct ownermap *ownermap, int *scores)
+ownermap_scores(board_t *b, ownermap_t *ownermap, int *scores)
 {
 	foreach_point(b) {
 		if (board_at(b, c) == S_OFFBOARD)  continue;
@@ -164,7 +164,7 @@ ownermap_scores(struct board *b, struct ownermap *ownermap, int *scores)
 }
 
 int
-ownermap_dames(struct board *b, struct ownermap *ownermap)
+ownermap_dames(board_t *b, ownermap_t *ownermap)
 {
 	int scores[S_MAX] = { 0, };
 	ownermap_scores(b, ownermap, scores);
@@ -172,7 +172,7 @@ ownermap_dames(struct board *b, struct ownermap *ownermap)
 }
 
 enum point_judgement
-ownermap_score_est_coord(struct board *b, struct ownermap *ownermap, coord_t c)
+ownermap_score_est_coord(board_t *b, ownermap_t *ownermap, coord_t c)
 {
 	enum point_judgement j = ownermap_judge_point(ownermap, c, 0.67);
 	enum stone s = board_at(b, c);
@@ -184,7 +184,7 @@ ownermap_score_est_coord(struct board *b, struct ownermap *ownermap, coord_t c)
 }
 
 float
-ownermap_score_est(struct board *b, struct ownermap *ownermap)
+ownermap_score_est(board_t *b, ownermap_t *ownermap)
 {
 	int scores[S_MAX] = {0, };  /* Number of points owned by each color */
 	
@@ -198,7 +198,7 @@ ownermap_score_est(struct board *b, struct ownermap *ownermap)
 }
 
 float
-ownermap_score_est_color(struct board *b, struct ownermap *ownermap, enum stone color)
+ownermap_score_est_color(board_t *b, ownermap_t *ownermap, enum stone color)
 {
 	floating_t score = ownermap_score_est(b, ownermap);
 	return (color == S_BLACK ? -score : score);
@@ -206,7 +206,7 @@ ownermap_score_est_color(struct board *b, struct ownermap *ownermap, enum stone 
 
 /* Returns static buffer */
 char *
-ownermap_score_est_str(struct board *b, struct ownermap *ownermap)
+ownermap_score_est_str(board_t *b, ownermap_t *ownermap)
 {
 	static char buf[32];
 	float s = ownermap_score_est(b, ownermap);
@@ -215,7 +215,7 @@ ownermap_score_est_str(struct board *b, struct ownermap *ownermap)
 }
 
 static bool
-border_stone(struct board *b, coord_t c, int *final_ownermap)
+border_stone(board_t *b, coord_t c, int *final_ownermap)
 {
 	enum stone color = board_at(b, c);
 	foreach_neighbor(b, c, {
@@ -227,13 +227,13 @@ border_stone(struct board *b, coord_t c, int *final_ownermap)
 }
 
 bool
-board_position_final(struct board *b, struct ownermap *ownermap, char **msg)
+board_position_final(board_t *b, ownermap_t *ownermap, char **msg)
 {
 	*msg = "too early to pass";
 	if (b->moves < board_earliest_pass(b))
 		return false;
 	
-	struct move_queue dead, unclear;
+	move_queue_t dead, unclear;
 	get_dead_groups(b, ownermap, &dead, &unclear);
 	
 	floating_t score_est = ownermap_score_est(b, ownermap);
@@ -247,8 +247,8 @@ board_position_final(struct board *b, struct ownermap *ownermap, char **msg)
 }
 
 bool
-board_position_final_full(struct board *b, struct ownermap *ownermap,
-			  struct move_queue *dead, struct move_queue *unclear, float score_est,
+board_position_final_full(board_t *b, ownermap_t *ownermap,
+			  move_queue_t *dead, move_queue_t *unclear, float score_est,
 			  int *final_ownermap, int final_dames, float final_score, char **msg)
 {
 	*msg = "too early to pass";

--- a/pachi.c
+++ b/pachi.c
@@ -57,20 +57,24 @@ network_init()
 #endif
 }
 
-static engine_init_t engine_inits[E_MAX] = {
-	[ E_RANDOM ]      = engine_random_init,
-	[ E_REPLAY ]      = engine_replay_init,
-	[ E_PATTERNSCAN ] = engine_patternscan_init,
-	[ E_PATTERNPLAY ] = engine_patternplay_init,
-	[ E_JOSEKISCAN ]  = engine_josekiscan_init,
-	[ E_JOSEKIPLAY ]  = engine_josekiplay_init,
-	[ E_MONTECARLO ]  = engine_montecarlo_init,
-	[ E_UCT ]         = engine_uct_init,
+static engine_init_t engine_inits[E_MAX] = { NULL };
+
+static void
+init()
+{
+	engine_inits[ E_RANDOM ]      = engine_random_init;
+	engine_inits[ E_REPLAY ]      = engine_replay_init;
+	engine_inits[ E_PATTERNSCAN ] = engine_patternscan_init;
+	engine_inits[ E_PATTERNPLAY ] = engine_patternplay_init;
+	engine_inits[ E_JOSEKISCAN ]  = engine_josekiscan_init;
+	engine_inits[ E_JOSEKIPLAY ]  = engine_josekiplay_init;
+	engine_inits[ E_MONTECARLO ]  = engine_montecarlo_init;
+	engine_inits[ E_UCT ]         = engine_uct_init;
 #ifdef DISTRIBUTED
-	[ E_DISTRIBUTED ] = engine_distributed_init,
+	engine_inits[ E_DISTRIBUTED ] = engine_distributed_init;
 #endif
 #ifdef DCNN
-	[ E_DCNN ]        = engine_dcnn_init,
+	engine_inits[ E_DCNN ]        = engine_dcnn_init;
 #endif
 };
 
@@ -224,9 +228,11 @@ static struct option longopts[] = {
 
 int main(int argc, char *argv[])
 {
+	init();
+	
 	pachi_exe = argv[0];
 	enum engine_id engine_id = E_UCT;
-	struct time_info ti_default = { .period = TT_NULL };
+	struct time_info ti_default = ti_none;
 	int  seed = time(NULL) ^ getpid();
 	char *testfile = NULL;
 	char *log_port = NULL;

--- a/pachi.c
+++ b/pachi.c
@@ -37,7 +37,7 @@
 #include "patternprob.h"
 #include "joseki.h"
 
-static void main_loop(gtp_t *gtp, struct board *b, struct engine *e, char *e_arg, struct time_info *ti, struct time_info *ti_default);
+static void main_loop(gtp_t *gtp, board_t *b, engine_t *e, char *e_arg, time_info_t *ti, time_info_t *ti_default);
 
 char *pachi_exe = NULL;
 int   debug_level = 3;
@@ -79,7 +79,7 @@ init()
 };
 
 void
-pachi_engine_init(struct engine *e, int id, char *e_arg, struct board *b)
+pachi_engine_init(engine_t *e, int id, char *e_arg, board_t *b)
 {
 	assert(id >= 0 && id < E_MAX);
 	
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
 	
 	pachi_exe = argv[0];
 	enum engine_id engine_id = E_UCT;
-	struct time_info ti_default = ti_none;
+	time_info_t ti_default = ti_none;
 	int  seed = time(NULL) ^ getpid();
 	char *testfile = NULL;
 	char *log_port = NULL;
@@ -395,13 +395,13 @@ int main(int argc, char *argv[])
 	if (DEBUGL(2))	         fprintf(stderr, "Random seed: %d\n", seed);
 	fifo_init();
 
-	struct board *b = board_new(19 + 2, fbookfile);
+	board_t *b = board_new(19 + 2, fbookfile);
 	if (forced_ruleset) {
 		if (!board_set_rules(b, forced_ruleset))  die("Unknown ruleset: %s\n", forced_ruleset);
 		if (DEBUGL(1))  fprintf(stderr, "Rules: %s\n", forced_ruleset);
 	}
 
-	struct time_info ti[S_MAX];
+	time_info_t ti[S_MAX];
 	ti[S_BLACK] = ti_default;
 	ti[S_WHITE] = ti_default;
 
@@ -409,7 +409,7 @@ int main(int argc, char *argv[])
 
 	char *e_arg = NULL;
 	if (optind < argc)	e_arg = argv[optind];
-	struct engine e;  engine_init(&e, engine_id, e_arg, b);
+	engine_t e;  engine_init(&e, engine_id, e_arg, b);
 	network_init();
 
 	while (1) {
@@ -430,7 +430,7 @@ int main(int argc, char *argv[])
 }
 
 static void
-main_loop(gtp_t *gtp, struct board *b, struct engine *e, char *e_arg, struct time_info *ti, struct time_info *ti_default)
+main_loop(gtp_t *gtp, board_t *b, engine_t *e, char *e_arg, time_info_t *ti, time_info_t *ti_default)
 {
 	char buf[4096];
 	while (fgets(buf, 4096, stdin)) {

--- a/pachi.h
+++ b/pachi.h
@@ -3,16 +3,6 @@
 
 #include <stdbool.h>
 
-/* Pachi binary */
-extern char *pachi_exe;
-
-/* Ruleset from cmdline, if present. */
-extern char *forced_ruleset;
-
-/* Don't pass first ? Needed on kgs or cleanup phase can be abused. */
-extern bool nopassfirst;
-
-
 struct board;
 struct engine;
 
@@ -22,5 +12,14 @@ void pachi_done();
 /* Init engines */
 void pachi_engine_init(struct engine *e, int id, char *e_arg, struct board *b);
 
+
+/* Pachi binary */
+extern char *pachi_exe;
+
+/* Ruleset from cmdline, if present. */
+extern char *forced_ruleset;
+
+/* Don't pass first ? Needed on kgs or cleanup phase can be abused. */
+extern bool nopassfirst;
 
 #endif

--- a/pattern.c
+++ b/pattern.c
@@ -66,88 +66,97 @@ pattern_has_feature(struct pattern *p, int feature_id, int payload)
 	return false;
 }
 
-static struct pattern_config DEFAULT_PATTERN_CONFIG = {
-	.bdist_max = 4,
 
-	.spat_min = 3, .spat_max = 10,
-	.spat_largest = false,
-};
-
-struct feature_info pattern_features[] = {
-	[FEAT_CAPTURE] =         { .name = "capture",         .payloads = PF_CAPTURE_N,    .spatial = 0 },
-	[FEAT_AESCAPE] =         { .name = "atariescape",     .payloads = PF_AESCAPE_N,    .spatial = 0 },
-	[FEAT_ATARI] =           { .name = "atari",           .payloads = PF_ATARI_N,      .spatial = 0 },
-	[FEAT_CUT] =             { .name = "cut",             .payloads = PF_CUT_N,        .spatial = 0 },
-	[FEAT_NET] =             { .name = "net",             .payloads = PF_NET_N,        .spatial = 0 },
-	[FEAT_DEFENCE] =         { .name = "defence",         .payloads = PF_DEFENCE_N,    .spatial = 0 },
-	[FEAT_DOUBLE_SNAPBACK] = { .name = "double_snapback", .payloads = 1,               .spatial = 0 },
-	[FEAT_SELFATARI] =       { .name = "selfatari",       .payloads = PF_SELFATARI_N,  .spatial = 0 },
-	[FEAT_BORDER] =          { .name = "border",          .payloads = -1,              .spatial = 0 },
-	[FEAT_DISTANCE] =        { .name = "dist",            .payloads = 19,              .spatial = 0 },
-	[FEAT_DISTANCE2] =       { .name = "dist2",           .payloads = 19,              .spatial = 0 },
-	[FEAT_MCOWNER] =         { .name = "mcowner",         .payloads = 9,               .spatial = 0 },
-	[FEAT_NO_SPATIAL] =      { .name = "nospat",          .payloads = 1,               .spatial = 0 },
-	[FEAT_SPATIAL3] =        { .name = "s3",              .payloads = -1,              .spatial = 3 },
-	[FEAT_SPATIAL4] =        { .name = "s4",              .payloads = -1,              .spatial = 4 },
-	[FEAT_SPATIAL5] =        { .name = "s5",              .payloads = -1,              .spatial = 5 },
-	[FEAT_SPATIAL6] =        { .name = "s6",              .payloads = -1,              .spatial = 6 },
-	[FEAT_SPATIAL7] =        { .name = "s7",              .payloads = -1,              .spatial = 7 },
-	[FEAT_SPATIAL8] =        { .name = "s8",              .payloads = -1,              .spatial = 8 },
-	[FEAT_SPATIAL9] =        { .name = "s9",              .payloads = -1,              .spatial = 9 },
-	[FEAT_SPATIAL10] =       { .name = "s10",             .payloads = -1,              .spatial = 10 },
-};
+feature_info_t pattern_features[FEAT_MAX];
 
 /* For convenience */
-static struct feature_info *features = pattern_features;
+static feature_info_t *features = pattern_features;
+
+static void
+features_init()
+{
+	memset(pattern_features, 0, sizeof(pattern_features));
+	
+	features[FEAT_CAPTURE] =         feature_info("capture",         PF_CAPTURE_N,    0);
+	features[FEAT_AESCAPE] =         feature_info("atariescape",     PF_AESCAPE_N,    0);
+	features[FEAT_ATARI] =           feature_info("atari",           PF_ATARI_N,      0);
+	features[FEAT_CUT] =             feature_info("cut",             PF_CUT_N,        0);
+	features[FEAT_NET] =             feature_info("net",             PF_NET_N,        0);
+	features[FEAT_DEFENCE] =         feature_info("defence",         PF_DEFENCE_N,    0);
+	features[FEAT_DOUBLE_SNAPBACK] = feature_info("double_snapback", 1,               0);
+	features[FEAT_SELFATARI] =       feature_info("selfatari",       PF_SELFATARI_N,  0);
+	features[FEAT_BORDER] =          feature_info("border",          -1,              0);
+	features[FEAT_DISTANCE] =        feature_info("dist",            19,              0);
+	features[FEAT_DISTANCE2] =       feature_info("dist2",           19,              0);
+	features[FEAT_MCOWNER] =         feature_info("mcowner",         9,               0);
+	features[FEAT_NO_SPATIAL] =      feature_info("nospat",          1,               0);
+	features[FEAT_SPATIAL3] =        feature_info("s3",              -1,              3);
+	features[FEAT_SPATIAL4] =        feature_info("s4",              -1,              4);
+	features[FEAT_SPATIAL5] =        feature_info("s5",              -1,              5);
+	features[FEAT_SPATIAL6] =        feature_info("s6",              -1,              6);
+	features[FEAT_SPATIAL7] =        feature_info("s7",              -1,              7);
+	features[FEAT_SPATIAL8] =        feature_info("s8",              -1,              8);
+	features[FEAT_SPATIAL9] =        feature_info("s9",              -1,              9);
+	features[FEAT_SPATIAL10] =       feature_info("s10",             -1,              10);
+}
 
 
 /* Feature values may be named, otherwise payload is printed as number.
  * Names may not begin with a number. */
 #define PAYLOAD_NAMES_MAX 16
-static char* payloads_names[FEAT_MAX][PAYLOAD_NAMES_MAX] = {
-	[FEAT_CAPTURE] =   { [ PF_CAPTURE_ATARIDEF] = "ataridef",
-			     [ PF_CAPTURE_LAST] = "last",
-			     [ PF_CAPTURE_PEEP] = "peep",
-			     [ PF_CAPTURE_LADDER] = "ladder",
-			     [ PF_CAPTURE_NOLADDER] = "noladder", 
-			     [ PF_CAPTURE_TAKE_KO] = "take_ko",
-			     [ PF_CAPTURE_END_KO] = "end_ko",
-	},
-	[FEAT_AESCAPE] =   { [ PF_AESCAPE_NEW_NOLADDER] = "new_noladder",
-			     [ PF_AESCAPE_NEW_LADDER] = "new_ladder",
-			     [ PF_AESCAPE_NOLADDER] = "noladder",
-			     [ PF_AESCAPE_LADDER] = "ladder",
-			     [ PF_AESCAPE_FILL_KO] = "fill_ko",
-	},
-	[FEAT_SELFATARI] = { [ PF_SELFATARI_BAD] = "bad",
-			     [ PF_SELFATARI_GOOD] = "good",
-			     [ PF_SELFATARI_2LIBS] = "twolibs",
-	},
-	[FEAT_ATARI] =     { [ PF_ATARI_DOUBLE] = "double",
-			     [ PF_ATARI_AND_CAP] = "and_cap",
-			     [ PF_ATARI_SNAPBACK] = "snapback",
-			     [ PF_ATARI_LADDER_BIG] = "ladder_big",
-			     [ PF_ATARI_LADDER_LAST] = "ladder_last",
-			     [ PF_ATARI_LADDER_SAFE] = "ladder_safe", 
-			     [ PF_ATARI_LADDER_CUT] = "ladder_cut",
-			     [ PF_ATARI_LADDER] = "ladder", 
-			     [ PF_ATARI_KO] = "ko",
-			     [ PF_ATARI_SOME] = "some",
-	},
-	[FEAT_CUT] =       { [ PF_CUT_DANGEROUS] = "dangerous" },
-	[FEAT_NET] =       { [ PF_NET_LAST] = "last",
-			     [ PF_NET_CUT] = "cut",
-			     [ PF_NET_SOME] = "some",
-			     [ PF_NET_DEAD] = "dead",
-	},
-	[FEAT_DEFENCE] =   { [ PF_DEFENCE_LINE2] = "line2",
-			     [ PF_DEFENCE_SILLY] = "silly",
-	},
-};
+static char* payloads_names[FEAT_MAX][PAYLOAD_NAMES_MAX];
+
+static void
+payloads_names_init()
+{
+	memset(payloads_names, 0, sizeof(payloads_names));
+
+	payloads_names[FEAT_CAPTURE][PF_CAPTURE_ATARIDEF] = "ataridef";
+	payloads_names[FEAT_CAPTURE][PF_CAPTURE_LAST] = "last";
+	payloads_names[FEAT_CAPTURE][PF_CAPTURE_PEEP] = "peep";
+	payloads_names[FEAT_CAPTURE][PF_CAPTURE_LADDER] = "ladder";
+	payloads_names[FEAT_CAPTURE][PF_CAPTURE_NOLADDER] = "noladder";
+	payloads_names[FEAT_CAPTURE][PF_CAPTURE_TAKE_KO] = "take_ko";
+	payloads_names[FEAT_CAPTURE][PF_CAPTURE_END_KO] = "end_ko";
+
+	payloads_names[FEAT_AESCAPE][PF_AESCAPE_NEW_NOLADDER] = "new_noladder";
+	payloads_names[FEAT_AESCAPE][PF_AESCAPE_NEW_LADDER] = "new_ladder";
+	payloads_names[FEAT_AESCAPE][PF_AESCAPE_NOLADDER] = "noladder";
+	payloads_names[FEAT_AESCAPE][PF_AESCAPE_LADDER] = "ladder";
+	payloads_names[FEAT_AESCAPE][PF_AESCAPE_FILL_KO] = "fill_ko";
+
+	payloads_names[FEAT_SELFATARI][PF_SELFATARI_BAD] = "bad";
+	payloads_names[FEAT_SELFATARI][PF_SELFATARI_GOOD] = "good";
+	payloads_names[FEAT_SELFATARI][PF_SELFATARI_2LIBS] = "twolibs";
+
+	payloads_names[FEAT_ATARI][PF_ATARI_DOUBLE] = "double";
+	payloads_names[FEAT_ATARI][PF_ATARI_AND_CAP] = "and_cap";
+	payloads_names[FEAT_ATARI][PF_ATARI_SNAPBACK] = "snapback";
+	payloads_names[FEAT_ATARI][PF_ATARI_LADDER_BIG] = "ladder_big";
+	payloads_names[FEAT_ATARI][PF_ATARI_LADDER_LAST] = "ladder_last";
+	payloads_names[FEAT_ATARI][PF_ATARI_LADDER_SAFE] = "ladder_safe";
+	payloads_names[FEAT_ATARI][PF_ATARI_LADDER_CUT] = "ladder_cut";
+	payloads_names[FEAT_ATARI][PF_ATARI_LADDER] = "ladder";
+	payloads_names[FEAT_ATARI][PF_ATARI_KO] = "ko";
+	payloads_names[FEAT_ATARI][PF_ATARI_SOME] = "some";
+
+	payloads_names[FEAT_CUT][PF_CUT_DANGEROUS] = "dangerous";
+	
+	payloads_names[FEAT_NET][PF_NET_LAST] = "last";
+	payloads_names[FEAT_NET][PF_NET_CUT] = "cut";
+	payloads_names[FEAT_NET][PF_NET_SOME] = "some";
+	payloads_names[FEAT_NET][PF_NET_DEAD] = "dead";
+	
+	payloads_names[FEAT_DEFENCE][PF_DEFENCE_LINE2] = "line2";
+	payloads_names[FEAT_DEFENCE][PF_DEFENCE_SILLY] = "silly";
+}
 
 static void
 init_feature_info(struct pattern_config *pc)
 {
+	features_init();
+	payloads_names_init();
+	
 	/* Sanity check, we use FEAT_MAX to iterate over features. */
 	assert(sizeof(pattern_features) / sizeof(*pattern_features) == FEAT_MAX);
 
@@ -182,6 +191,12 @@ void
 patterns_init(struct pattern_config *pc, char *arg, bool create, bool load_prob)
 {
 	char *pdict_file = NULL;
+	struct pattern_config DEFAULT_PATTERN_CONFIG = { 0 };
+	DEFAULT_PATTERN_CONFIG.bdist_max = 4;
+	DEFAULT_PATTERN_CONFIG.spat_min = 3;
+	DEFAULT_PATTERN_CONFIG.spat_max = 10;
+	DEFAULT_PATTERN_CONFIG.spat_largest = false;
+	
 	*pc = DEFAULT_PATTERN_CONFIG;
 
 	if (!patterns_enabled)	return;
@@ -938,7 +953,7 @@ static void
 mcowner_playouts_(struct board *b, enum stone color, struct ownermap *ownermap, int playouts)
 {
 	static struct playout_policy *policy = NULL;
-	struct playout_setup setup = { .gamelen = MAX_GAMELEN };
+	struct playout_setup setup = playout_setup(MAX_GAMELEN, 0);
 	
 	if (!policy)  policy = playout_moggy_init(NULL, b);
 	ownermap_init(ownermap);
@@ -984,7 +999,7 @@ dump_feature_stats(struct pattern_config *pc)
 	
 	fprintf(file, "feature hits:\n");
 	for (int i = 0; i < FEAT_MAX; i++) {
-		struct feature f = {  .id = i  };
+		struct feature f = {  i  };
 		if (i >= FEAT_SPATIAL) continue; // For now ...
 		
 		/* Regular feature */

--- a/pattern.c
+++ b/pattern.c
@@ -179,9 +179,9 @@ init_feature_info(pattern_config_t *pc)
 }
 
 int
-feature_payloads(enum feature_id id)
+feature_payloads(int id)
 {
-	assert(id < FEAT_MAX);
+	assert(id >= 0 && id < FEAT_MAX);
 	assert(features[id].payloads > 0);
 	return features[id].payloads;
 }
@@ -908,7 +908,7 @@ pattern_match_spatial_outer(pattern_config_t *pc,
 		
 		/* Record spatial feature, one per distance. */
 		unsigned int sid = spatial_id(s, spat_dict);
-		f->id = FEAT_SPATIAL3 + d - 3;
+		f->id = (enum feature_id)(FEAT_SPATIAL3 + d - 3);
 		f->payload = sid;
 		if (!pc->spat_largest)
 			(f++, p->n++);
@@ -1142,7 +1142,7 @@ str2feature(char *str, feature_t *f)
 	unsigned int flen = strcspn(str, ":");
 	for (unsigned int i = 0; i < FEAT_MAX; i++)
 		if (strlen(features[i].name) == flen && !strncmp(features[i].name, str, flen)) {
-			f->id = i;
+			f->id = (enum feature_id)i;
 			goto found;
 		}
 	die("invalid featurespec: '%.*s'\n", flen, str);
@@ -1196,21 +1196,21 @@ check_pattern_gammas(pattern_config_t *pc)
 
 	if (DEBUGL(1)) {  fprintf(stderr, "Checking gammas ...");  fflush(stderr);  }
 	for (int i = 0; i < FEAT_MAX; i++) {
-		f.id = i;
+		f.id = (enum feature_id)i;
 
 		if (i >= FEAT_SPATIAL) { 
 			for (unsigned int j = 0; j < spat_dict->nspatials; j++) {
                                 spatial_t *s = &spat_dict->spatials[j];
 				if (!s->dist)  continue;
 				assert(s->dist >= 3);
-				f.id = FEAT_SPATIAL + s->dist - 3;
+				f.id = (enum feature_id)(FEAT_SPATIAL + s->dist - 3);
 				f.payload = j;
 				if (!feature_has_gamma(pc, &f))  goto error;
 			}
 			goto done;  /* Check all spatial features at once ... */
 		}
 
-		for (int j = 0; j < feature_payloads(i); j++) {
+		for (int j = 0; j < feature_payloads((enum feature_id)i); j++) {
 			f.payload = j;
 			if (!feature_has_gamma(pc, &f))  goto error;
 		}

--- a/pattern.h
+++ b/pattern.h
@@ -171,7 +171,7 @@ char *feature2str(char *str, feature_t *f);
 /* Feature to static string */
 char *feature2sstr(feature_t *f);
 /* Get number of possible payload values associated with the feature. */
-int feature_payloads(enum feature_id f);
+int feature_payloads(int id);
 
 /* Append pattern as feature spec string. */
 char *pattern2str(char *str, pattern_t *p);

--- a/pattern.h
+++ b/pattern.h
@@ -29,11 +29,11 @@
  * Output written to mm-feature-hits.dat periodically. */
 //#define PATTERN_FEATURE_STATS 1
 
-struct feature_info {
+typedef struct feature_info {
 	char *name;
 	int payloads;
 	int spatial;   /* For spatial features, spatial feature dist */
-};
+} feature_info_t;
 
 extern struct feature_info pattern_features[];
 
@@ -139,6 +139,8 @@ struct feature {
 	unsigned int payload:24;
 };
 
+#define feature(id, payload)  {  (enum feature_id)(id), (payload)  }
+
 /* Pattern (matched) is set of features. */
 struct pattern {       
 	int n;
@@ -157,6 +159,7 @@ struct pattern_config {
 	 * to the largest matched spatial pattern. */
 	bool spat_largest;
 };
+
 
 bool using_patterns();
 void disable_patterns();
@@ -195,6 +198,13 @@ void pattern_stats_new_position();
 #endif
 
 #define feature_eq(f1, f2) ((f1)->id == (f2)->id && (f1)->payload == (f2)->payload)
+
+static inline feature_info_t
+feature_info(char *name, int payloads, int spatial)
+{
+       feature_info_t f = { name, payloads, spatial };
+       return f;
+}
 
 static inline bool
 pattern_eq(struct pattern *p1, struct pattern *p2)

--- a/pattern.h
+++ b/pattern.h
@@ -29,13 +29,13 @@
  * Output written to mm-feature-hits.dat periodically. */
 //#define PATTERN_FEATURE_STATS 1
 
-typedef struct feature_info {
+typedef struct {
 	char *name;
 	int payloads;
 	int spatial;   /* For spatial features, spatial feature dist */
 } feature_info_t;
 
-extern struct feature_info pattern_features[];
+extern feature_info_t pattern_features[];
 
 /* If you add a payload for a feature, don't forget to update the values in feature_info. 
  * Legend:                          *      Ordinary feature
@@ -134,20 +134,20 @@ enum feature_id {
 /* Having separate spatial features is nice except for this ... */
 #define FEAT_SPATIAL FEAT_SPATIAL3
 
-struct feature {
+typedef struct {
 	enum feature_id id:8;
 	unsigned int payload:24;
-};
+} feature_t;
 
 #define feature(id, payload)  {  (enum feature_id)(id), (payload)  }
 
 /* Pattern (matched) is set of features. */
-struct pattern {       
+typedef struct {
 	int n;
-	struct feature f[FEAT_MAX];
-};
+	feature_t f[FEAT_MAX];
+} pattern_t;
 
-struct pattern_config {
+typedef struct {
 	/* FEAT_BORDER: Generate features only up to this board distance. */
 	unsigned int bdist_max;
 
@@ -158,40 +158,40 @@ struct pattern_config {
 	/* Produce only a single spatial feature per pattern, corresponding
 	 * to the largest matched spatial pattern. */
 	bool spat_largest;
-};
+} pattern_config_t;
 
 
 bool using_patterns();
 void disable_patterns();
 void require_patterns();
-void patterns_init(struct pattern_config *pc, char *arg, bool create, bool load_prob);
+void patterns_init(pattern_config_t *pc, char *arg, bool create, bool load_prob);
 
 /* Append feature to string. */
-char *feature2str(char *str, struct feature *f);
+char *feature2str(char *str, feature_t *f);
 /* Feature to static string */
-char *feature2sstr(struct feature *f);
+char *feature2sstr(feature_t *f);
 /* Get number of possible payload values associated with the feature. */
 int feature_payloads(enum feature_id f);
 
 /* Append pattern as feature spec string. */
-char *pattern2str(char *str, struct pattern *p);
+char *pattern2str(char *str, pattern_t *p);
 /* Returns static string. */
-char *pattern2sstr(struct pattern *p);
+char *pattern2sstr(pattern_t *p);
 /* Convert string to pattern, return pointer after the patternspec. */
-char *str2pattern(char *str, struct pattern *p);
+char *str2pattern(char *str, pattern_t *p);
 /* Dump pattern as numbers for mm tools */
 
 /* Compare two patterns for equality. Assumes fixed feature order. */
-static bool pattern_eq(struct pattern *p1, struct pattern *p2);
+static bool pattern_eq(pattern_t *p1, pattern_t *p2);
 
 /* Initialize p and fill it with features matched by the given board move. 
  * @locally: Looking for local moves ? Distance features disabled if false. */
-void pattern_match(struct pattern_config *pc, struct pattern *p, struct board *b, struct move *m, struct ownermap *ownermap, bool locally);
+void pattern_match(pattern_config_t *pc, pattern_t *p, board_t *b, move_t *m, ownermap_t *ownermap, bool locally);
 
 /* Fill ownermap for mcowner feature. */
-void mcowner_playouts(struct board *b, enum stone color, struct ownermap *ownermap);
+void mcowner_playouts(board_t *b, enum stone color, ownermap_t *ownermap);
 /* Faster version with few playouts, don't use for anything reliable. */
-void mcowner_playouts_fast(struct board *b, enum stone color, struct ownermap *ownermap);
+void mcowner_playouts_fast(board_t *b, enum stone color, ownermap_t *ownermap);
 
 #ifdef PATTERN_FEATURE_STATS
 void pattern_stats_new_position();
@@ -207,7 +207,7 @@ feature_info(char *name, int payloads, int spatial)
 }
 
 static inline bool
-pattern_eq(struct pattern *p1, struct pattern *p2)
+pattern_eq(pattern_t *p1, pattern_t *p2)
 {
 	if (p1->n != p2->n) return false;
 	for (int i = 0; i < p1->n; i++)

--- a/pattern3.c
+++ b/pattern3.c
@@ -9,7 +9,7 @@
 
 
 static void
-pattern_record(struct pattern3s *p, int pi, char *str, hash3_t pat, int fixed_color)
+pattern_record(pattern3s_t *p, int pi, char *str, hash3_t pat, int fixed_color)
 {
 	hash_t h = hash3_to_hash(pat);
 	while (p->hash[h & pattern3_hash_mask].pattern != pat
@@ -101,7 +101,7 @@ pattern3_transpose(hash3_t pat, hash3_t (*transp)[8])
 }
 
 static void
-pattern_gen(struct pattern3s *p, int pi, hash3_t pat, char *src, int srclen, int fixed_color)
+pattern_gen(pattern3s_t *p, int pi, hash3_t pat, char *src, int srclen, int fixed_color)
 {
 	for (; srclen > 0; src++, srclen--) {
 		if (srclen == 5)
@@ -203,7 +203,7 @@ pattern_gen(struct pattern3s *p, int pi, hash3_t pat, char *src, int srclen, int
 }
 
 static void
-patterns_gen(struct pattern3s *p, char src[][11], int src_n)
+patterns_gen(pattern3s_t *p, char src[][11], int src_n)
 {
 	for (int i = 0; i < src_n; i++) {
 		//printf("<%s>\n", src[i]);
@@ -243,7 +243,7 @@ error:
 }
 
 void
-pattern3s_init(struct pattern3s *p, char src[][11], int src_n)
+pattern3s_init(pattern3s_t *p, char src[][11], int src_n)
 {
 	char nsrc[src_n][11];
 

--- a/pattern3.c
+++ b/pattern3.c
@@ -256,6 +256,7 @@ pattern3s_init(pattern3s_t *p, char src[][11], int src_n)
 	patterns_gen(p, nsrc, src_n);
 }
 
+hash3_t p3hashes[8][2][S_MAX];
 
 static __attribute__((constructor)) void
 p3hashes_init(void)

--- a/pattern3.h
+++ b/pattern3.h
@@ -8,9 +8,6 @@
 /* (Note that this is completely independent from the general pattern
  * matching infrastructure in pattern.[ch]. This is fast and simple.) */
 
-struct board;
-struct move;
-
 /* hash3_t pattern: ignore middle point, 2 bits per intersection (color)
  * plus 1 bit per each direct neighbor => 8*2 + 4 bits. Bitmap point order:
  * 7 6 5    b
@@ -20,20 +17,20 @@ struct move;
 
 /* XXX: See <board.h> for hash3_t typedef. */
 
-struct pattern2p {
+typedef struct {
 	hash3_t pattern;
 	unsigned char value;
-};
+} pattern2p_t;
 
-struct pattern3s {
+typedef struct {
 	/* In case of a collision, following hash entries are
 	 * used. value==0 indicates an unoccupied hash entry. */
 	/* The hash indices are zobrist hashes based on p3hashes. */
 #define pattern3_hash_bits 19
 #define pattern3_hash_size (1 << pattern3_hash_bits)
 #define pattern3_hash_mask (pattern3_hash_size - 1)
-	struct pattern2p hash[pattern3_hash_size];
-};
+	pattern2p_t hash[pattern3_hash_size];
+} pattern3s_t;
 
 /* Zobrist hashes for the various 3x3 points. */
 /* [point][is_atari][color] */
@@ -50,13 +47,13 @@ hash_t p3hashes[8][2][S_MAX];
  * extra X: pattern valid only for one side;
  * middle point ignored. */
 
-void pattern3s_init(struct pattern3s *p, char src[][11], int src_n);
+void pattern3s_init(pattern3s_t *p, char src[][11], int src_n);
 
 /* Compute pattern3 hash at local position. */
-static hash3_t pattern3_hash(struct board *b, coord_t c);
+static hash3_t pattern3_hash(board_t *b, coord_t c);
 
 /* Check if we match any 3x3 pattern centered on given move. */
-static bool pattern3_move_here(struct pattern3s *p, struct board *b, struct move *m, char *idx);
+static bool pattern3_move_here(pattern3s_t *p, board_t *b, move_t *m, char *idx);
 
 /* Generate all transpositions of given pattern, stored in an
  * hash3_t[8] array. */
@@ -67,7 +64,7 @@ static hash3_t pattern3_reverse(hash3_t pat);
 
 
 static inline hash3_t
-pattern3_hash(struct board *b, coord_t c)
+pattern3_hash(board_t *b, coord_t c)
 {
 	hash3_t pat = 0;
 	int x = coord_x(c), y = coord_y(c);
@@ -102,7 +99,7 @@ hash3_to_hash(hash3_t pat)
 }
 
 static inline bool
-pattern3_move_here(struct pattern3s *p, struct board *b, struct move *m, char *idx)
+pattern3_move_here(pattern3s_t *p, board_t *b, move_t *m, char *idx)
 {
 #ifdef BOARD_PAT3
 	hash3_t pat = b->pat3[m->coord];

--- a/pattern3.h
+++ b/pattern3.h
@@ -34,7 +34,7 @@ typedef struct {
 
 /* Zobrist hashes for the various 3x3 points. */
 /* [point][is_atari][color] */
-hash_t p3hashes[8][2][S_MAX];
+extern hash3_t p3hashes[8][2][S_MAX];
 
 /* Source pattern encoding:
  * X: black;  O: white;  .: empty;  #: edge

--- a/pattern3.h
+++ b/pattern3.h
@@ -70,7 +70,7 @@ static inline hash3_t
 pattern3_hash(struct board *b, coord_t c)
 {
 	hash3_t pat = 0;
-	int x = coord_x(c, b), y = coord_y(c, b);
+	int x = coord_x(c), y = coord_y(c);
 	/* Stone info. */
 	pat |= (board_atxy(b, x - 1, y - 1) << 14)
 		| (board_atxy(b, x, y - 1) << 12)

--- a/patternprob.c
+++ b/patternprob.c
@@ -24,13 +24,13 @@ prob_dict_init(char *filename, pattern_config_t *pc)
 		return;
 	}
 
-	prob_dict = calloc2(1, sizeof(*prob_dict));
-	prob_dict->table = calloc2(spat_dict->nspatials + 1, sizeof(*prob_dict->table));
+	prob_dict = calloc2(1, prob_dict_t);
+	prob_dict->table = calloc2(spat_dict->nspatials + 1, pattern_prob_t*);
 
 	int i = 0;
 	char sbuf[1024];
 	while (fgets(sbuf, sizeof(sbuf), f)) {
-		pattern_prob_t *pb = calloc2(1, sizeof(*pb));
+		pattern_prob_t *pb = calloc2(1, pattern_prob_t);
 		//int c, o;
 
 		char *buf = sbuf;

--- a/patternprob.c
+++ b/patternprob.c
@@ -94,7 +94,7 @@ pattern_max_rating(struct pattern_config *pc,
 	for (int f = 0; f < b->flen; f++) {
 		probs[f] = NAN;
 
-		struct move mo = { .coord = b->f[f], .color = color };
+		struct move mo = move(b->f[f], color);
 		if (is_pass(mo.coord))	continue;
 		if (!board_is_valid_play_no_suicide(b, mo.color, mo.coord)) continue;
 

--- a/patternprob.c
+++ b/patternprob.c
@@ -106,7 +106,7 @@ pattern_max_rating(struct pattern_config *pc,
 		}
 		if (DEBUGL(5)) {
 			char buf[256]; pattern2str(buf, &pats[f]);
-			fprintf(stderr, "=> move %s pattern %s prob %.3f\n", coord2sstr(mo.coord, b), buf, prob);
+			fprintf(stderr, "=> move %s pattern %s prob %.3f\n", coord2sstr(mo.coord), buf, prob);
 		}
 	}
 

--- a/patternprob.h
+++ b/patternprob.h
@@ -9,9 +9,6 @@
 #include "move.h"
 #include "pattern.h"
 
-/* The patterns probability dictionary */
-extern struct prob_dict *prob_dict;
-
 /* The pattern probability table considers each pattern as a whole
  * (not dividing it to individual features) and stores probability
  * of the pattern being played. */
@@ -20,66 +17,69 @@ extern struct prob_dict *prob_dict;
  * feature); within a single primary key chain, the entries are
  * unsorted (for now). */
 
-struct pattern_prob {
-	struct pattern p;
+typedef struct pattern_prob {
+	pattern_t p;
 	floating_t gamma;
 	struct pattern_prob *next;
-};
+} pattern_prob_t;
 
-struct prob_dict {
-	struct pattern_prob **table; /* [pc->spat_dict->nspatials + 1] */
-};
+typedef struct {
+	pattern_prob_t **table; /* [pc->spat_dict->nspatials + 1] */
+} prob_dict_t;
+
+/* The patterns probability dictionary */
+extern prob_dict_t *prob_dict;
 
 
 /* Initialize the prob_dict data structure from a given file (pass NULL
  * to use default filename). */
-void prob_dict_init(char *filename, struct pattern_config *pc);
+void prob_dict_init(char *filename, pattern_config_t *pc);
 
 /* Free patterns probability dictionary. */
 void prob_dict_done();
 
 /* Return probability associated with given pattern. */
-static inline floating_t pattern_gamma(struct pattern_config *pc, struct pattern *p);
+static inline floating_t pattern_gamma(pattern_config_t *pc, pattern_t *p);
 
 /* Evaluate patterns for all available moves. Stores found patterns to pats[b->flen]
  * and NON-normalized probability of each pattern to probs[b->flen].
  * Returns the sum of all probabilities that can be used for normalization. */
-floating_t pattern_rate_moves(struct pattern_config *pc,
-			      struct board *b, enum stone color,
-			      struct pattern *pats, floating_t *probs,
-			      struct ownermap *ownermap);
+floating_t pattern_rate_moves(pattern_config_t *pc,
+			      board_t *b, enum stone color,
+			      pattern_t *pats, floating_t *probs,
+			      ownermap_t *ownermap);
 
 /* Helper function for pattern_match() callers:
  * Returns @locally flag to use for this position. */
-bool pattern_matching_locally(struct pattern_config *pc,
-			      struct board *b, enum stone color,				
-			      struct ownermap *ownermap);
+bool pattern_matching_locally(pattern_config_t *pc,
+			      board_t *b, enum stone color,				
+			      ownermap_t *ownermap);
 
-void print_pattern_best_moves(struct board *b, coord_t *best_c, float *best_r, int nbest);
-void get_pattern_best_moves(struct board *b, float *probs, coord_t *best_c, float *best_r, int nbest);
+void print_pattern_best_moves(board_t *b, coord_t *best_c, float *best_r, int nbest);
+void get_pattern_best_moves(board_t *b, float *probs, coord_t *best_c, float *best_r, int nbest);
 
 /* Debugging */
-void dump_gammas(strbuf_t *buf, struct pattern_config *pc, struct pattern *p);
+void dump_gammas(strbuf_t *buf, pattern_config_t *pc, pattern_t *p);
 
 /* Do we have a gamma for that feature ? */
-bool feature_has_gamma(struct pattern_config *pc, struct feature *f);
+bool feature_has_gamma(pattern_config_t *pc, feature_t *f);
 
 /* Lookup gamma for that feature. */
-static floating_t feature_gamma(struct pattern_config *pc, struct feature *f);
+static floating_t feature_gamma(pattern_config_t *pc, feature_t *f);
 
 /* Compute pattern gamma */
-static floating_t pattern_gamma(struct pattern_config *pc, struct pattern *p);
+static floating_t pattern_gamma(pattern_config_t *pc, pattern_t *p);
 
 /* Extract spatial id from pattern feature.
  * If not a spatial feature returns highest spatial id plus one. */
-static uint32_t feature2spatial(struct pattern_config *pc, struct feature *f);
+static uint32_t feature2spatial(pattern_config_t *pc, feature_t *f);
 
 
 static inline floating_t
-feature_gamma(struct pattern_config *pc, struct feature *f)
+feature_gamma(pattern_config_t *pc, feature_t *f)
 {
 	uint32_t spi = feature2spatial(pc, f);
-	for (struct pattern_prob *pb = prob_dict->table[spi]; pb; pb = pb->next)
+	for (pattern_prob_t *pb = prob_dict->table[spi]; pb; pb = pb->next)
 		if (feature_eq(f, &pb->p.f[0]))
 			return pb->gamma;
 	die("no gamma for feature (%s) !\n", feature2sstr(f));
@@ -87,7 +87,7 @@ feature_gamma(struct pattern_config *pc, struct feature *f)
 }
 
 static inline floating_t
-pattern_gamma(struct pattern_config *pc, struct pattern *p)
+pattern_gamma(pattern_config_t *pc, pattern_t *p)
 {
 	floating_t gammas = 1;
 	for (int i = 0; i < p->n; i++)
@@ -97,7 +97,7 @@ pattern_gamma(struct pattern_config *pc, struct pattern *p)
 
 
 static inline uint32_t
-feature2spatial(struct pattern_config *pc, struct feature *f)
+feature2spatial(pattern_config_t *pc, feature_t *f)
 {
 	if (f->id >= FEAT_SPATIAL3)
 		return f->payload;

--- a/patternsp.c
+++ b/patternsp.c
@@ -310,7 +310,7 @@ spatial_dict_addc(spatial_dict_t *d, spatial_t *s)
 static void
 spatial_dict_addh(spatial_dict_t *dict, hash_t spatial_hash, unsigned int id)
 {
-	spatial_entry_t *e = malloc(sizeof(*e));
+	spatial_entry_t *e = malloc2(spatial_entry_t);
 	e->hash = spatial_hash;
 	e->id = id;
 	e->next = NULL;
@@ -501,7 +501,7 @@ spatial_dict_init(pattern_config_t *pc, bool create)
 		return;
 	}
 
-	spat_dict = calloc2(1, sizeof(*spat_dict));
+	spat_dict = calloc2(1, spatial_dict_t);
 	/* Dummy record for index 0 so ids start at 1. */
 	spatial_t dummy = { 0, };
 	spatial_dict_addc(spat_dict, &dummy);

--- a/patternsp.c
+++ b/patternsp.c
@@ -142,7 +142,7 @@ spatial_init(void)
 	pthashes_init();
 }
 
-inline hash_t
+hash_t
 spatial_hash(unsigned int rotation, spatial_t *s)
 {
 	hash_t h = 0;
@@ -207,7 +207,7 @@ spatial_print(board_t *board, spatial_t *s, FILE *f, move_t *at)
 	for (int i = 0; i < real_board_size(b); i++)
 		for (int j = 0; j < real_board_size(b); j++) {
 			coord_t c = coord_xy(i+1, j+1);
-			board_at(b, c) = 4; // HACK !
+			board_at(b, c) = (enum stone)4; // HACK !
 		}
 	
 	for (unsigned int j = 0; j < ptind[s->dist + 1]; j++) {
@@ -301,7 +301,7 @@ static unsigned int
 spatial_dict_addc(spatial_dict_t *d, spatial_t *s)
 {
 	if (!(d->nspatials % SPATIALS_ALLOC))
-		d->spatials = realloc(d->spatials, (d->nspatials + SPATIALS_ALLOC) * sizeof(*d->spatials));
+		d->spatials = (spatial_t*)realloc(d->spatials, (d->nspatials + SPATIALS_ALLOC) * sizeof(*d->spatials));
 	d->spatials[d->nspatials] = *s;
 	return d->nspatials++;
 }

--- a/patternsp.c
+++ b/patternsp.c
@@ -169,7 +169,7 @@ outer_spatial_hash_from_board_rot_d(struct board *b, coord_t coord, enum stone c
 	enum stone (*bt)[4] = color == S_WHITE ? &bt_white : &bt_black;
 
 	for (unsigned int i = ptind[2]; i < ptind[d + 1]; i++) {
-		ptcoords_at(x, y, coord, b, i);
+		ptcoords_at(x, y, coord, i);
 		h ^= pthashes[rot][i][(*bt)[board_atxy(b, x, y)]];
 	}
 	return h;
@@ -206,13 +206,13 @@ spatial_print(struct board *board, struct spatial *s, FILE *f, struct move *at)
 	
 	for (int i = 0; i < real_board_size(b); i++)
 		for (int j = 0; j < real_board_size(b); j++) {
-			coord_t c = coord_xy(b, i+1, j+1);
+			coord_t c = coord_xy(i+1, j+1);
 			board_at(b, c) = 4; // HACK !
 		}
 	
 	for (unsigned int j = 0; j < ptind[s->dist + 1]; j++) {
-		ptcoords_at(x, y, at->coord, b, j);
-		struct move m = move(coord_xy(b, x, y), spatial_point_at(*s, j) );
+		ptcoords_at(x, y, at->coord, j);
+		struct move m = move(coord_xy(x, y), spatial_point_at(*s, j) );
 		board_at(b, m.coord) = m.color;
 	}
 	board_print(b, stderr);	
@@ -234,7 +234,7 @@ spatial_from_board(struct pattern_config *pc, struct spatial *s,
 
 	memset(s, 0, sizeof(*s));
 	for (unsigned int j = 0; j < ptind[pc->spat_max + 1]; j++) {
-		ptcoords_at(x, y, m->coord, b, j);
+		ptcoords_at(x, y, m->coord, j);
 		s->points[j / 4] |= (*bt)[board_atxy(b, x, y)] << ((j % 4) * 2);
 	}
 	s->dist = pc->spat_max;

--- a/patternsp.c
+++ b/patternsp.c
@@ -212,7 +212,7 @@ spatial_print(struct board *board, struct spatial *s, FILE *f, struct move *at)
 	
 	for (unsigned int j = 0; j < ptind[s->dist + 1]; j++) {
 		ptcoords_at(x, y, at->coord, b, j);
-		struct move m = { .coord = coord_xy(b, x, y), .color = spatial_point_at(*s, j)  };
+		struct move m = move(coord_xy(b, x, y), spatial_point_at(*s, j) );
 		board_at(b, m.coord) = m.color;
 	}
 	board_print(b, stderr);	
@@ -361,7 +361,7 @@ spatial_dict_read(struct spatial_dict *dict, char *buf)
 	assert(radius <= MAX_PATTERN_DIST);
 
 	/* Load the stone configuration. */
-	struct spatial s = { .dist = radius };
+	struct spatial s = { radius, };
 	unsigned int sl = 0;
 	while (!isspace(*bufp)) {
 		s.points[sl / 4] |= char2stone(*bufp++) << ((sl % 4)*2);
@@ -503,7 +503,7 @@ spatial_dict_init(struct pattern_config *pc, bool create)
 
 	spat_dict = calloc2(1, sizeof(*spat_dict));
 	/* Dummy record for index 0 so ids start at 1. */
-	struct spatial dummy = { .dist = 0 };
+	struct spatial dummy = { 0, };
 	spatial_dict_addc(spat_dict, &dummy);
 
 	if (f) {

--- a/patternsp.h
+++ b/patternsp.h
@@ -58,7 +58,7 @@ typedef struct {
 	 * spiral from middle to the edge; the dictionary file has
 	 * a comment describing the ordering at the top. */
 	unsigned char points[MAX_PATTERN_AREA / 4];
-#define spatial_point_at(s, i) (((s).points[(i) / 4] >> (((i) % 4) * 2)) & 3)
+#define spatial_point_at(s, i) ((enum stone)(((s).points[(i) / 4] >> (((i) % 4) * 2)) & 3))
 } spatial_t;
 
 
@@ -120,11 +120,11 @@ void spatial_print(board_t *b, spatial_t *s, FILE *f, move_t *at);
 typedef struct { short x, y; } ptcoord_t;
 extern ptcoord_t ptcoords[MAX_PATTERN_AREA];
 /* For each radius, starting index in ptcoords[]. */
-unsigned int ptind[MAX_PATTERN_DIST + 2];
+extern unsigned int ptind[MAX_PATTERN_DIST + 2];
 
 /* Zobrist hashes used for points in patterns. */
 #define PTH__ROTATIONS	8
-hash_t pthashes[PTH__ROTATIONS][MAX_PATTERN_AREA][S_MAX];
+extern hash_t pthashes[PTH__ROTATIONS][MAX_PATTERN_AREA][S_MAX];
 
 #define ptcoords_at(x_, y_, c_, j_) \
 	int x_ = coord_x((c_)) + ptcoords[j_].x; \

--- a/patternsp.h
+++ b/patternsp.h
@@ -50,7 +50,7 @@
 
 /* Spatial record - single stone configuration. */
 
-typedef struct spatial {
+typedef struct {
 	/* Gridcular radius of matched pattern. */
 	unsigned char dist;
 	/* The points; each point is two bits, corresponding
@@ -63,9 +63,6 @@ typedef struct spatial {
 
 
 /* Spatial dictionary - collection of stone configurations. */
-
-extern struct spatial_dict *spat_dict;
-extern const char *spatial_dict_filename;
 
 #ifndef GENSPATIAL
 #define spatial_hash_bits 20 // 4Mb array
@@ -80,10 +77,10 @@ typedef struct spatial_entry {
 	struct spatial_entry *next;	/* next entry with same hash */
 } spatial_entry_t;
 
-typedef struct spatial_dict {
+typedef struct {
 	/* Indexed base store */
 	unsigned int nspatials; /* Number of records. */
-	struct spatial *spatials; /* Actual records. */
+	spatial_t *spatials; /* Actual records. */
 	
 	/* number of spatials for each dist, for mm tool */
 	unsigned int     nspatials_by_dist[MAX_PATTERN_DIST+1];
@@ -93,32 +90,35 @@ typedef struct spatial_dict {
 	spatial_entry_t* hashtable[1 << spatial_hash_bits];
 } spatial_dict_t;
 
+extern spatial_dict_t *spat_dict;
+extern const char *spatial_dict_filename;
+
 #define spatial_id(s, dict)  ((unsigned int)((s) - (dict)->spatials))
 #define spatial(id, dict)    ((dict)->spatials + (id))
 
 
 /* Fill up the spatial record from @m vincinity, up to full distance
  * given by pattern config. */
-struct pattern_config;
-void spatial_from_board(struct pattern_config *pc, spatial_t *s, struct board *b, struct move *m);
+void spatial_from_board(pattern_config_t *pc, spatial_t *s, board_t *b, move_t *m);
 
 /* Compute hash of given spatial pattern. */
 hash_t spatial_hash(unsigned int rotation, spatial_t *s);
 
 /* Compute spatial hash from board, ignoring center stone */
-hash_t outer_spatial_hash_from_board(struct board *b, coord_t coord, enum stone color);
-hash_t outer_spatial_hash_from_board_rot(struct board *b, coord_t coord, enum stone color, int rot);
-hash_t outer_spatial_hash_from_board_rot_d(struct board *b, coord_t coord, enum stone color, int rot, unsigned int d);
+hash_t outer_spatial_hash_from_board(board_t *b, coord_t coord, enum stone color);
+hash_t outer_spatial_hash_from_board_rot(board_t *b, coord_t coord, enum stone color, int rot);
+hash_t outer_spatial_hash_from_board_rot_d(board_t *b, coord_t coord, enum stone color, int rot, unsigned int d);
 
 /* Convert given spatial pattern to string. */
 char *spatial2str(spatial_t *s);
 
 /* Print spatial on board centered on @at */
-void spatial_print(struct board *b, spatial_t *s, FILE *f, struct move *at);
+void spatial_print(board_t *b, spatial_t *s, FILE *f, move_t *at);
 
 /* Mapping from point sequence to coordinate offsets (to determine
  * coordinates relative to pattern center). */
-struct ptcoord { short x, y; } ptcoords[MAX_PATTERN_AREA];
+typedef struct { short x, y; } ptcoord_t;
+extern ptcoord_t ptcoords[MAX_PATTERN_AREA];
 /* For each radius, starting index in ptcoords[]. */
 unsigned int ptind[MAX_PATTERN_DIST + 2];
 
@@ -140,7 +140,7 @@ hash_t pthashes[PTH__ROTATIONS][MAX_PATTERN_AREA][S_MAX];
  * about non-existing file and initialize the dictionary anyway.
  * If hash is true, loaded spatials will be added to the hashtable;
  * use false if this is to be done later (e.g. by patternprob). */
-void spatial_dict_init(struct pattern_config *pc, bool create);
+void spatial_dict_init(pattern_config_t *pc, bool create);
 
 /* Free spatial dictionary. */
 void spatial_dict_done();
@@ -150,13 +150,13 @@ spatial_t *spatial_dict_lookup(spatial_dict_t *dict, int dist, hash_t spatial_ha
 
 /* Store specified spatial pattern in the dictionary if it is not known yet.
  * Returns spatial id. */
-unsigned int spatial_dict_add(spatial_dict_t *dict, struct spatial *s);
+unsigned int spatial_dict_add(spatial_dict_t *dict, spatial_t *s);
 
 /* Write comment lines describing the dictionary (e.g. point order
  * in patterns) to given file. */
-void spatial_dict_writeinfo(struct spatial_dict *dict, FILE *f);
+void spatial_dict_writeinfo(spatial_dict_t *dict, FILE *f);
 
 /* Append specified spatial pattern to the given file. */
-void spatial_write(struct spatial_dict *dict, struct spatial *s, unsigned int id, FILE *f);
+void spatial_write(spatial_dict_t *dict, spatial_t *s, unsigned int id, FILE *f);
 
 #endif

--- a/patternsp.h
+++ b/patternsp.h
@@ -126,11 +126,11 @@ unsigned int ptind[MAX_PATTERN_DIST + 2];
 #define PTH__ROTATIONS	8
 hash_t pthashes[PTH__ROTATIONS][MAX_PATTERN_AREA][S_MAX];
 
-#define ptcoords_at(x_, y_, c_, b_, j_) \
-	int x_ = coord_x((c_), (b_)) + ptcoords[j_].x; \
-	int y_ = coord_y((c_), (b_)) + ptcoords[j_].y; \
-	if (x_ >= board_size(b_)) x_ = board_size(b_) - 1; else if (x_ < 0) x_ = 0; \
-	if (y_ >= board_size(b_)) y_ = board_size(b_) - 1; else if (y_ < 0) y_ = 0;
+#define ptcoords_at(x_, y_, c_, j_) \
+	int x_ = coord_x((c_)) + ptcoords[j_].x; \
+	int y_ = coord_y((c_)) + ptcoords[j_].y; \
+	if (x_ >= the_board_size()) x_ = the_board_size() - 1; else if (x_ < 0) x_ = 0; \
+	if (y_ >= the_board_size()) y_ = the_board_size() - 1; else if (y_ < 0) y_ = 0;
 
 
 /* Spatial dictionary file manipulation. */

--- a/playout.c
+++ b/playout.c
@@ -72,7 +72,7 @@ playout_play_move(struct playout_setup *setup,
 	if (is_pass(coord)) {
 		coord = policy->choose(policy, setup, b, color);
 		coord = playout_check_move(policy, b, coord, color);
-		// fprintf(stderr, "policy: %s\n", coord2sstr(coord, b));
+		// fprintf(stderr, "policy: %s\n", coord2sstr(coord));
 	}
 
 	if (is_pass(coord)) {
@@ -87,8 +87,7 @@ playout_play_move(struct playout_setup *setup,
 		struct move m = move(coord, color);
 		if (board_play(b, &m) < 0) {
 			if (PLDEBUGL(4)) {
-				fprintf(stderr, "Pre-picked move %d,%d is ILLEGAL:\n",
-					coord_x(coord, b), coord_y(coord, b));
+				fprintf(stderr, "Pre-picked move %d,%d is ILLEGAL:\n", coord_x(coord), coord_y(coord));
 				board_print(b, stderr);
 			}
 			goto play_random;
@@ -111,10 +110,10 @@ fill_bent_four(struct board *b, enum stone color, coord_t *other, coord_t *kill)
 {
 	enum stone other_color = stone_other(color);  // white here
 	int s = real_board_size(b);
-	coord_t corners[4] = { coord_xy(b, 1, 1),
-			       coord_xy(b, 1, s),
-			       coord_xy(b, s, 1),
-			       coord_xy(b, s, s),
+	coord_t corners[4] = { coord_xy(1, 1),
+			       coord_xy(1, s),
+			       coord_xy(s, 1),
+			       coord_xy(s, s),
 	};
 	
 	for (int i = 0; i < 4; i++) {
@@ -127,23 +126,23 @@ fill_bent_four(struct board *b, enum stone color, coord_t *other, coord_t *kill)
 
 		
 		coord_t stone3 = pass;
-		int x = coord_x(corner, b);
-		int y = coord_y(corner, b);
+		int x = coord_x(corner);
+		int y = coord_y(corner);
 
 		/* check 3 in line, horizontal */
 		int dx = (x == 1 ? 1 : -1);
 		for (int j = 0; j < 3; j++) {
-			coord_t c = coord_xy(b, x + j * dx, y);
+			coord_t c = coord_xy(x + j * dx, y);
 			if (board_at(b, c) != other_color)  break;
-			if (j == 2)  {  stone3 = c;  *kill = coord_xy(b, x + dx, y);  }
+			if (j == 2)  {  stone3 = c;  *kill = coord_xy(x + dx, y);  }
 		}
 
 		/* check 3 in line, vertical */
 		int dy = (y == 1 ? 1 : -1);
 		for (int j = 0; j < 3; j++) {
-			coord_t c = coord_xy(b, x, y + j * dy);
+			coord_t c = coord_xy(x, y + j * dy);
 			if (board_at(b, c) != other_color)  break;
-			if (j == 2)  {  stone3 = c;  *kill = coord_xy(b, x, y + dy);  }
+			if (j == 2)  {  stone3 = c;  *kill = coord_xy(x, y + dy);  }
 		}
 
 		if (stone3 == pass)  continue;
@@ -171,7 +170,7 @@ fill_bent_four(struct board *b, enum stone color, coord_t *other, coord_t *kill)
 
 #define random_game_loop_stuff  \
 		if (PLDEBUGL(7)) { \
-			fprintf(stderr, "%s %s\n", stone2str(color), coord2sstr(coord, b)); \
+			fprintf(stderr, "%s %s\n", stone2str(color), coord2sstr(coord)); \
 			if (PLDEBUGL(8)) board_print(b, stderr); \
 		} \
 \

--- a/playout.c
+++ b/playout.c
@@ -39,7 +39,7 @@ playout_permit_move(struct playout_policy *p, struct board *b, struct move *m, b
 static coord_t
 playout_check_move(struct playout_policy *p, struct board *b, coord_t coord, enum stone color)
 {
-	struct move m = { .coord = coord, .color = color };
+	struct move m = move(coord, color);
 	if (!playout_permit_move(p, b, &m, true, false))
 		return pass;
 	return m.coord;
@@ -50,7 +50,7 @@ playout_check_move(struct playout_policy *p, struct board *b, coord_t coord, enu
 bool
 playout_permit(struct playout_policy *p, struct board *b, coord_t coord, enum stone color, bool rnd)
 {
-	struct move m = { .coord = coord, .color = color };
+	struct move m = move(coord, color);
 	return playout_permit_move(p, b, &m, false, rnd);
 }
 
@@ -84,8 +84,7 @@ playout_play_move(struct playout_setup *setup,
 		board_play_random(b, color, &coord, random_permit_handler, policy);
 
 	} else {
-		struct move m;
-		m.coord = coord; m.color = color;
+		struct move m = move(coord, color);
 		if (board_play(b, &m) < 0) {
 			if (PLDEBUGL(4)) {
 				fprintf(stderr, "Pre-picked move %d,%d is ILLEGAL:\n",
@@ -160,7 +159,7 @@ fill_bent_four(struct board *b, enum stone color, coord_t *other, coord_t *kill)
 				if (board_at(b, c) == S_NONE)  {  fill = c;  break;  }
 			});
 
-		struct move m = {  .coord = fill, .color = other_color };
+		struct move m = move(fill, other_color);
 		if (board_permit(b, &m, NULL)) {
 			*other = board_group_other_lib(b, g, fill);
 			return fill;
@@ -236,14 +235,14 @@ playout_play_game(struct playout_setup *setup,
 		if (b->moves == bent4_moves + 1) {
 			/* Capture or kill group. */
 			coord = (board_at(b, bent4_other) == S_NONE ? bent4_other : bent4_kill);
-			struct move m = { .color = color, .coord = coord };
+			struct move m = move(coord, color);
 			int r = board_play(b, &m);  assert(r == 0);
 		}
 		else    coord = playout_play_move(setup, b, color, policy);
 		
 		/* Fill bent-fours */
 		if (coord == pass && (coord = fill_bent_four(b, stone_other(color), &bent4_other, &bent4_kill)) != pass) {
-			struct move m = { .color = color, .coord = coord };
+			struct move m = move(coord, color);
 			int r = board_play(b, &m);  assert(r == 0);
 			bent4_moves = b->moves;
 		}

--- a/playout.c
+++ b/playout.c
@@ -57,7 +57,7 @@ playout_permit(playout_policy_t *p, board_t *b, coord_t coord, enum stone color,
 static bool
 random_permit_handler(board_t *b, move_t *m, void *data)
 {
-	playout_policy_t *policy = data;
+	playout_policy_t *policy = (playout_policy_t*)data;
 	return playout_permit_move(policy, b, m, true, true);
 }
 

--- a/playout.h
+++ b/playout.h
@@ -3,17 +3,16 @@
 
 #define MAX_GAMELEN 600
 
-struct board;
-struct move;
-enum stone;
+#include "board.h"
+#include "ownermap.h"
+
 struct prior_map;
-struct ownermap;
+
+typedef struct playout_policy playout_policy_t;
+typedef struct playout_setup playout_setup_t;
 
 
 /** Playout policy interface: */
-
-struct playout_policy;
-struct playout_setup;
 
 /* Initialize policy data structures for new playout; subsequent choose calls
  * (but not assess/permit calls!) will all be made on the same board; if
@@ -21,25 +20,26 @@ struct playout_setup;
  * on the board subsequently. The routine is expected to initialize b->ps
  * with internal data. b->ps will be simply free()d when board is destroyed,
  * so make sure all data is within single allocated block. */
-typedef void (*playoutp_setboard)(struct playout_policy *playout_policy, struct board *b);
+typedef void (*playoutp_setboard)(playout_policy_t *playout_policy, board_t *b);
 
 /* Pick the next playout simulation move. */
-typedef coord_t (*playoutp_choose)(struct playout_policy *playout_policy, struct playout_setup *playout_setup, struct board *b, enum stone to_play);
+typedef coord_t (*playoutp_choose)(playout_policy_t *playout_policy, playout_setup_t *playout_setup, board_t *b, enum stone to_play);
 
 /* Set number of won (>0) or lost (<0) games for each considerable
  * move (usually a proportion of @games); can leave some untouched
  * if policy has no opinion. The number must have proper parity;
  * just use uct/prior.h:add_prior_value(). */
-typedef void (*playoutp_assess)(struct playout_policy *playout_policy, struct prior_map *map, int games);
+typedef void (*playoutp_assess)(playout_policy_t *playout_policy, struct prior_map *map, int games);
 
 
 /* Whether to allow given move. All playout moves must pass permit() before being played.
  * @alt:  policy may suggest another move if this one doesn't pass (in which case m will be changed).
  * @rnd:  move has been randomly picked.   */
-typedef bool (*playoutp_permit)(struct playout_policy *playout_policy, struct board *b, struct move *m, bool alt, bool rnd);
+typedef bool (*playoutp_permit)(playout_policy_t *playout_policy, board_t *b, move_t *m, bool alt, bool rnd);
 
 /* Tear down the policy state; policy and policy->data will be free()d by caller. */
-typedef void (*playoutp_done)(struct playout_policy *playout_policy);
+typedef void (*playoutp_done)(playout_policy_t *playout_policy);
+
 
 struct playout_policy {
 	int debug_level;
@@ -74,7 +74,7 @@ struct playout_setup {
 
 #define playout_setup(gamelen, mercymin)  { gamelen, mercymin }
 
-struct playout_amafmap {
+typedef struct {
 	/* We keep record of the game so that we can
 	 * examine nakade moves; really going out of our way to
 	 * implement nakade AMAF properly turns out to be crucial
@@ -86,27 +86,27 @@ struct playout_amafmap {
 	/* Our current position in the game sequence; in AMAF, we search
 	 * the range [game_baselen, gamelen[ */
 	int game_baselen;
-};
+} playout_amafmap_t;
 
 
 /* >0: starting_color wins,
  * <0: starting_color loses; returned number is DOUBLE the score difference.
  *  0: superko inside the game tree (XXX: jigo not handled) */
-int playout_play_game(struct playout_setup *setup,
-		      struct board *b, enum stone starting_color,
-		      struct playout_amafmap *amafmap,
-		      struct ownermap *ownermap,
-		      struct playout_policy *policy);
+int playout_play_game(playout_setup_t *setup,
+		      board_t *b, enum stone starting_color,
+		      playout_amafmap_t *amafmap,
+		      ownermap_t *ownermap,
+		      playout_policy_t *policy);
 
 /* Play move returned by playout policy, or a randomly picked move if there was none. */
-coord_t playout_play_move(struct playout_setup *setup,
-			  struct board *b, enum stone color,
-			  struct playout_policy *policy);
+coord_t playout_play_move(playout_setup_t *setup,
+			  board_t *b, enum stone color,
+			  playout_policy_t *policy);
 
 /* Is *this* move permitted ? 
  * Called by policy permit() to check something so never the main permit() call. */
-bool playout_permit(struct playout_policy *p, struct board *b, coord_t coord, enum stone color, bool rnd);
+bool playout_permit(playout_policy_t *p, board_t *b, coord_t coord, enum stone color, bool rnd);
 
-void playout_policy_done(struct playout_policy *p);
+void playout_policy_done(playout_policy_t *p);
 
 #endif

--- a/playout.h
+++ b/playout.h
@@ -66,7 +66,7 @@ struct playout_policy {
 /** Playout engine interface: */
 
 struct playout_setup {
-	unsigned int gamelen; /* Maximal # of moves in playout. */
+	int gamelen; /* Maximal # of moves in playout. */
 	/* Minimal difference between captures to terminate the playout.
 	 * 0 means don't check. */
 	int mercymin;

--- a/playout.h
+++ b/playout.h
@@ -72,6 +72,7 @@ struct playout_setup {
 	int mercymin;
 };
 
+#define playout_setup(gamelen, mercymin)  { gamelen, mercymin }
 
 struct playout_amafmap {
 	/* We keep record of the game so that we can

--- a/playout/light.c
+++ b/playout/light.c
@@ -22,7 +22,7 @@ playout_light_choose(playout_policy_t *p, playout_setup_t *s, board_t *b, enum s
 playout_policy_t *
 playout_light_init(char *arg, board_t *b)
 {
-	playout_policy_t *p = calloc2(1, sizeof(*p));
+	playout_policy_t *p = calloc2(1, playout_policy_t);
 	p->choose = playout_light_choose;
 
 	if (arg)

--- a/playout/light.c
+++ b/playout/light.c
@@ -13,16 +13,16 @@
 
 
 coord_t
-playout_light_choose(struct playout_policy *p, struct playout_setup *s, struct board *b, enum stone to_play)
+playout_light_choose(playout_policy_t *p, playout_setup_t *s, board_t *b, enum stone to_play)
 {
 	return pass;
 }
 
 
-struct playout_policy *
-playout_light_init(char *arg, struct board *b)
+playout_policy_t *
+playout_light_init(char *arg, board_t *b)
 {
-	struct playout_policy *p = calloc2(1, sizeof(*p));
+	playout_policy_t *p = calloc2(1, sizeof(*p));
 	p->choose = playout_light_choose;
 
 	if (arg)

--- a/playout/light.h
+++ b/playout/light.h
@@ -1,9 +1,8 @@
 #ifndef PACHI_PLAYOUT_LIGHT_H
 #define PACHI_PLAYOUT_LIGHT_H
 
-struct board;
-struct playout_policy;
+#include "playout.h"
 
-struct playout_policy *playout_light_init(char *arg, struct board *b);
+playout_policy_t *playout_light_init(char *arg, board_t *b);
 
 #endif

--- a/playout/moggy.c
+++ b/playout/moggy.c
@@ -189,7 +189,7 @@ static char moggy_patterns_src[PAT3_N][11] = {
 static inline bool
 test_pattern3_here(playout_policy_t *p, board_t *b, move_t *m, bool middle_ladder, double *gamma)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	/* Check if 3x3 pattern is matched by given move... */
 	char pi = -1;
 	if (!pattern3_move_here(&pp->patterns, b, m, &pi))
@@ -211,7 +211,7 @@ test_pattern3_here(playout_policy_t *p, board_t *b, move_t *m, bool middle_ladde
 static void
 apply_pattern_here(playout_policy_t *p, board_t *b, coord_t c, enum stone color, move_queue_t *q, fixp_t *gammas)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	move_t m2 = move(c, color);
 	double gamma;
 	if (board_is_valid_move(b, &m2) && test_pattern3_here(p, b, &m2, pp->middle_ladder, &gamma)) {
@@ -247,7 +247,7 @@ apply_pattern(playout_policy_t *p, board_t *b, move_t *m, move_t *mm, move_queue
 static void
 joseki_check(playout_policy_t *p, board_t *b, enum stone to_play, move_queue_t *q)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	if (!joseki_dict)
 		return;
 
@@ -268,7 +268,7 @@ global_atari_check(playout_policy_t *p, board_t *b, enum stone to_play, move_que
 	if (b->clen == 0)
 		return;
 
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	if (pp->capcheckall) {
 		for (int g = 0; g < b->clen; g++)
 			group_atari_check(pp->alwaysccaprate, b, group_at(b, group_base(b->c[g])), to_play, q, NULL, pp->middle_ladder, 1<<MQ_GATARI);
@@ -304,7 +304,7 @@ global_atari_check(playout_policy_t *p, board_t *b, enum stone to_play, move_que
 static int
 local_atari_check(playout_policy_t *p, board_t *b, move_t *m, move_queue_t *q)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	int force = false;
 
 	/* Did the opponent play a self-atari? */
@@ -356,7 +356,7 @@ local_ladder_check(playout_policy_t *p, board_t *b, move_t *m, move_queue_t *q)
 static void
 local_2lib_check(playout_policy_t *p, board_t *b, move_t *m, move_queue_t *q)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	group_t group = group_at(b, m->coord), group2 = 0;
 
 	/* Does the opponent have just two liberties? */
@@ -388,7 +388,7 @@ local_2lib_check(playout_policy_t *p, board_t *b, move_t *m, move_queue_t *q)
 static void
 local_2lib_capture_check(playout_policy_t *p, board_t *b, move_t *m, move_queue_t *q)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	group_t group = group_at(b, m->coord), group2 = 0;
 
 	/* Nothing there normally since opponent avoided bad selfatari ... */
@@ -422,7 +422,7 @@ local_2lib_capture_check(playout_policy_t *p, board_t *b, move_t *m, move_queue_
 static void
 local_nlib_check(playout_policy_t *p, board_t *b, move_t *m, move_queue_t *q)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	enum stone color = stone_other(m->color);
 
 	/* Attacking N-liberty groups in general is probably
@@ -578,7 +578,7 @@ eye_fix_check(playout_policy_t *p, board_t *b, move_t *m, enum stone to_play, mo
 static coord_t
 fillboard_check(playout_policy_t *p, board_t *b)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	unsigned int fbtries = b->flen / 8;
 	if (pp->fillboardtries < fbtries)
 		fbtries = pp->fillboardtries;
@@ -601,8 +601,8 @@ next_try:
 static coord_t
 playout_moggy_seqchoose(playout_policy_t *p, playout_setup_t *s, board_t *b, enum stone to_play)
 {
-	moggy_policy_t *pp = p->data;
-	moggy_state_t *ps = b->ps;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
+	moggy_state_t *ps = (moggy_state_t*)b->ps;
 	enum stone other_color = stone_other(to_play);
 
 	if (PLDEBUGL(5))
@@ -726,7 +726,7 @@ playout_moggy_seqchoose(playout_policy_t *p, playout_setup_t *s, board_t *b, enu
 static coord_t
 mq_tagged_choose(playout_policy_t *p, board_t *b, enum stone to_play, move_queue_t *q)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 
 	/* First, merge all entries for a move. */
 	/* We use a naive O(N^2) since the average length of the queue
@@ -782,7 +782,7 @@ mq_tagged_choose(playout_policy_t *p, board_t *b, enum stone to_play, move_queue
 static coord_t
 playout_moggy_fullchoose(playout_policy_t *p, playout_setup_t *s, board_t *b, enum stone to_play)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	move_queue_t q;  mq_init(&q);
 
 	if (PLDEBUGL(5))
@@ -872,7 +872,7 @@ playout_moggy_fullchoose(playout_policy_t *p, playout_setup_t *s, board_t *b, en
 static void
 playout_moggy_assess_group(playout_policy_t *p, prior_map_t *map, group_t g, int games)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	board_t *b = map->b;
 	move_queue_t q;  mq_init(&q);
 
@@ -970,7 +970,7 @@ playout_moggy_assess_group(playout_policy_t *p, prior_map_t *map, group_t g, int
 static void
 playout_moggy_assess_one(playout_policy_t *p, prior_map_t *map, coord_t coord, int games)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 	board_t *b = map->b;
 
 	if (PLDEBUGL(5)) {
@@ -1015,7 +1015,7 @@ playout_moggy_assess_one(playout_policy_t *p, prior_map_t *map, coord_t coord, i
 static void
 playout_moggy_assess(playout_policy_t *p, prior_map_t *map, int games)
 {
-	moggy_policy_t *pp = p->data;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
 
 	/* First, go through all endangered groups. */
 	for (group_t g = 1; g < board_size2(map->b); g++)
@@ -1043,8 +1043,8 @@ playout_moggy_assess(playout_policy_t *p, prior_map_t *map, int games)
 static bool
 playout_moggy_permit(playout_policy_t *p, board_t *b, move_t *m, bool alt, bool random_move)
 {
-	moggy_policy_t *pp = p->data;
-	moggy_state_t *ps = b->ps;
+	moggy_policy_t *pp = (moggy_policy_t*)p->data;
+	moggy_state_t *ps = (moggy_state_t*)b->ps;
 
 	/* The idea is simple for now - never allow bad self-atari moves.
 	 * They suck in general, but this also permits us to actually
@@ -1080,6 +1080,8 @@ playout_moggy_permit(playout_policy_t *p, board_t *b, move_t *m, bool alt, bool 
 			fprintf(stderr, "skipping eyefill test\n");
 		goto eyefill_skip;
 	}
+
+	{
 	bool eyefill = board_is_eyelike(b, m->coord, m->color);
 	/* If saving a group in atari don't interfere ! */
 	if (eyefill && !board_get_atari_neighbor(b, m->coord, m->color)) {
@@ -1108,6 +1110,7 @@ playout_moggy_permit(playout_policy_t *p, board_t *b, move_t *m, bool alt, bool 
 				break;
 			}
 		} foreach_diag_neighbor_end;
+	}
 	}
 
 eyefill_skip:

--- a/playout/moggy.c
+++ b/playout/moggy.c
@@ -202,7 +202,7 @@ test_pattern3_here(struct playout_policy *p, struct board *b, struct move *m, bo
 	if (atari_neighbor && is_ladder(b, atari_neighbor, middle_ladder)
 	    && !can_countercapture(b, atari_neighbor, NULL, 0))
 		return false;
-	//fprintf(stderr, "%s: %d (%.3f)\n", coord2sstr(m->coord, b), (int) pi, pp->pat3_gammas[(int) pi]);
+	//fprintf(stderr, "%s: %d (%.3f)\n", coord2sstr(m->coord), (int) pi, pp->pat3_gammas[(int) pi]);
 	if (gamma)
 		*gamma = pp->pat3_gammas[(int) pi];
 	return true;
@@ -233,14 +233,14 @@ apply_pattern(struct playout_policy *p, struct board *b, struct move *m, struct 
 
 	if (mm) { /* Second move for pattern searching */
 		foreach_8neighbor(b, mm->coord) {
-			if (coord_is_8adjecent(m->coord, c, b))
+			if (coord_is_8adjecent(m->coord, c))
 				continue;
 			apply_pattern_here(p, b, c, stone_other(m->color), q, gammas);
 		} foreach_8neighbor_end;
 	}
 
 	if (PLDEBUGL(5))
-		mq_gamma_print(q, gammas, b, "Pattern");
+		mq_gamma_print(q, gammas, "Pattern");
 }
 
 #ifdef MOGGY_JOSEKI
@@ -258,7 +258,7 @@ joseki_check(struct playout_policy *p, struct board *b, enum stone to_play, stru
 	} foreach_joseki_move_end;
 
 	if (q->moves > 0 && PLDEBUGL(5))
-		mq_print(q, b, "Joseki");
+		mq_print(q, "Joseki");
 }
 #endif /* MOGGY_JOSEKI */
 
@@ -273,7 +273,7 @@ global_atari_check(struct playout_policy *p, struct board *b, enum stone to_play
 		for (int g = 0; g < b->clen; g++)
 			group_atari_check(pp->alwaysccaprate, b, group_at(b, group_base(b->c[g])), to_play, q, NULL, pp->middle_ladder, 1<<MQ_GATARI);
 		if (PLDEBUGL(5))
-			mq_print(q, b, "Global atari");
+			mq_print(q, "Global atari");
 		if (pp->fullchoose)
 			return;
 	}
@@ -284,7 +284,7 @@ global_atari_check(struct playout_policy *p, struct board *b, enum stone to_play
 		if (q->moves > 0) {
 			/* XXX: Try carrying on. */
 			if (PLDEBUGL(5))
-				mq_print(q, b, "Global atari");
+				mq_print(q, "Global atari");
 			if (pp->fullchoose)
 				return;
 		}
@@ -294,7 +294,7 @@ global_atari_check(struct playout_policy *p, struct board *b, enum stone to_play
 		if (q->moves > 0) {
 			/* XXX: Try carrying on. */
 			if (PLDEBUGL(5))
-				mq_print(q, b, "Global atari");
+				mq_print(q, "Global atari");
 			if (pp->fullchoose)
 				return;
 		}
@@ -328,7 +328,7 @@ local_atari_check(struct playout_policy *p, struct board *b, struct move *m, str
 	});
 
 	if (PLDEBUGL(5))
-		mq_print(q, b, "Local atari");
+		mq_print(q, "Local atari");
 
 	return (force || pp->lcapturerate > fast_random(100));
 }
@@ -349,7 +349,7 @@ local_ladder_check(struct playout_policy *p, struct board *b, struct move *m, st
 	}
 
 	if (q->moves > 0 && PLDEBUGL(5))
-		mq_print(q, b, "Ladder");
+		mq_print(q, "Ladder");
 }
 
 
@@ -382,7 +382,7 @@ local_2lib_check(struct playout_policy *p, struct board *b, struct move *m, stru
 	});
 
 	if (PLDEBUGL(5))
-		mq_print(q, b, "Local 2lib");
+		mq_print(q, "Local 2lib");
 }
 
 static void
@@ -416,7 +416,7 @@ local_2lib_capture_check(struct playout_policy *p, struct board *b, struct move 
 	});
 
 	if (PLDEBUGL(5))
-		mq_print(q, b, "Local 2lib capture");
+		mq_print(q, "Local 2lib capture");
 }
 
 static void
@@ -465,7 +465,7 @@ local_nlib_check(struct playout_policy *p, struct board *b, struct move *m, stru
 	} foreach_8neighbor_end;
 
 	if (PLDEBUGL(5))
-		mq_print(q, b, "Local nlib");
+		mq_print(q, "Local nlib");
 }
 
 static coord_t
@@ -479,7 +479,7 @@ nakade_check(struct playout_policy *p, struct board *b, struct move *m, enum sto
 			empty = c;
 			continue;
 		}
-		if (!coord_is_8adjecent(c, empty, b)) {
+		if (!coord_is_8adjecent(c, empty)) {
 			/* Seems like impossible nakade
 			 * shape! */
 			return pass;
@@ -489,7 +489,7 @@ nakade_check(struct playout_policy *p, struct board *b, struct move *m, enum sto
 
 	coord_t nakade = nakade_point(b, empty, stone_other(to_play));
 	if (PLDEBUGL(5) && !is_pass(nakade))
-		fprintf(stderr, "Nakade: %s\n", coord2sstr(nakade, b));
+		fprintf(stderr, "Nakade: %s\n", coord2sstr(nakade));
 	return nakade;
 }
 
@@ -524,7 +524,7 @@ eye_fix_check(struct playout_policy *p, struct board *b, struct move *m, enum st
 
 		/* The last move must have a pair of unfriendly diagonal
 		 * neighbors separated by a friendly stone. */
-		//fprintf(stderr, "inv. %s(%s)-%s(%s)-%s(%s), imm. libcount %d\n", coord2sstr(c0, b), stone2str(board_at(b, c0)), coord2sstr(c1, b), stone2str(board_at(b, c1)), coord2sstr(c2, b), stone2str(board_at(b, c2)), immediate_liberty_count(b, c1));
+		//fprintf(stderr, "inv. %s(%s)-%s(%s)-%s(%s), imm. libcount %d\n", coord2sstr(c0), stone2str(board_at(b, c0)), coord2sstr(c1), stone2str(board_at(b, c1)), coord2sstr(c2), stone2str(board_at(b, c2)), immediate_liberty_count(b, c1));
 		if ((board_at(b, c0) == to_play || board_at(b, c0) == S_OFFBOARD)
 		    && board_at(b, c1) == m->color
 		    && (board_at(b, c2) == to_play || board_at(b, c2) == S_OFFBOARD)
@@ -572,7 +572,7 @@ eye_fix_check(struct playout_policy *p, struct board *b, struct move *m, enum st
 	}
 
 	if (q->moves > 0 && PLDEBUGL(5))
-		mq_print(q, b, "Eye fix");
+		mq_print(q, "Eye fix");
 }
 
 static coord_t
@@ -750,7 +750,7 @@ mq_tagged_choose(struct playout_policy *p, struct board *b, enum stone to_play, 
 		assert(q->tag[i] != 0);
 		for (int j = 0; j < MQ_MAX; j++)
 			if (q->tag[i] & (1<<j)) {
-				//fprintf(stderr, "%s(%x) %d %f *= %f\n", coord2sstr(q->move[i], b), q->tag[i], j, val, pp->mq_prob[j]);
+				//fprintf(stderr, "%s(%x) %d %f *= %f\n", coord2sstr(q->move[i]), q->tag[i], j, val, pp->mq_prob[j]);
 				val *= pp->mq_prob[j];
 			}
 		pd[i] = double_to_fixp(val);
@@ -763,12 +763,12 @@ mq_tagged_choose(struct playout_policy *p, struct board *b, enum stone to_play, 
 	if (PLDEBUGL(5)) {
 		fprintf(stderr, "Pick (total %.3f stab %.3f): ", fixp_to_double(total), fixp_to_double(stab));
 		for (unsigned int i = 0; i < q->moves; i++) {
-			fprintf(stderr, "%s(%x:%.3f) ", coord2sstr(q->move[i], b), q->tag[i], fixp_to_double(pd[i]));
+			fprintf(stderr, "%s(%x:%.3f) ", coord2sstr(q->move[i]), q->tag[i], fixp_to_double(pd[i]));
 		}
 		fprintf(stderr, "\n");
 	}
 	for (unsigned int i = 0; i < q->moves; i++) {
-		//fprintf(stderr, "%s(%x) %f (%f/%f)\n", coord2sstr(q->move[i], b), q->tag[i], fixp_to_double(stab), fixp_to_double(pd[i]), fixp_to_double(total));
+		//fprintf(stderr, "%s(%x) %f (%f/%f)\n", coord2sstr(q->move[i]), q->tag[i], fixp_to_double(stab), fixp_to_double(pd[i]), fixp_to_double(total));
 		if (stab < pd[i])
 			return q->move[i];
 		stab -= pd[i];
@@ -851,7 +851,7 @@ playout_moggy_fullchoose(struct playout_policy *p, struct playout_setup *s, stru
 	/* Average length of the queue is 1.4 move. */
 	printf("MQL %d ", q.moves);
 	for (unsigned int i = 0; i < q.moves; i++)
-		printf("%s ", coord2sstr(q.move[i], b));
+		printf("%s ", coord2sstr(q.move[i]));
 	printf("\n");
 #endif
 
@@ -880,7 +880,7 @@ playout_moggy_assess_group(struct playout_policy *p, struct prior_map *map, grou
 		return;
 
 	if (PLDEBUGL(5)) {
-		fprintf(stderr, "ASSESS of group %s:\n", coord2sstr(g, b));
+		fprintf(stderr, "ASSESS of group %s:\n", coord2sstr(g));
 		board_print(b, stderr);
 	}
 
@@ -893,7 +893,7 @@ playout_moggy_assess_group(struct playout_policy *p, struct prior_map *map, grou
 		while (q.moves--) {
 			coord_t coord = q.move[q.moves];
 			if (PLDEBUGL(5))
-				fprintf(stderr, "1.0: nlib %s\n", coord2sstr(coord, b));
+				fprintf(stderr, "1.0: nlib %s\n", coord2sstr(coord));
 			int assess = games / 2;
 			add_prior_value(map, coord, 1, assess);
 		}
@@ -921,7 +921,7 @@ playout_moggy_assess_group(struct playout_policy *p, struct prior_map *map, grou
 		while (q.moves--) {
 			coord_t coord = q.move[q.moves];
 			if (PLDEBUGL(5))
-				fprintf(stderr, "1.0: 2lib %s\n", coord2sstr(coord, b));
+				fprintf(stderr, "1.0: 2lib %s\n", coord2sstr(coord));
 			int assess = games / 2;
 			add_prior_value(map, coord, 1, assess);
 		}
@@ -948,7 +948,7 @@ playout_moggy_assess_group(struct playout_policy *p, struct prior_map *map, grou
 			/* FIXME: We give the malus even if this move
 			 * captures another group. */
 			if (PLDEBUGL(5))
-				fprintf(stderr, "0.0: ladder %s\n", coord2sstr(coord, b));
+				fprintf(stderr, "0.0: ladder %s\n", coord2sstr(coord));
 			add_prior_value(map, coord, 0, games);
 			continue;
 		}
@@ -962,7 +962,7 @@ playout_moggy_assess_group(struct playout_policy *p, struct prior_map *map, grou
 			assess += (stones > 0 ? stones : 0) * games * 100 / pp->cap_stone_denom;
 		}
 		if (PLDEBUGL(5))
-			fprintf(stderr, "1.0 (%d): atari %s\n", assess, coord2sstr(coord, b));
+			fprintf(stderr, "1.0 (%d): atari %s\n", assess, coord2sstr(coord));
 		add_prior_value(map, coord, 1, assess);
 	}
 }
@@ -974,7 +974,7 @@ playout_moggy_assess_one(struct playout_policy *p, struct prior_map *map, coord_
 	struct board *b = map->b;
 
 	if (PLDEBUGL(5)) {
-		fprintf(stderr, "ASSESS of move %s:\n", coord2sstr(coord, b));
+		fprintf(stderr, "ASSESS of move %s:\n", coord2sstr(coord));
 		board_print(b, stderr);
 	}
 
@@ -992,7 +992,7 @@ playout_moggy_assess_one(struct playout_policy *p, struct prior_map *map, coord_
 			if (is_pass(coord))
 				return;
 			if (PLDEBUGL(5))
-				fprintf(stderr, "1.0: self-atari redirect %s\n", coord2sstr(coord, b));
+				fprintf(stderr, "1.0: self-atari redirect %s\n", coord2sstr(coord));
 			add_prior_value(map, coord, 1.0, games);
 			return;
 		}
@@ -1056,7 +1056,7 @@ playout_moggy_permit(struct playout_policy *p, struct board *b, struct move *m, 
 	if (bad_selfatari) {
 		if (PLDEBUGL(5))
 			fprintf(stderr, "__ Prohibiting self-atari %s %s\n",
-				stone2str(m->color), coord2sstr(m->coord, b));
+				stone2str(m->color), coord2sstr(m->coord));
 		if (alt && pp->selfatari_other) {
 			ps->last_selfatari[m->color] = m->coord;
 			/* Ok, try the other liberty of the atari'd group. */
@@ -1064,7 +1064,7 @@ playout_moggy_permit(struct playout_policy *p, struct board *b, struct move *m, 
 			if (!permit_move(c)) return false;
 			if (PLDEBUGL(5))
 				fprintf(stderr, "___ Redirecting to other lib %s\n",
-					coord2sstr(c, b));
+					coord2sstr(c));
 			m->coord = c;
 			return true;
 		}
@@ -1092,7 +1092,7 @@ playout_moggy_permit(struct playout_policy *p, struct board *b, struct move *m, 
 				if (permit_move(c)) {
 					if (PLDEBUGL(5))
 						fprintf(stderr, "___ Redirecting to capture %s\n",
-							coord2sstr(c, b));
+							coord2sstr(c));
 					m->coord = c;
 					return true;
 				}

--- a/playout/moggy.c
+++ b/playout/moggy.c
@@ -1128,7 +1128,7 @@ playout_moggy_setboard(playout_policy_t *playout_policy, board_t *b)
 {
 	if (b->ps)
 		return;
-	moggy_state_t *ps = malloc2(sizeof(moggy_state_t));
+	moggy_state_t *ps = malloc2(moggy_state_t);
 	ps->last_selfatari[S_BLACK] = ps->last_selfatari[S_WHITE] = 0;
 	b->ps = ps;
 }
@@ -1136,8 +1136,8 @@ playout_moggy_setboard(playout_policy_t *playout_policy, board_t *b)
 playout_policy_t *
 playout_moggy_init(char *arg, board_t *b)
 {
-	playout_policy_t *p = calloc2(1, sizeof(*p));
-	moggy_policy_t *pp = calloc2(1, sizeof(*pp));
+	playout_policy_t *p = calloc2(1, playout_policy_t);
+	moggy_policy_t *pp = calloc2(1, moggy_policy_t);
 	p->data = pp;
 	p->setboard = playout_moggy_setboard;
 	p->setboard_randomok = true;

--- a/playout/moggy.h
+++ b/playout/moggy.h
@@ -1,9 +1,8 @@
 #ifndef PACHI_PLAYOUT_MOGGY_H
 #define PACHI_PLAYOUT_MOGGY_H
 
-struct board;
-struct playout_policy;
+#include "playout.h"
 
-struct playout_policy *playout_moggy_init(char *arg, struct board *b);
+struct playout_policy *playout_moggy_init(char *arg, board_t *b);
 
 #endif

--- a/probdist.c
+++ b/probdist.c
@@ -22,7 +22,7 @@ probdist_pick(struct probdist *restrict pd, coord_t *restrict ignore)
 	coord_t c = board_size(pd->b) + 1;
 	while (stab > pd->rowtotals[r]) {
 		if (DEBUGL(6))
-			fprintf(stderr, "[%s] skipping row %f (%f)\n", coord2sstr(c, pd->b), fixp_to_double(pd->rowtotals[r]), fixp_to_double(stab));
+			fprintf(stderr, "[%s] skipping row %f (%f)\n", coord2sstr(c), fixp_to_double(pd->rowtotals[r]), fixp_to_double(stab));
 
 		stab -= pd->rowtotals[r];
 		r++; assert(r < board_size(pd->b));
@@ -34,7 +34,7 @@ probdist_pick(struct probdist *restrict pd, coord_t *restrict ignore)
 
 	for (; c < board_size2(pd->b); c++) {
 		if (DEBUGL(6))
-			fprintf(stderr, "[%s] %f (%f)\n", coord2sstr(c, pd->b), fixp_to_double(pd->items[c]), fixp_to_double(stab));
+			fprintf(stderr, "[%s] %f (%f)\n", coord2sstr(c), fixp_to_double(pd->items[c]), fixp_to_double(stab));
 
 		assert(is_pass(*ignore) || c <= *ignore);
 		if (c == *ignore) {

--- a/probdist.c
+++ b/probdist.c
@@ -6,12 +6,12 @@
 //#define DEBUG
 #include "debug.h"
 #include "move.h"
-#include "probdist.h"
 #include "random.h"
 #include "board.h"
+#include "probdist.h"
 
 coord_t
-probdist_pick(struct probdist *restrict pd, coord_t *restrict ignore)
+probdist_pick(probdist_t *restrict pd, coord_t *restrict ignore)
 {
 	fixp_t total = probdist_total(pd);
 	fixp_t stab = fast_irandom(total);

--- a/probdist.h
+++ b/probdist.h
@@ -65,7 +65,7 @@ probdist_set(struct probdist *pd, coord_t c, fixp_t val)
 	assert(val >= 0);
 #endif
 	pd->total += val - pd->items[c];
-	pd->rowtotals[coord_y(c, pd->b)] += val - pd->items[c];
+	pd->rowtotals[coord_y(c)] += val - pd->items[c];
 	pd->items[c] = val;
 }
 
@@ -73,7 +73,7 @@ static inline void
 probdist_mute(struct probdist *pd, coord_t c)
 {
 	pd->total -= pd->items[c];
-	pd->rowtotals[coord_y(c, pd->b)] -= pd->items[c];
+	pd->rowtotals[coord_y(c)] -= pd->items[c];
 }
 
 #endif

--- a/probdist.h
+++ b/probdist.h
@@ -28,7 +28,7 @@ struct probdist {
 #define probdist_alloca(pd_, b_) \
 	fixp_t pd_ ## __pdi[board_size2(b_)] __attribute__((aligned(32))); memset(pd_ ## __pdi, 0, sizeof(pd_ ## __pdi)); \
 	fixp_t pd_ ## __pdr[board_size(b_)] __attribute__((aligned(32))); memset(pd_ ## __pdr, 0, sizeof(pd_ ## __pdr)); \
-	struct probdist pd_ = { .b = b_, .items = pd_ ## __pdi, .rowtotals = pd_ ## __pdr, .total = 0 };
+	struct probdist pd_ = { b_, pd_ ## __pdi, pd_ ## __pdr, 0 };
 
 /* Get the value of given item. */
 #define probdist_one(pd, c) ((pd)->items[c])

--- a/probdist.h
+++ b/probdist.h
@@ -11,17 +11,15 @@
 #include "move.h"
 #include "util.h"
 
-struct board;
-
 /* The interface looks a bit funny-wrapped since we used to switch
  * between different probdist representations. */
 
-struct probdist {
-	struct board *b;
+typedef struct {
+	board_t *b;
 	fixp_t *items; // [bsize2], [i] = P(pick==i)
 	fixp_t *rowtotals; // [bsize], [i] = sum of items in row i
 	fixp_t total; // sum of all items
-};
+} probdist_t;
 
 
 /* Declare pd_ corresponding to board b_ in the local scope. */
@@ -37,16 +35,16 @@ struct probdist {
 #define probdist_total(pd) ((pd)->total)
 
 /* Set the value of given item. */
-static void probdist_set(struct probdist *pd, coord_t c, fixp_t val);
+static void probdist_set(probdist_t *pd, coord_t c, fixp_t val);
 
 /* Remove the item from the totals; this is used when you then
  * pass it in the ignore list to probdist_pick(). Of course you
  * must restore the totals afterwards. */
-static void probdist_mute(struct probdist *pd, coord_t c);
+static void probdist_mute(probdist_t *pd, coord_t c);
 
 /* Pick a random item. ignore is a pass-terminated sorted array of items
  * that are not to be considered (and whose values are not in @total). */
-coord_t probdist_pick(struct probdist *pd, coord_t *ignore);
+coord_t probdist_pick(probdist_t *pd, coord_t *ignore);
 
 
 /* Now, we do something horrible - include board.h for the inline helpers.
@@ -55,7 +53,7 @@ coord_t probdist_pick(struct probdist *pd, coord_t *ignore);
 
 
 static inline void
-probdist_set(struct probdist *pd, coord_t c, fixp_t val)
+probdist_set(probdist_t *pd, coord_t c, fixp_t val)
 {
 	/* We disable the assertions here since this is quite time-critical
 	 * part of code, and also the compiler is reluctant to inline the
@@ -70,7 +68,7 @@ probdist_set(struct probdist *pd, coord_t c, fixp_t val)
 }
 
 static inline void
-probdist_mute(struct probdist *pd, coord_t c)
+probdist_mute(probdist_t *pd, coord_t c)
 {
 	pd->total -= pd->items[c];
 	pd->rowtotals[coord_y(c)] -= pd->items[c];

--- a/stats.h
+++ b/stats.h
@@ -14,6 +14,8 @@ struct move_stats {
 	int playouts; // # of playouts
 };
 
+#define move_stats(value, playouts)  { value, playouts }
+
 /* Add a result to the stats. */
 static void stats_add_result(struct move_stats *s, floating_t result, int playouts);
 

--- a/stats.h
+++ b/stats.h
@@ -9,24 +9,24 @@
  * What this means in practice is that perhaps the value will get
  * slightly wrong, but not drastically corrupted. */
 
-struct move_stats {
+typedef struct {
 	floating_t value; // BLACK wins/playouts
 	int playouts; // # of playouts
-};
+} move_stats_t;
 
 #define move_stats(value, playouts)  { value, playouts }
 
 /* Add a result to the stats. */
-static void stats_add_result(struct move_stats *s, floating_t result, int playouts);
+static void stats_add_result(move_stats_t *s, floating_t result, int playouts);
 
 /* Remove a result from the stats. */
-static void stats_rm_result(struct move_stats *s, floating_t result, int playouts);
+static void stats_rm_result(move_stats_t *s, floating_t result, int playouts);
 
 /* Merge two stats together. THIS IS NOT ATOMIC! */
-static void stats_merge(struct move_stats *dest, struct move_stats *src);
+static void stats_merge(move_stats_t *dest, move_stats_t *src);
 
 /* Reverse stats parity. */
-static void stats_reverse_parity(struct move_stats *s);
+static void stats_reverse_parity(move_stats_t *s);
 
 
 /* We actually do the atomicity in a pretty hackish way - we simply
@@ -39,7 +39,7 @@ static void stats_reverse_parity(struct move_stats *s);
  * current s->playouts is zero. */
 
 static inline void
-stats_add_result(struct move_stats *s, floating_t result, int playouts)
+stats_add_result(move_stats_t *s, floating_t result, int playouts)
 {
 	int s_playouts = s->playouts;
 	floating_t s_value = s->value;
@@ -57,7 +57,7 @@ stats_add_result(struct move_stats *s, floating_t result, int playouts)
 }
 
 static inline void
-stats_rm_result(struct move_stats *s, floating_t result, int playouts)
+stats_rm_result(move_stats_t *s, floating_t result, int playouts)
 {
 	if (s->playouts > playouts) {
 		int s_playouts = s->playouts;
@@ -85,7 +85,7 @@ stats_rm_result(struct move_stats *s, floating_t result, int playouts)
 }
 
 static inline void
-stats_merge(struct move_stats *dest, struct move_stats *src)
+stats_merge(move_stats_t *dest, move_stats_t *src)
 {
 	/* In a sense, this is non-atomic version of stats_add_result(). */
 	if (src->playouts) {
@@ -95,7 +95,7 @@ stats_merge(struct move_stats *dest, struct move_stats *src)
 }
 
 static inline void
-stats_reverse_parity(struct move_stats *s)
+stats_reverse_parity(move_stats_t *s)
 {
 	s->value = 1 - s->value;
 }

--- a/t-predict/predict.c
+++ b/t-predict/predict.c
@@ -58,7 +58,7 @@ avg_dev_diagram(char *diag, int len, float avg, float dev, float prob_max)
 
 
 static void
-collect_move_stats(struct board *b, struct move *m, coord_t *best_c, int *guessed_move, int *total_move)
+collect_move_stats(board_t *b, move_t *m, coord_t *best_c, int *guessed_move, int *total_move)
 {
 	int i = MIN(b->moves/10, PREDICT_MOVE_MAX/10 - 1);
 	if (m->coord == best_c[0])
@@ -67,7 +67,7 @@ collect_move_stats(struct board *b, struct move *m, coord_t *best_c, int *guesse
 }
 
 static void
-collect_prob_stats(struct move *m, coord_t *best_c, float *best_r, int *guessed_by_prob, int *total_by_prob)
+collect_prob_stats(move_t *m, coord_t *best_c, float *best_r, int *guessed_by_prob, int *total_by_prob)
 {
 	for (int k = 0; k < PREDICT_TOPN; k++) {
 		int i = best_r[k] * 10;
@@ -80,7 +80,7 @@ collect_prob_stats(struct move *m, coord_t *best_c, float *best_r, int *guessed_
 }
 
 static void
-collect_topn_stats(struct move *m, coord_t *best_c, int *guessed_top)
+collect_topn_stats(move_t *m, coord_t *best_c, int *guessed_top)
 {
 	int k; /* Correct move is kth guess */
 	for (k = 0; k < PREDICT_TOPN; k++)
@@ -211,7 +211,7 @@ print_prob_stats(strbuf_t *buf, int *guessed_by_prob, int *total_by_prob)
 
 
 static char *
-predict_stats(struct board *b, struct move *m, coord_t *best_c, float *best_r, int games)
+predict_stats(board_t *b, move_t *m, coord_t *best_c, float *best_r, int games)
 {
 	static int total_ = 0;
 	int total = ++total_;
@@ -262,7 +262,7 @@ predict_stats(struct board *b, struct move *m, coord_t *best_c, float *best_r, i
 }
 
 char *
-predict_move(struct board *b, struct engine *e, struct time_info *ti, struct move *m, int games)
+predict_move(board_t *b, engine_t *e, time_info_t *ti, move_t *m, int games)
 {
 	enum stone color = m->color;
 	
@@ -280,7 +280,7 @@ predict_move(struct board *b, struct engine *e, struct time_info *ti, struct mov
 	coord_t best_c[PREDICT_TOPN];
 	for (int i = 0; i < PREDICT_TOPN; i++)
 		best_c[i] = pass;
-	struct time_info *ti_genmove = time_info_genmove(b, ti, color);
+	time_info_t *ti_genmove = time_info_genmove(b, ti, color);
 	engine_best_moves(e, b, ti_genmove, color, best_c, best_r, PREDICT_TOPN);
 	//print_dcnn_best_moves(b, best_c, best_r, PREDICT_TOPN);
 

--- a/t-predict/predict.c
+++ b/t-predict/predict.c
@@ -271,10 +271,8 @@ predict_move(struct board *b, struct engine *e, struct time_info *ti, struct mov
 		return NULL;
 	}
 
-	if (DEBUGL(5))
-		fprintf(stderr, "predict move %d,%d,%d\n", m->color, coord_x(m->coord, b), coord_y(m->coord, b));
-	if (DEBUGL(1) && debug_boardprint)
-		engine_board_print(e, b, stderr);
+	if (DEBUGL(5))  fprintf(stderr, "predict move %d,%d,%d\n", m->color, coord_x(m->coord), coord_y(m->coord));
+	if (DEBUGL(1) && debug_boardprint)  engine_board_print(e, b, stderr);
 
 	// Not bothering with timer here for now.
 
@@ -288,15 +286,15 @@ predict_move(struct board *b, struct engine *e, struct time_info *ti, struct mov
 
 	// Play correct expected move
 	if (board_play(b, m) < 0)
-		die("ILLEGAL EXPECTED MOVE: [%s, %s]\n", coord2sstr(m->coord, b), stone2str(m->color));
+		die("ILLEGAL EXPECTED MOVE: [%s, %s]\n", coord2sstr(m->coord), stone2str(m->color));
 
-	fprintf(stderr, "WINNER is %s in the actual game.\n", coord2sstr(m->coord, b));		
+	fprintf(stderr, "WINNER is %s in the actual game.\n", coord2sstr(m->coord));
 	if (best_c[0] == m->coord)
 		fprintf(stderr, "Move %3i: Predict: Correctly predicted %s %s\n", b->moves,
-			(color == S_BLACK ? "b" : "w"), coord2sstr(best_c[0], b));
+			(color == S_BLACK ? "b" : "w"), coord2sstr(best_c[0]));
 	else
 		fprintf(stderr, "Move %3i: Predict: Wrong prediction: %s %s != %s\n", b->moves,
-			(color == S_BLACK ? "b" : "w"), coord2sstr(best_c[0], b), coord2sstr(m->coord, b));
+			(color == S_BLACK ? "b" : "w"), coord2sstr(best_c[0]), coord2sstr(m->coord));
 
 	if (DEBUGL(1) && debug_boardprint)
 		engine_board_print(e, b, stderr);

--- a/t-predict/predict.h
+++ b/t-predict/predict.h
@@ -3,6 +3,6 @@
 
 /* See if engine guesses move m, and return stats string from time to time.
  * Returned string must be freed */
-char *predict_move(struct board *b, struct engine *e, struct time_info *ti, struct move *m, int games);
+char *predict_move(board_t *b, engine_t *e, time_info_t *ti, move_t *m, int games);
 
 #endif

--- a/t-unit/board_regtest.c
+++ b/t-unit/board_regtest.c
@@ -187,7 +187,7 @@ static void
 print_move(struct board *b, struct move *m)
 {
 	if (m->color == S_NONE)  printf("%7s", "");
-	else printf("%1.1s %-4s ", stone2str(m->color), coord2sstr(m->coord, b));
+	else printf("%1.1s %-4s ", stone2str(m->color), coord2sstr(m->coord));
 }
 
 static void
@@ -208,7 +208,7 @@ dump_board(struct board *b)
 	printf("cap %-2i %-2i ", b->captures[S_BLACK], b->captures[S_WHITE]);
 
 	if (is_pass(b->ko.coord))  printf("%7s", "");
-	else                       printf("ko %-3s ", coord2sstr(b->ko.coord, b));
+	else                       printf("ko %-3s ", coord2sstr(b->ko.coord));
 
 #ifdef CHECK_KO_AGE
 	if (b->last_ko_age)  printf("ko_age %-3i ", b->last_ko_age);

--- a/t-unit/board_regtest.c
+++ b/t-unit/board_regtest.c
@@ -39,10 +39,10 @@
 #define hash_final(md)     do {  r = SHA1_Final(md, &ctx);  assert(r);  } while(0)
 
 
-static void print_board_flags(struct board *b);
+static void print_board_flags(board_t *b);
 
 static unsigned char*
-hash_board_statics(struct board *b)
+hash_board_statics(board_t *b)
 {
 	hash_init();
 
@@ -64,7 +64,7 @@ hash_board_statics(struct board *b)
 }
 
 static unsigned char*
-hash_board(struct board *b)
+hash_board(board_t *b)
 {
 	hash_init();
 
@@ -164,7 +164,7 @@ hash_board(struct board *b)
 }
 
 static void
-dump_board_statics(struct board *b)
+dump_board_statics(board_t *b)
 {
 	int size = real_board_size(b);
 
@@ -184,14 +184,14 @@ dump_board_statics(struct board *b)
 }
 
 static void
-print_move(struct board *b, struct move *m)
+print_move(board_t *b, move_t *m)
 {
 	if (m->color == S_NONE)  printf("%7s", "");
 	else printf("%1.1s %-4s ", stone2str(m->color), coord2sstr(m->coord));
 }
 
 static void
-dump_board(struct board *b)
+dump_board(board_t *b)
 {
 	if (b->last_move.color == S_NONE)
 		dump_board_statics(b);
@@ -229,7 +229,7 @@ dump_board(struct board *b)
 }
 
 static void
-print_board_flags(struct board *b)
+print_board_flags(board_t *b)
 {
 	static int shown = 0;
 	if (shown++) return;
@@ -262,15 +262,15 @@ print_board_flags(struct board *b)
 
 /* Replay games dumping board state hashes at every move. */
 bool
-board_regression_test(struct board *b, char *arg)
+board_regression_test(board_t *b, char *arg)
 {
-	struct time_info ti[S_MAX];
+	time_info_t ti[S_MAX];
 	ti[S_BLACK] = ti_none;
 	ti[S_WHITE] = ti_none;
 
 	gtp_t gtp;  gtp_init(&gtp);
 	char buf[4096];
-	struct engine e;  memset(&e, 0, sizeof(e));  /* dummy engine */
+	engine_t e;  memset(&e, 0, sizeof(e));  /* dummy engine */
 	while (fgets(buf, 4096, stdin)) {
 		if (buf[0] == '#') continue;
 		//if (!strncmp(buf, "clear_board", 11))  printf("\nGame %i:\n", gtp.played_games + 1);

--- a/t-unit/board_regtest.c
+++ b/t-unit/board_regtest.c
@@ -264,8 +264,9 @@ print_board_flags(struct board *b)
 bool
 board_regression_test(struct board *b, char *arg)
 {
-	struct time_info ti_default = { .period = TT_NULL };
-	struct time_info ti[S_MAX] = { [S_BLACK] = ti_default, [S_WHITE] = ti_default };
+	struct time_info ti[S_MAX];
+	ti[S_BLACK] = ti_none;
+	ti[S_WHITE] = ti_none;
 
 	gtp_t gtp;  gtp_init(&gtp);
 	char buf[4096];

--- a/t-unit/moggy_regtest.c
+++ b/t-unit/moggy_regtest.c
@@ -20,7 +20,7 @@ play_game(struct playout_setup *setup,
 	int passes = 0;
 	for (int gamelen = setup->gamelen; gamelen-- > 0 && passes < 2; ) {
 		coord_t coord = playout_play_move(setup, b, color, policy);
-		fprintf(stderr, "move %-3i %1.1s %s\n", b->moves, stone2str(color), coord2sstr(coord, b));
+		fprintf(stderr, "move %-3i %1.1s %s\n", b->moves, stone2str(color), coord2sstr(coord));
 		if (is_pass(coord)) passes++;  else passes = 0;
 		color = stone_other(color);
 	}	

--- a/t-unit/moggy_regtest.c
+++ b/t-unit/moggy_regtest.c
@@ -11,9 +11,9 @@
 #include "playout/moggy.h"
 
 static void
-play_game(struct playout_setup *setup,
-	  struct board *b, enum stone color,
-	  struct playout_policy *policy)
+play_game(playout_setup_t *setup,
+	  board_t *b, enum stone color,
+	  playout_policy_t *policy)
 {
 	if (policy->setboard)  policy->setboard(policy, b);
 	
@@ -28,7 +28,7 @@ play_game(struct playout_setup *setup,
 
 /* Play some predictable moggy games dumping every move. */
 bool
-moggy_regression_test(struct board *board, char *arg)
+moggy_regression_test(board_t *board, char *arg)
 {
 	int games = 10;
 	fast_srandom(0x12345);
@@ -36,13 +36,13 @@ moggy_regression_test(struct board *board, char *arg)
 	if (DEBUGL(2))  board_print(board, stderr);
 	if (DEBUGL(1))  printf("moggy regression test.   Playing %i games\n", games);
 
-	struct playout_policy *policy = playout_moggy_init(NULL, board);
-	struct playout_setup setup = { .gamelen = MAX_GAMELEN };
+	playout_policy_t *policy = playout_moggy_init(NULL, board);
+	playout_setup_t setup = { .gamelen = MAX_GAMELEN };
 	
 	/* Play some games */
 	for (int i = 0; i < games; i++)  {
 		enum stone color = S_BLACK;
-		struct board b;
+		board_t b;
 		board_copy(&b, board);
 		fprintf(stderr, "game %i:\n", i+1);
 		play_game(&setup, &b, color, policy);

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -94,7 +94,7 @@ set_handicap(struct board *b, char *arg)
 static void
 board_load(struct board *b, FILE *f, unsigned int size)
 {
-	struct move last_move = { .coord = pass };
+	struct move last_move = move(pass, S_NONE);
 	last_move_set = false;
 	board_resize(b, size);
 	board_clear(b);
@@ -122,7 +122,7 @@ board_load(struct board *b, FILE *f, unsigned int size)
 			if (line[i] && line[i] != ' ' && line[i] != ')')
 				die("No space after stone %i: '%c'\n", i/2 + 1, line[i]);
 
-			struct move m = { .color = s, .coord = coord_xy(b, i/2 + 1, y + 1) };
+			struct move m = move(coord_xy(b, i/2 + 1, y + 1), s);
 			if (line[i] == ')') {
 				assert(s == S_BLACK || s == S_WHITE);
 				assert(last_move.coord == pass);
@@ -448,7 +448,7 @@ static int
 moggy_games(struct board *b, enum stone color, int games, struct ownermap *ownermap, bool speed_benchmark)
 {
 	struct playout_policy *policy = playout_moggy_init(NULL, b);
-	struct playout_setup setup = { .gamelen = MAX_GAMELEN };
+	struct playout_setup setup = playout_setup(MAX_GAMELEN, 0);
 	ownermap_init(ownermap);
 	
 	int wr = 0;
@@ -526,7 +526,7 @@ test_moggy_status(struct board *b, char *arg)
 	/* Get final status estimate after a number of moggy games */	
 	struct ownermap ownermap;
 	int wr = moggy_games(b, color, games, &ownermap, speed_benchmark);
-		
+
 	int wr_black = wr * 100 / games;
 	int wr_white = (games - wr) * 100 / games;
 	if (wr_black > wr_white)  { if (DEBUGL(2)) fprintf(stderr, "Winrate: [ black %i%% ]  white %i%%\n\n", wr_black, wr_white); }

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -92,7 +92,7 @@ set_handicap(board_t *b, char *arg)
 }
 
 static void
-board_load(board_t *b, FILE *f, unsigned int size)
+board_load(board_t *b, FILE *f, int size)
 {
 	move_t last_move = move(pass, S_NONE);
 	last_move_set = false;
@@ -107,10 +107,10 @@ board_load(board_t *b, FILE *f, unsigned int size)
 		if (!strncmp(line, "komi ", 5))     {  set_komi(b, line + 5);     y++; continue;  }
 		if (!strncmp(line, "handicap ", 9)) {  set_handicap(b, line + 9); y++; continue;  }
 
-		if (strlen(line) != size * 2 - 1 && 
-		    strlen(line) != size * 2)       die("Line not %d char long: '%s'\n", size * 2 - 1, line);
+		if ((int)strlen(line) != size * 2 - 1 && 
+		    (int)strlen(line) != size * 2)       die("Line not %d char long: '%s'\n", size * 2 - 1, line);
 		
-		for (unsigned int i = 0; i < size * 2; i++) {
+		for (int i = 0; i < size * 2; i++) {
 			enum stone s;
 			switch (line[i]) {
 				case '.': s = S_NONE; break;
@@ -517,7 +517,7 @@ test_moggy_status(board_t *b, char *arg)
 	board_print_test(2, b);
 	if (DEBUGL(2))  fprintf(stderr, "moggy status ");
 	for (int i = 0; i < n; i++) {
-		char *chr = (thres[i] == 80 ? ":XO," : ":xo,");
+		const char *chr = (thres[i] == 80 ? ":XO," : ":xo,");
 		if (!thres[i])  chr = "????";
 		if (DEBUGL(2)) fprintf(stderr, "%s %c  ", coord2sstr(status_at[i]),	chr[expected[i]]);
 	}
@@ -546,7 +546,7 @@ test_moggy_status(board_t *b, char *arg)
 		int pc = ownermap.map[c][color] * 100 / ownermap.playouts;
 
 		int passed = (!thres[i] || (j == expected[i] && pc >= thres[i]));
-		char *colorstr = (j == PJ_SEKI ? "seki" : stone2str(color));
+		const char *colorstr = (j == PJ_SEKI ? "seki" : stone2str(color));
 		PRINT_TEST(b, "moggy status %3s %-5s -> %3i%%    ", coord2sstr(c), colorstr, pc);
 		
 		if (!passed)  ret = false;

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -59,7 +59,7 @@ args_end()
 }
 
 static void
-board_print_test(int level, struct board *b)
+board_print_test(int level, board_t *b)
 {
 	if (!DEBUGL(level) || board_printed)
 		return;
@@ -68,7 +68,7 @@ board_print_test(int level, struct board *b)
 }
 
 static void
-check_play_move(struct board *b, struct move *m)
+check_play_move(board_t *b, move_t *m)
 {
 	if (board_play(b, m) < 0) {
 		fprintf(stderr, "Failed to play %s %s\n", stone2str(m->color), coord2sstr(m->coord));
@@ -78,23 +78,23 @@ check_play_move(struct board *b, struct move *m)
 }
 
 static void
-set_komi(struct board *b, char *arg)
+set_komi(board_t *b, char *arg)
 {
 	assert(*arg == '-' || *arg == '+' || isdigit(*arg));
 	b->komi = atof(arg);
 }
 
 static void
-set_handicap(struct board *b, char *arg)
+set_handicap(board_t *b, char *arg)
 {
 	assert(isdigit(*arg));
 	b->handicap = atoi(arg);
 }
 
 static void
-board_load(struct board *b, FILE *f, unsigned int size)
+board_load(board_t *b, FILE *f, unsigned int size)
 {
-	struct move last_move = move(pass, S_NONE);
+	move_t last_move = move(pass, S_NONE);
 	last_move_set = false;
 	board_resize(b, size);
 	board_clear(b);
@@ -122,7 +122,7 @@ board_load(struct board *b, FILE *f, unsigned int size)
 			if (line[i] && line[i] != ' ' && line[i] != ')')
 				die("No space after stone %i: '%c'\n", i/2 + 1, line[i]);
 
-			struct move m = move(coord_xy(i/2 + 1, y + 1), s);
+			move_t m = move(coord_xy(i/2 + 1, y + 1), s);
 			if (line[i] == ')') {
 				assert(s == S_BLACK || s == S_WHITE);
 				assert(last_move.coord == pass);
@@ -143,10 +143,10 @@ board_load(struct board *b, FILE *f, unsigned int size)
 }
 
 static void
-set_ko(struct board *b, char *arg)
+set_ko(board_t *b, char *arg)
 {
 	assert(isalpha(*arg));
-	struct move last;
+	move_t last;
 	last.coord = str2coord(arg);
 	last.color = board_at(b, last.coord);
 	assert(last.color == S_BLACK || last.color == S_WHITE);
@@ -190,7 +190,7 @@ show_title_if_needed(int passed)
 
 
 static bool
-test_sar(struct board *b, char *arg)
+test_sar(board_t *b, char *arg)
 {
 	next_arg(arg);
 	enum stone color = str2stone(arg);
@@ -210,7 +210,7 @@ test_sar(struct board *b, char *arg)
 }
 
 static bool
-test_corner_seki(struct board *b, char *arg)
+test_corner_seki(board_t *b, char *arg)
 {
 	next_arg(arg);
 	enum stone color = str2stone(arg);
@@ -230,7 +230,7 @@ test_corner_seki(struct board *b, char *arg)
 }
 
 static bool
-test_false_eye_seki(struct board *b, char *arg)
+test_false_eye_seki(board_t *b, char *arg)
 {
 	next_arg(arg);
 	enum stone color = str2stone(arg);
@@ -251,7 +251,7 @@ test_false_eye_seki(struct board *b, char *arg)
 
 
 static bool
-test_ladder(struct board *b, char *arg)
+test_ladder(board_t *b, char *arg)
 {
 	next_arg(arg);
 	enum stone color = str2stone(arg);
@@ -274,7 +274,7 @@ test_ladder(struct board *b, char *arg)
 
 
 static bool
-test_ladder_any(struct board *b, char *arg)
+test_ladder_any(board_t *b, char *arg)
 {
 	next_arg(arg);
 	enum stone color = str2stone(arg);
@@ -297,7 +297,7 @@ test_ladder_any(struct board *b, char *arg)
 
 
 static bool
-test_wouldbe_ladder(struct board *b, char *arg)
+test_wouldbe_ladder(board_t *b, char *arg)
 {
 	next_arg(arg);
 	enum stone color = str2stone(arg);
@@ -320,7 +320,7 @@ test_wouldbe_ladder(struct board *b, char *arg)
 }
 
 static bool
-test_wouldbe_ladder_any(struct board *b, char *arg)
+test_wouldbe_ladder_any(board_t *b, char *arg)
 {
 	next_arg(arg);
 	enum stone color = str2stone(arg);
@@ -344,7 +344,7 @@ test_wouldbe_ladder_any(struct board *b, char *arg)
 
 
 static bool
-test_useful_ladder(struct board *b, char *arg)
+test_useful_ladder(board_t *b, char *arg)
 {
 	next_arg(arg);
 	enum stone color = str2stone(arg);
@@ -367,7 +367,7 @@ test_useful_ladder(struct board *b, char *arg)
 }
 
 static bool
-test_can_countercap(struct board *b, char *arg)
+test_can_countercap(board_t *b, char *arg)
 {
 	next_arg(arg);
 	coord_t c = str2coord(arg);
@@ -388,7 +388,7 @@ test_can_countercap(struct board *b, char *arg)
 
 
 static bool
-test_two_eyes(struct board *b, char *arg)
+test_two_eyes(board_t *b, char *arg)
 {
 	next_arg(arg);
 	coord_t c = str2coord(arg);
@@ -413,7 +413,7 @@ test_two_eyes(struct board *b, char *arg)
  * Syntax:  moggy moves
  */
 static bool
-test_moggy_moves(struct board *b, char *arg)
+test_moggy_moves(board_t *b, char *arg)
 {
 	int runs = 1000;
 
@@ -422,7 +422,7 @@ test_moggy_moves(struct board *b, char *arg)
 	board_print_test(2, b);
 
 	char e_arg[128];  sprintf(e_arg, "runs=%i", runs);
-	struct engine e;  engine_init(&e, E_REPLAY, e_arg, b);
+	engine_t e;  engine_init(&e, E_REPLAY, e_arg, b);
 	enum stone color = stone_other(b->last_move.color);
 	
 	if (DEBUGL(2))
@@ -445,16 +445,16 @@ test_moggy_moves(struct board *b, char *arg)
 }
 
 static int
-moggy_games(struct board *b, enum stone color, int games, struct ownermap *ownermap, bool speed_benchmark)
+moggy_games(board_t *b, enum stone color, int games, ownermap_t *ownermap, bool speed_benchmark)
 {
-	struct playout_policy *policy = playout_moggy_init(NULL, b);
-	struct playout_setup setup = playout_setup(MAX_GAMELEN, 0);
+	playout_policy_t *policy = playout_moggy_init(NULL, b);
+	playout_setup_t setup = playout_setup(MAX_GAMELEN, 0);
 	ownermap_init(ownermap);
 	
 	int wr = 0;
 	double time_start = time_now();
 	for (int i = 0; i < games; i++)  {
-		struct board b2;
+		board_t b2;
 		board_copy(&b2, b);
 		
 		int score = playout_play_game(&setup, &b2, color, NULL, ownermap, policy);
@@ -483,7 +483,7 @@ moggy_games(struct board *b, enum stone color, int games, struct ownermap *owner
  *   moggy status                              speed benchmark
  */
 static bool
-test_moggy_status(struct board *b, char *arg)
+test_moggy_status(board_t *b, char *arg)
 {
 	next_arg(arg);
 
@@ -524,7 +524,7 @@ test_moggy_status(struct board *b, char *arg)
 	if (DEBUGL(2)) fprintf(stderr, "\n%s to play. Playing %i games ...\n", stone2str(color), games);
 
 	/* Get final status estimate after a number of moggy games */	
-	struct ownermap ownermap;
+	ownermap_t ownermap;
 	int wr = moggy_games(b, color, games, &ownermap, speed_benchmark);
 
 	int wr_black = wr * 100 / games;
@@ -556,12 +556,12 @@ test_moggy_status(struct board *b, char *arg)
 	return ret;
 }
 
-bool board_undo_stress_test(struct board *orig, char *arg);
-bool board_regression_test(struct board *orig, char *arg);
-bool moggy_regression_test(struct board *orig, char *arg);
-bool spatial_regression_test(struct board *orig, char *arg);
+bool board_undo_stress_test(board_t *orig, char *arg);
+bool board_regression_test(board_t *orig, char *arg);
+bool moggy_regression_test(board_t *orig, char *arg);
+bool spatial_regression_test(board_t *orig, char *arg);
 
-typedef bool (*t_unit_func)(struct board *board, char *arg);
+typedef bool (*t_unit_func)(board_t *board, char *arg);
 
 typedef struct {
 	char *cmd;
@@ -592,7 +592,7 @@ static t_unit_cmd commands[] = {
 };
 
 int
-unit_test_cmd(struct board *b, char *line)
+unit_test_cmd(board_t *b, char *line)
 {
 	board_printed = false;
 	chomp(line);
@@ -628,7 +628,7 @@ unit_test(char *filename)
 	int total = 0, passed = 0;
 	int total_opt = 0, passed_opt = 0;
 	
-	struct board *b = board_new(19+2, NULL);
+	board_t *b = board_new(19+2, NULL);
 	b->komi = 7.5;
 	char buf[256]; char *line = buf;
 

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -71,7 +71,7 @@ static void
 check_play_move(struct board *b, struct move *m)
 {
 	if (board_play(b, m) < 0) {
-		fprintf(stderr, "Failed to play %s %s\n", stone2str(m->color), coord2sstr(m->coord, b));
+		fprintf(stderr, "Failed to play %s %s\n", stone2str(m->color), coord2sstr(m->coord));
 		board_print(b, stderr);
 		exit(EXIT_FAILURE);
 	}
@@ -122,7 +122,7 @@ board_load(struct board *b, FILE *f, unsigned int size)
 			if (line[i] && line[i] != ' ' && line[i] != ')')
 				die("No space after stone %i: '%c'\n", i/2 + 1, line[i]);
 
-			struct move m = move(coord_xy(b, i/2 + 1, y + 1), s);
+			struct move m = move(coord_xy(i/2 + 1, y + 1), s);
 			if (line[i] == ')') {
 				assert(s == S_BLACK || s == S_WHITE);
 				assert(last_move.coord == pass);
@@ -147,7 +147,7 @@ set_ko(struct board *b, char *arg)
 {
 	assert(isalpha(*arg));
 	struct move last;
-	last.coord = str2coord(arg, board_size(b));
+	last.coord = str2coord(arg);
 	last.color = board_at(b, last.coord);
 	assert(last.color == S_BLACK || last.color == S_WHITE);
 	b->last_move = last;
@@ -195,12 +195,12 @@ test_sar(struct board *b, char *arg)
 	next_arg(arg);
 	enum stone color = str2stone(arg);
 	next_arg(arg);
-	coord_t c = str2coord(arg, board_size(b));
+	coord_t c = str2coord(arg);
 	next_arg(arg);
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "sar %s %s %d...\t", stone2str(color), coord2sstr(c, b), eres);
+	PRINT_TEST(b, "sar %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
 
 	assert(board_at(b, c) == S_NONE);
 	int rres = is_bad_selfatari(b, color, c);
@@ -215,12 +215,12 @@ test_corner_seki(struct board *b, char *arg)
 	next_arg(arg);
 	enum stone color = str2stone(arg);
 	next_arg(arg);
-	coord_t c = str2coord(arg, board_size(b));
+	coord_t c = str2coord(arg);
 	next_arg(arg);
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "corner_seki %s %s %d...\t", stone2str(color), coord2sstr(c, b), eres);
+	PRINT_TEST(b, "corner_seki %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
 
 	assert(board_at(b, c) == S_NONE);
 	int rres = breaking_corner_seki(b, c, color);
@@ -235,12 +235,12 @@ test_false_eye_seki(struct board *b, char *arg)
 	next_arg(arg);
 	enum stone color = str2stone(arg);
 	next_arg(arg);
-	coord_t c = str2coord(arg, board_size(b));
+	coord_t c = str2coord(arg);
 	next_arg(arg);
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "false_eye_seki %s %s %d...\t", stone2str(color), coord2sstr(c, b), eres);
+	PRINT_TEST(b, "false_eye_seki %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
 
 	assert(board_at(b, c) == S_NONE);
 	int rres = breaking_false_eye_seki(b, c, color);
@@ -256,12 +256,12 @@ test_ladder(struct board *b, char *arg)
 	next_arg(arg);
 	enum stone color = str2stone(arg);
 	next_arg(arg);
-	coord_t c = str2coord(arg, board_size(b));
+	coord_t c = str2coord(arg);
 	next_arg(arg);
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "ladder %s %s %d...\t", stone2str(color), coord2sstr(c, b), eres);
+	PRINT_TEST(b, "ladder %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
 	
 	assert(board_at(b, c) == color);
 	group_t group = group_at(b, c);
@@ -279,12 +279,12 @@ test_ladder_any(struct board *b, char *arg)
 	next_arg(arg);
 	enum stone color = str2stone(arg);
 	next_arg(arg);
-	coord_t c = str2coord(arg, board_size(b));
+	coord_t c = str2coord(arg);
 	next_arg(arg);
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "ladder_any %s %s %d...\t", stone2str(color), coord2sstr(c, b), eres);
+	PRINT_TEST(b, "ladder_any %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
 
 	assert(board_at(b, c) == color);
 	group_t group = group_at(b, c);
@@ -302,12 +302,12 @@ test_wouldbe_ladder(struct board *b, char *arg)
 	next_arg(arg);
 	enum stone color = str2stone(arg);
 	next_arg(arg);
-	coord_t c = str2coord(arg, board_size(b));
+	coord_t c = str2coord(arg);
 	next_arg(arg);
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "wouldbe_ladder %s %s %d...\t", stone2str(color), coord2sstr(c, b), eres);
+	PRINT_TEST(b, "wouldbe_ladder %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
 	
 	assert(board_at(b, c) == S_NONE);
 	group_t g = board_get_2lib_neighbor(b, c, stone_other(color));
@@ -325,12 +325,12 @@ test_wouldbe_ladder_any(struct board *b, char *arg)
 	next_arg(arg);
 	enum stone color = str2stone(arg);
 	next_arg(arg);
-	coord_t c = str2coord(arg, board_size(b));
+	coord_t c = str2coord(arg);
 	next_arg(arg);
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "wouldbe_ladder_any %s %s %d...\t", stone2str(color), coord2sstr(c, b), eres);
+	PRINT_TEST(b, "wouldbe_ladder_any %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
 	
 	assert(board_at(b, c) == S_NONE);
 	group_t g = board_get_2lib_neighbor(b, c, stone_other(color));
@@ -349,12 +349,12 @@ test_useful_ladder(struct board *b, char *arg)
 	next_arg(arg);
 	enum stone color = str2stone(arg);
 	next_arg(arg);
-	coord_t c = str2coord(arg, board_size(b));
+	coord_t c = str2coord(arg);
 	next_arg(arg);
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "useful_ladder %s %s %d...\t", stone2str(color), coord2sstr(c, b), eres);
+	PRINT_TEST(b, "useful_ladder %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
 	
 	assert(board_at(b, c) == S_NONE);
 	group_t atari_neighbor = board_get_atari_neighbor(b, c, color);
@@ -370,12 +370,12 @@ static bool
 test_can_countercap(struct board *b, char *arg)
 {
 	next_arg(arg);
-	coord_t c = str2coord(arg, board_size(b));
+	coord_t c = str2coord(arg);
 	next_arg(arg);
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "can_countercap %s %d...\t", coord2sstr(c, b), eres);
+	PRINT_TEST(b, "can_countercap %s %d...\t", coord2sstr(c), eres);
 
 	enum stone color = board_at(b, c);
 	group_t g = group_at(b, c);
@@ -391,12 +391,12 @@ static bool
 test_two_eyes(struct board *b, char *arg)
 {
 	next_arg(arg);
-	coord_t c = str2coord(arg, board_size(b));
+	coord_t c = str2coord(arg);
 	next_arg(arg);
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "two_eyes %s %d...\t", coord2sstr(c, b), eres);
+	PRINT_TEST(b, "two_eyes %s %d...\t", coord2sstr(c), eres);
 
 	enum stone color = board_at(b, c);
 	assert(color == S_BLACK || color == S_WHITE);
@@ -438,7 +438,7 @@ test_moggy_moves(struct board *b, char *arg)
 	for (int k = most_played; k > 0; k--)
 		for (coord_t c = pass; c < b->size2; c++)
 			if (played[c] == k)
-				if (DEBUGL(2)) fprintf(stderr, "%3s: %.2f%%\n", coord2str(c, b), (float)k * 100 / runs);
+				if (DEBUGL(2)) fprintf(stderr, "%3s: %.2f%%\n", coord2str(c), (float)k * 100 / runs);
 	
 	engine_done(&e);
 	return true;   // Not much of a unit test right now =)
@@ -496,17 +496,17 @@ test_moggy_status(struct board *b, char *arg)
 	
 	for (n = 0; *arg; n++) {
 		if (!isalpha(*arg))  die("Invalid arg: '%s'\n", arg);
-		status_at[n] = str2coord(arg, board_size(b));
+		status_at[n] = str2coord(arg);
 		next_arg(arg);
 
-		if (!*arg || strlen(arg) != 1) die("Expected x/o/X/O/: after coord %s\n", coord2sstr(status_at[n], b));
+		if (!*arg || strlen(arg) != 1) die("Expected x/o/X/O/: after coord %s\n", coord2sstr(status_at[n]));
 		thres[n] = 67;
 		if (!strcmp(arg, "X") || !strcmp(arg, "O" )) thres[n] = 80;
 		if      (!strcasecmp(arg, "x"))  expected[n] = PJ_BLACK;
 		else if (!strcasecmp(arg, "o"))  expected[n] = PJ_WHITE;
 		else if (!strcasecmp(arg, ":"))  expected[n] = PJ_SEKI;
 		else if (!strcasecmp(arg, "?"))  { expected[n] = PJ_BLACK; thres[n] = 0;  }
-		else    die("Expected x/o/X/O/: after coord %s\n", coord2sstr(status_at[n], b));
+		else    die("Expected x/o/X/O/: after coord %s\n", coord2sstr(status_at[n]));
 		next_arg(arg);
 	}
 	args_end();
@@ -519,7 +519,7 @@ test_moggy_status(struct board *b, char *arg)
 	for (int i = 0; i < n; i++) {
 		char *chr = (thres[i] == 80 ? ":XO," : ":xo,");
 		if (!thres[i])  chr = "????";
-		if (DEBUGL(2)) fprintf(stderr, "%s %c  ", coord2sstr(status_at[i], b),	chr[expected[i]]);
+		if (DEBUGL(2)) fprintf(stderr, "%s %c  ", coord2sstr(status_at[i]),	chr[expected[i]]);
 	}
 	if (DEBUGL(2)) fprintf(stderr, "\n%s to play. Playing %i games ...\n", stone2str(color), games);
 
@@ -547,7 +547,7 @@ test_moggy_status(struct board *b, char *arg)
 
 		int passed = (!thres[i] || (j == expected[i] && pc >= thres[i]));
 		char *colorstr = (j == PJ_SEKI ? "seki" : stone2str(color));
-		PRINT_TEST(b, "moggy status %3s %-5s -> %3i%%    ", coord2sstr(c, b), colorstr, pc);
+		PRINT_TEST(b, "moggy status %3s %-5s -> %3i%%    ", coord2sstr(c), colorstr, pc);
 		
 		if (!passed)  ret = false;
 		PRINT_RES(passed);

--- a/t-unit/test_undo.c
+++ b/t-unit/test_undo.c
@@ -95,7 +95,7 @@ test_undo(struct board *orig, coord_t c, enum stone color)
 	board_copy(&b, orig);
 	board_copy(&b2, orig);
 
-	struct move m = { .coord = c, .color = color };
+	struct move m = move(c, color);
 	int r = board_play(&b, &m);  assert(r >= 0);
 
 	with_move(&b2, c, color, {
@@ -149,7 +149,7 @@ board_undo_stress_test(struct board *board, char *arg)
 
 	// Light policy better to test wild multi-group suicides
 	struct playout_policy *policy = playout_light_init(NULL, board);
-	struct playout_setup setup = { .gamelen = MAX_GAMELEN };
+	struct playout_setup setup = playout_setup(MAX_GAMELEN, 0);
 	
 	// Hijack policy permit()
 	policy_permit = policy->permit;  policy->permit = permit_hook;

--- a/t-unit/test_undo.c
+++ b/t-unit/test_undo.c
@@ -15,19 +15,19 @@ static void
 board_dump_group(struct board *b, group_t g)
 {
         printf("group base: %s  color: %s  libs: %i  stones: %i\n",
-               coord2sstr(g, b), stone2str(board_at(b, g)),
+               coord2sstr(g), stone2str(board_at(b, g)),
                board_group_info(b, g).libs, group_stone_count(b, g, 500));
 
         printf("  stones: ");
         foreach_in_group(b, g) {
-                printf("%s ", coord2sstr(c, b));
+                printf("%s ", coord2sstr(c));
         } foreach_in_group_end;
         printf("\n");
 
         printf("  libs  : ");   
         for (int i = 0; i < board_group_info(b, g).libs; i++) {
                 coord_t lib = board_group_info(b, g).lib[i];
-                printf("%s ", coord2sstr(lib, b));
+                printf("%s ", coord2sstr(lib));
         }
         printf("\n");
 }
@@ -40,8 +40,8 @@ board_dump(struct board *b)
         board_print(b, stdout);
 
         printf("ko: %s %s  last_ko: %s %s  last_ko_age: %i\n",
-               stone2str(b->ko.color), coord2sstr(b->ko.coord, b),
-               stone2str(b->last_ko.color), coord2sstr(b->last_ko.coord, b),
+               stone2str(b->ko.color), coord2sstr(b->ko.coord),
+               stone2str(b->last_ko.color), coord2sstr(b->last_ko.coord),
                b->last_ko_age);
 
         printf("groups: \n");

--- a/tactics/1lib.c
+++ b/tactics/1lib.c
@@ -50,7 +50,7 @@ static inline bool
 can_capture(struct board *b, group_t g, enum stone to_play)
 {
 	coord_t capture = board_group_info(b, g).lib[0];
-	if (DEBUGL(6))  fprintf(stderr, "can capture group %d (%s)?\n", g, coord2sstr(capture, b));
+	if (DEBUGL(6))  fprintf(stderr, "can capture group %d (%s)?\n", g, coord2sstr(capture));
 	
 	/* Does playing on the liberty usefully capture the group? */
 	if (board_is_valid_play(b, to_play, capture)
@@ -64,7 +64,7 @@ static inline bool
 can_play_on_lib(struct board *b, group_t g, enum stone to_play)
 {
 	coord_t capture = board_group_info(b, g).lib[0];
-	if (DEBUGL(6))  fprintf(stderr, "can capture group %d (%s)?\n", g, coord2sstr(capture, b));
+	if (DEBUGL(6))  fprintf(stderr, "can capture group %d (%s)?\n", g, coord2sstr(capture));
 	
 	/* Does playing on the liberty usefully capture the group? */
 	if (board_is_valid_play(b, to_play, capture)
@@ -183,7 +183,7 @@ group_atari_check(unsigned int alwaysccaprate, struct board *b, group_t group, e
 
 	assert(color != S_OFFBOARD && color != S_NONE);
 	if (DEBUGL(5))  fprintf(stderr, "[%s] atariiiiiiiii %s of color %d\n",
-				coord2sstr(group, b), coord2sstr(lib, b), color);
+				coord2sstr(group), coord2sstr(lib), color);
 	assert(board_at(b, lib) == S_NONE);
 
 	if (to_play != color) {

--- a/tactics/1lib.c
+++ b/tactics/1lib.c
@@ -14,7 +14,7 @@
 
 
 bool
-capturing_group_is_snapback(struct board *b, group_t group)
+capturing_group_is_snapback(board_t *b, group_t group)
 {	
 	coord_t lib = board_group_info(b, group).lib[0];
 
@@ -47,7 +47,7 @@ capturing_group_is_snapback(struct board *b, group_t group)
 
 
 static inline bool
-can_capture(struct board *b, group_t g, enum stone to_play)
+can_capture(board_t *b, group_t g, enum stone to_play)
 {
 	coord_t capture = board_group_info(b, g).lib[0];
 	if (DEBUGL(6))  fprintf(stderr, "can capture group %d (%s)?\n", g, coord2sstr(capture));
@@ -61,7 +61,7 @@ can_capture(struct board *b, group_t g, enum stone to_play)
 }
 
 static inline bool
-can_play_on_lib(struct board *b, group_t g, enum stone to_play)
+can_play_on_lib(board_t *b, group_t g, enum stone to_play)
 {
 	coord_t capture = board_group_info(b, g).lib[0];
 	if (DEBUGL(6))  fprintf(stderr, "can capture group %d (%s)?\n", g, coord2sstr(capture));
@@ -76,7 +76,7 @@ can_play_on_lib(struct board *b, group_t g, enum stone to_play)
 
 /* Checks snapbacks */
 bool
-can_countercapture(struct board *b, group_t group, struct move_queue *q, int tag)
+can_countercapture(board_t *b, group_t group, move_queue_t *q, int tag)
 {
 	enum stone color = board_at(b, group);
 	enum stone other = stone_other(color);
@@ -106,7 +106,7 @@ can_countercapture(struct board *b, group_t group, struct move_queue *q, int tag
 /* Same as can_countercapture() but returns capturable groups instead of moves,
  * queue may not be NULL, and is always cleared. */
 bool
-countercapturable_groups(struct board *b, group_t group, struct move_queue *q)
+countercapturable_groups(board_t *b, group_t group, move_queue_t *q)
 {
 	q->moves = 0;
 	enum stone color = board_at(b, group);
@@ -131,7 +131,7 @@ countercapturable_groups(struct board *b, group_t group, struct move_queue *q)
 }
 
 bool
-can_countercapture_any(struct board *b, group_t group, struct move_queue *q, int tag)
+can_countercapture_any(board_t *b, group_t group, move_queue_t *q, int tag)
 {
 	enum stone color = board_at(b, group);
 	enum stone other = stone_other(color);
@@ -163,7 +163,7 @@ can_countercapture_any(struct board *b, group_t group, struct move_queue *q, int
 
 #ifdef NO_DOOMED_GROUPS
 static bool
-can_be_rescued(struct board *b, group_t group, enum stone color, int tag)
+can_be_rescued(board_t *b, group_t group, enum stone color, int tag)
 {
 	/* Does playing on the liberty rescue the group? */
 	if (can_play_on_lib(b, group, color))
@@ -175,8 +175,8 @@ can_be_rescued(struct board *b, group_t group, enum stone color, int tag)
 #endif
 
 void
-group_atari_check(unsigned int alwaysccaprate, struct board *b, group_t group, enum stone to_play,
-                  struct move_queue *q, coord_t *ladder, bool middle_ladder, int tag)
+group_atari_check(unsigned int alwaysccaprate, board_t *b, group_t group, enum stone to_play,
+                  move_queue_t *q, coord_t *ladder, bool middle_ladder, int tag)
 {
 	enum stone color = board_at(b, group_base(group));
 	coord_t lib = board_group_info(b, group).lib[0];

--- a/tactics/1lib.h
+++ b/tactics/1lib.h
@@ -6,34 +6,31 @@
 #include "board.h"
 #include "debug.h"
 
-struct move_queue;
-
-
-bool capturing_group_is_snapback(struct board *b, group_t group);
+bool capturing_group_is_snapback(board_t *b, group_t group);
 /* Can group @group usefully capture a neighbor ? 
  * (usefully: not a snapback) */
-bool can_countercapture(struct board *b, group_t group, struct move_queue *q, int tag);
+bool can_countercapture(board_t *b, group_t group, move_queue_t *q, int tag);
 /* Same as can_countercapture() but returns capturable groups instead of moves,
  * queue may not be NULL, and is always cleared. */
-bool countercapturable_groups(struct board *b, group_t group, struct move_queue *q);
+bool countercapturable_groups(board_t *b, group_t group, move_queue_t *q);
 /* Can group @group capture *any* neighbor ? */
-bool can_countercapture_any(struct board *b, group_t group, struct move_queue *q, int tag);
+bool can_countercapture_any(board_t *b, group_t group, move_queue_t *q, int tag);
 
 /* Examine given group in atari, suggesting suitable moves for player
  * @to_play to deal with it (rescuing or capturing it). */
 /* ladder != NULL implies to always enqueue all relevant moves. */
-void group_atari_check(unsigned int alwaysccaprate, struct board *b, group_t group, enum stone to_play,
-                       struct move_queue *q, coord_t *ladder, bool middle_ladder, int tag);
+void group_atari_check(unsigned int alwaysccaprate, board_t *b, group_t group, enum stone to_play,
+                       move_queue_t *q, coord_t *ladder, bool middle_ladder, int tag);
 
 
 /* Returns 0 or ID of neighboring group in atari. */
-static group_t board_get_atari_neighbor(struct board *b, coord_t coord, enum stone group_color);
+static group_t board_get_atari_neighbor(board_t *b, coord_t coord, enum stone group_color);
 /* Get all neighboring groups in atari */
-static void board_get_atari_neighbors(struct board *b, coord_t coord, enum stone group_color, struct move_queue *q);
+static void board_get_atari_neighbors(board_t *b, coord_t coord, enum stone group_color, move_queue_t *q);
 
 
 static inline group_t
-board_get_atari_neighbor(struct board *b, coord_t coord, enum stone group_color)
+board_get_atari_neighbor(board_t *b, coord_t coord, enum stone group_color)
 {
 	assert(coord != pass);
 	foreach_neighbor(b, coord, {
@@ -46,7 +43,7 @@ board_get_atari_neighbor(struct board *b, coord_t coord, enum stone group_color)
 }
 
 static inline void
-board_get_atari_neighbors(struct board *b, coord_t c, enum stone group_color, struct move_queue *q)
+board_get_atari_neighbors(board_t *b, coord_t c, enum stone group_color, move_queue_t *q)
 {
 	assert(c != pass);
 	q->moves = 0;
@@ -61,7 +58,7 @@ board_get_atari_neighbors(struct board *b, coord_t c, enum stone group_color, st
 
 #define foreach_atari_neighbor(b, c, group_color)			\
 	do {								\
-		struct move_queue __q;					\
+		move_queue_t __q;					\
 		board_get_atari_neighbors(b, (c), (group_color), &__q);	\
 		for (unsigned int __i = 0; __i < __q.moves; __i++) {		\
 			group_t g = __q.move[__i];

--- a/tactics/2lib.c
+++ b/tactics/2lib.c
@@ -75,7 +75,7 @@ defense_is_hopeless(struct board *b, group_t group, enum stone owner,
 	if (to_play == owner && neighbor_count_at(b, lib, owner) == 1) {
 		if (immediate_liberty_count(b, lib) == 1)	return true;
 		if (immediate_liberty_count(b, lib) == 2
-		    && coord_is_adjecent(lib, otherlib, b))	return true;
+		    && coord_is_adjecent(lib, otherlib))	return true;
 	}
 	return false;
 }
@@ -93,8 +93,8 @@ can_atari_group(struct board *b, group_t group, enum stone owner,
 		if (!board_is_valid_play(b, to_play, lib))  continue;
 
 		if (DEBUGL(6))  fprintf(stderr, "- checking liberty %s of %s %s, filled by %s\n",
-					coord2sstr(lib, b),
-					stone2str(owner), coord2sstr(group, b),
+					coord2sstr(lib),
+					stone2str(owner), coord2sstr(group),
 					stone2str(to_play));
 
 		/* Don't play at the spot if it is extremely short
@@ -144,7 +144,7 @@ can_atari_group(struct board *b, group_t group, enum stone owner,
 			/* Ok, connect, but prefer not to. */
 			enum stone byowner = board_at(b, bygroup);
 			if (DEBUGL(7))  fprintf(stderr, "\treluctantly switching to cousin %s (group %s %s)\n",
-						coord2sstr(coord, b), coord2sstr(bygroup, b), stone2str(byowner));
+						coord2sstr(coord), coord2sstr(bygroup), stone2str(byowner));
 			/* One more thing - is the cousin sensible defense
 			 * for the other group? */
 			if (defense_is_hopeless(b, bygroup, byowner, to_play, coord, lib, use_def_no_hopeless))
@@ -170,7 +170,7 @@ can_atari_group(struct board *b, group_t group, enum stone owner,
 			preference[i] = false;
 		}
 
-		if (DEBUGL(6))  fprintf(stderr, "+ liberty %s ready with preference %d\n", coord2sstr(lib, b), preference[i]);
+		if (DEBUGL(6))  fprintf(stderr, "+ liberty %s ready with preference %d\n", coord2sstr(lib), preference[i]);
 
 		/* If we prefer only one of the moves, pick that one. */
 		if (i == 1 && have[0] && preference[0] != preference[1]) {
@@ -194,9 +194,9 @@ can_atari_group(struct board *b, group_t group, enum stone owner,
 	if (DEBUGL(7)) {
 		char label[256];
 		snprintf(label, 256, "= final %s %s liberties to play by %s",
-			stone2str(owner), coord2sstr(group, b),
+			stone2str(owner), coord2sstr(group),
 			stone2str(to_play));
-		mq_print(q, b, label);
+		mq_print(q, label);
 	}
 }
 
@@ -207,7 +207,7 @@ group_2lib_check(struct board *b, group_t group, enum stone to_play, struct move
 	assert(color != S_OFFBOARD && color != S_NONE);
 
 	if (DEBUGL(5))  fprintf(stderr, "[%s] 2lib check of color %d\n",
-				coord2sstr(group, b), color);
+				coord2sstr(group), color);
 
 	/* Do not try to atari groups that cannot be harmed. */
 	if (use_miaisafe && miai_2lib(b, group, color))
@@ -243,7 +243,7 @@ can_capture_2lib_group(struct board *b, group_t g, struct move_queue *q, int tag
 	assert(board_group_info(b, g).libs == 2);
 	for (int i = 0; i < 2; i++) {
 		coord_t lib = board_group_info(b, g).lib[i];
-		//fprintf(stderr, "can_capture_2lib_group(): checking %s\n", coord2sstr(lib, b));
+		//fprintf(stderr, "can_capture_2lib_group(): checking %s\n", coord2sstr(lib));
 		if (wouldbe_ladder_any(b, g, lib)) {
 			if (q)  mq_add(q, lib, tag);
 			return true;
@@ -259,7 +259,7 @@ group_2lib_capture_check(struct board *b, group_t group, enum stone to_play, str
 	assert(color != S_OFFBOARD && color != S_NONE);
 	
 	if (DEBUGL(5))  fprintf(stderr, "[%s] 2lib capture check of color %d\n",
-				coord2sstr(group, b), color);
+				coord2sstr(group), color);
 
 	if (to_play != color) {  /* Attacker */		
 		can_capture_2lib_group(b, group, q, tag);

--- a/tactics/2lib.c
+++ b/tactics/2lib.c
@@ -20,7 +20,7 @@
 
 
 static bool
-miai_2lib(struct board *b, group_t group, enum stone color)
+miai_2lib(board_t *b, group_t group, enum stone color)
 {
 	bool can_connect = false, can_pull_out = false;
 	/* We have miai if we can either connect on both libs,
@@ -56,9 +56,9 @@ miai_2lib(struct board *b, group_t group, enum stone color)
 }
 
 static bool
-defense_is_hopeless(struct board *b, group_t group, enum stone owner,
-			enum stone to_play, coord_t lib, coord_t otherlib,
-			bool use)
+defense_is_hopeless(board_t *b, group_t group, enum stone owner,
+		    enum stone to_play, coord_t lib, coord_t otherlib,
+		    bool use)
 {
 	/* If we are the defender not connecting out, do not
 	 * escape with moves that do not gain liberties anyway
@@ -81,9 +81,9 @@ defense_is_hopeless(struct board *b, group_t group, enum stone owner,
 }
 
 void
-can_atari_group(struct board *b, group_t group, enum stone owner,
-		  enum stone to_play, struct move_queue *q,
-		  int tag, bool use_def_no_hopeless)
+can_atari_group(board_t *b, group_t group, enum stone owner,
+		enum stone to_play, move_queue_t *q,
+		int tag, bool use_def_no_hopeless)
 {
 	bool have[2] = { false, false };
 	bool preference[2] = { true, true };
@@ -201,7 +201,7 @@ can_atari_group(struct board *b, group_t group, enum stone owner,
 }
 
 void
-group_2lib_check(struct board *b, group_t group, enum stone to_play, struct move_queue *q, int tag, bool use_miaisafe, bool use_def_no_hopeless)
+group_2lib_check(board_t *b, group_t group, enum stone to_play, move_queue_t *q, int tag, bool use_miaisafe, bool use_def_no_hopeless)
 {
 	enum stone color = board_at(b, group_base(group));
 	assert(color != S_OFFBOARD && color != S_NONE);
@@ -238,7 +238,7 @@ group_2lib_check(struct board *b, group_t group, enum stone to_play, struct move
 
 
 bool
-can_capture_2lib_group(struct board *b, group_t g, struct move_queue *q, int tag)
+can_capture_2lib_group(board_t *b, group_t g, move_queue_t *q, int tag)
 {
 	assert(board_group_info(b, g).libs == 2);
 	for (int i = 0; i < 2; i++) {
@@ -253,7 +253,7 @@ can_capture_2lib_group(struct board *b, group_t g, struct move_queue *q, int tag
 }
 
 void
-group_2lib_capture_check(struct board *b, group_t group, enum stone to_play, struct move_queue *q, int tag, bool use_miaisafe, bool use_def_no_hopeless)
+group_2lib_capture_check(board_t *b, group_t group, enum stone to_play, move_queue_t *q, int tag, bool use_miaisafe, bool use_def_no_hopeless)
 {
 	enum stone color = board_at(b, group_base(group));
 	assert(color != S_OFFBOARD && color != S_NONE);

--- a/tactics/2lib.h
+++ b/tactics/2lib.h
@@ -7,20 +7,18 @@
 #include "board.h"
 #include "debug.h"
 
-struct move_queue;
+void can_atari_group(board_t *b, group_t group, enum stone owner, enum stone to_play, move_queue_t *q, int tag, bool use_def_no_hopeless);
+void group_2lib_check(board_t *b, group_t group, enum stone to_play, move_queue_t *q, int tag, bool use_miaisafe, bool use_def_no_hopeless);
 
-void can_atari_group(struct board *b, group_t group, enum stone owner, enum stone to_play, struct move_queue *q, int tag, bool use_def_no_hopeless);
-void group_2lib_check(struct board *b, group_t group, enum stone to_play, struct move_queue *q, int tag, bool use_miaisafe, bool use_def_no_hopeless);
-
-bool can_capture_2lib_group(struct board *b, group_t g, struct move_queue *q, int tag);
-void group_2lib_capture_check(struct board *b, group_t group, enum stone to_play, struct move_queue *q, int tag, bool use_miaisafe, bool use_def_no_hopeless);
+bool can_capture_2lib_group(board_t *b, group_t g, move_queue_t *q, int tag);
+void group_2lib_capture_check(board_t *b, group_t group, enum stone to_play, move_queue_t *q, int tag, bool use_miaisafe, bool use_def_no_hopeless);
 
 /* Returns 0 or ID of neighboring group with 2 libs. */
-static group_t board_get_2lib_neighbor(struct board *b, coord_t c, enum stone color);
+static group_t board_get_2lib_neighbor(board_t *b, coord_t c, enum stone color);
 
 
 static inline group_t
-board_get_2lib_neighbor(struct board *b, coord_t c, enum stone color)
+board_get_2lib_neighbor(board_t *b, coord_t c, enum stone color)
 {
 	foreach_neighbor(b, c, {
 		group_t g = group_at(b, c);

--- a/tactics/dragon.c
+++ b/tactics/dragon.c
@@ -258,7 +258,7 @@ foreach_lib_in_connected_groups(struct board *b, enum stone color, coord_t to,
 				foreach_in_connected_groups_t f, void *data)
 {
 	int visited[BOARD_MAX_COORDS] = {0, };
-	struct foreach_lib_data d = { .visited = visited, .f = f, .data = data };	
+	struct foreach_lib_data d = { visited, f, data };	
 	foreach_connected_group(b, color, to, foreach_lib_handler, &d);
 }
 
@@ -488,7 +488,7 @@ count_eyes(struct board *b, enum stone color, coord_t lib, void *data)
 bool
 dragon_is_safe_full(struct board *b, group_t g, enum stone color, int *visited, int *eyes)
 {
-	struct safe_data d = { .visited = visited, .eyes = eyes };
+	struct safe_data d = { visited, eyes };
 	foreach_lib_in_connected_groups(b, color, g, count_eyes, &d);
 	return (*eyes >= 2);
 }
@@ -698,7 +698,7 @@ dragon_is_surrounded(struct board *b, coord_t to)
 	/* Mark connected stones */
 	foreach_in_connected_groups(b, color, to, mark_connected, connected);
 	
-	struct surrounded_data d = { .connected = connected, .surrounded = 1 };
+	struct surrounded_data d = { connected, 1 };
 	foreach_lib_in_connected_groups(b, color, to, surrounded_check, &d);
 	return d.surrounded;
 }

--- a/tactics/dragon.c
+++ b/tactics/dragon.c
@@ -10,7 +10,7 @@
 #include "tactics/dragon.h"
 
 static char*
-print_handler(struct board *board, coord_t c, void *data)
+print_handler(board_t *board, coord_t c, void *data)
 {
 	static char buf[64];
 	group_t dragon = *(group_t*)data;
@@ -24,7 +24,7 @@ print_handler(struct board *board, coord_t c, void *data)
 }
 
 void
-dragon_print(struct board *board, FILE *f, group_t dragon)
+dragon_print(board_t *board, FILE *f, group_t dragon)
 {
         board_hprint(board, f, print_handler, &dragon);
 }
@@ -63,7 +63,7 @@ pick_dragon_color(int i, bool bold, bool white_ok)
 }
 
 static char*
-print_dragons(struct board *board, coord_t c, void *data)
+print_dragons(board_t *board, coord_t c, void *data)
 {
 	static char buf[64];
 	group_t *dragons = data;
@@ -85,7 +85,7 @@ print_dragons(struct board *board, coord_t c, void *data)
 }
 
 void
-board_print_dragons(struct board *board, FILE *f)
+board_print_dragons(board_t *board, FILE *f)
 {
 	group_t dragons[BOARD_MAX_GROUPS] = { 0, };
         board_hprint(board, f, print_dragons, dragons);
@@ -102,7 +102,7 @@ board_print_dragons(struct board *board, FILE *f)
 /* Check if g and g2 are virtually connected through lib.
  * c2 is a stone of g2 next to lib */
 static bool
-virtual_connection_at(struct board *b, enum stone color, coord_t lib, coord_t c2, group_t g1, group_t g2)
+virtual_connection_at(board_t *b, enum stone color, coord_t lib, coord_t c2, group_t g1, group_t g2)
 {
 	assert(board_at(b, lib) == S_NONE);
 	assert(board_at(b, c2) == color);
@@ -145,10 +145,10 @@ virtual_connection_at(struct board *b, enum stone color, coord_t lib, coord_t c2
 
 
 /* Handler should return -1 to stop iterating */
-typedef int (*foreach_in_connected_groups_t)(struct board *b, enum stone color, coord_t c, void *data);
+typedef int (*foreach_in_connected_groups_t)(board_t *b, enum stone color, coord_t c, void *data);
 
 static int
-foreach_in_connected_groups_(struct board *b, enum stone color, group_t g, 
+foreach_in_connected_groups_(board_t *b, enum stone color, group_t g, 
 			     foreach_in_connected_groups_t f, void *data, int *visited)
 {
 	if (visited[group_base(g)])
@@ -179,7 +179,7 @@ foreach_in_connected_groups_(struct board *b, enum stone color, group_t g,
 
 /* Call f() for each stone in dragon at @to. */
 static void 
-foreach_in_connected_groups(struct board *b, enum stone color, coord_t to, 
+foreach_in_connected_groups(board_t *b, enum stone color, coord_t to, 
 			    foreach_in_connected_groups_t f, void *data)
 {
 	int visited[BOARD_MAX_COORDS] = {0, };
@@ -190,10 +190,10 @@ foreach_in_connected_groups(struct board *b, enum stone color, coord_t to,
 
 
 /* Handler should return -1 to stop iterating. */
-typedef int (*foreach_connected_group_t)(struct board *b, enum stone color, group_t g, void *data);
+typedef int (*foreach_connected_group_t)(board_t *b, enum stone color, group_t g, void *data);
 
 static int
-foreach_connected_group_(struct board *b, enum stone color, group_t g, 
+foreach_connected_group_(board_t *b, enum stone color, group_t g, 
 			 foreach_connected_group_t f, void *data, int *visited)
 {
 	if (visited[group_base(g)])
@@ -222,7 +222,7 @@ foreach_connected_group_(struct board *b, enum stone color, group_t g,
 
 /* Call f() for each group in dragon at @to. */
 static void 
-foreach_connected_group(struct board *b, enum stone color, coord_t to,
+foreach_connected_group(board_t *b, enum stone color, coord_t to,
 			foreach_connected_group_t f, void *data)
 {
 	int visited[BOARD_MAX_COORDS] = {0, };
@@ -231,16 +231,16 @@ foreach_connected_group(struct board *b, enum stone color, coord_t to,
 	foreach_connected_group_(b, color, g, f, data, visited);
 }
 
-struct foreach_lib_data {
+typedef struct {
 	int *visited;
 	foreach_in_connected_groups_t f;
 	void *data;
-};
+} foreach_lib_data_t;
 
 static int 
-foreach_lib_handler(struct board *b, enum stone color, group_t g, void *data)
+foreach_lib_handler(board_t *b, enum stone color, group_t g, void *data)
 {
-	struct foreach_lib_data *d = data;
+	foreach_lib_data_t *d = data;
 	for (int i = 0; i < board_group_info(b, g).libs; i++) {
 		coord_t lib = board_group_info(b, g).lib[i];
 		if (d->visited[lib])
@@ -254,24 +254,24 @@ foreach_lib_handler(struct board *b, enum stone color, group_t g, void *data)
 
 /* Call f() for each liberty of dragon at @to. */
 static void
-foreach_lib_in_connected_groups(struct board *b, enum stone color, coord_t to,
+foreach_lib_in_connected_groups(board_t *b, enum stone color, coord_t to,
 				foreach_in_connected_groups_t f, void *data)
 {
 	int visited[BOARD_MAX_COORDS] = {0, };
-	struct foreach_lib_data d = { visited, f, data };	
+	foreach_lib_data_t d = { visited, f, data };	
 	foreach_connected_group(b, color, to, foreach_lib_handler, &d);
 }
 
 
 static int
-stones_all_connected_handler(struct board *b,  enum stone color, coord_t c, void *data)
+stones_all_connected_handler(board_t *b,  enum stone color, coord_t c, void *data)
 {
 	int *connected = data;
 	connected[c] = 1;  return 0;
 }
 
 static bool
-stones_all_connected(struct board *b, enum stone color, coord_t *stones, int n)
+stones_all_connected(board_t *b, enum stone color, coord_t *stones, int n)
 {
 	// TODO optimize: check if all same group first ...
 	int connected[BOARD_MAX_COORDS] = {0, };
@@ -290,7 +290,7 @@ stones_all_connected(struct board *b, enum stone color, coord_t *stones, int n)
  *  - size >= 2  (so no false eye issues)
  * Returns size of the area, or 0 if doesn't match.  */
 int
-big_eye_area(struct board *b, enum stone color, coord_t around, int *visited)
+big_eye_area(board_t *b, enum stone color, coord_t around, int *visited)
 {
 	int NAKADE_MAX = 8;  // min area size for living group (corner)
 	                     // could increase to 10 (side) and 12 (middle)
@@ -355,7 +355,7 @@ big_eye_area(struct board *b, enum stone color, coord_t around, int *visited)
  * TODO - could make tiger mouth check smarter (check selfatari) 
  *      - handle more exotic cases (ladders ?) */
 bool
-is_controlled_eye_point(struct board *b, coord_t to, enum stone color)
+is_controlled_eye_point(board_t *b, coord_t to, enum stone color)
 {
 	assert(no_stone_at(to));
 
@@ -383,7 +383,7 @@ is_controlled_eye_point(struct board *b, coord_t to, enum stone color)
 
 
 static bool
-real_eye_endpoint(struct board *board, coord_t to, enum stone color)
+real_eye_endpoint(board_t *board, coord_t to, enum stone color)
 {
 	enum stone color_diag_libs[S_MAX] = {0, 0, 0, 0};
 	
@@ -416,14 +416,14 @@ real_eye_endpoint(struct board *board, coord_t to, enum stone color)
 /* Point is finished one point eye.
  * (board_is_one_point_eye() ones can become false later ...) */
 static bool
-is_real_one_point_eye(struct board *b, coord_t to, enum stone color)
+is_real_one_point_eye(board_t *b, coord_t to, enum stone color)
 {
 	return (board_is_eyelike(b, to, color) &&
 		real_eye_endpoint(b, to, color));
 }
 
 static bool
-is_real_two_point_eye(struct board *b, coord_t to, enum stone color, coord_t *pother)
+is_real_two_point_eye(board_t *b, coord_t to, enum stone color, coord_t *pother)
 {
 	if ((neighbor_count_at(b, to, color) +	    
 	     neighbor_count_at(b, to, S_OFFBOARD)) != 3)
@@ -445,15 +445,15 @@ is_real_two_point_eye(struct board *b, coord_t to, enum stone color, coord_t *po
 		real_eye_endpoint(b, other, color));
 }
 
-struct safe_data {
+typedef struct {
 	int *visited;
 	int *eyes;
-};
+} safe_data_t;
 
 static int
-count_eyes(struct board *b, enum stone color, coord_t lib, void *data)
+count_eyes(board_t *b, enum stone color, coord_t lib, void *data)
 {	
-	struct safe_data *d = data;
+	safe_data_t *d = data;
 	if (d->visited[lib])  /* Don't visit big eyes multiple times */
 		return 0;
 
@@ -486,15 +486,15 @@ count_eyes(struct board *b, enum stone color, coord_t lib, void *data)
 }
 
 bool
-dragon_is_safe_full(struct board *b, group_t g, enum stone color, int *visited, int *eyes)
+dragon_is_safe_full(board_t *b, group_t g, enum stone color, int *visited, int *eyes)
 {
-	struct safe_data d = { visited, eyes };
+	safe_data_t d = { visited, eyes };
 	foreach_lib_in_connected_groups(b, color, g, count_eyes, &d);
 	return (*eyes >= 2);
 }
 
 bool
-dragon_is_safe(struct board *b, group_t g, enum stone color)
+dragon_is_safe(board_t *b, group_t g, enum stone color)
 {
 	int visited[BOARD_MAX_COORDS] = {0, };
 	int eyes = 0;
@@ -512,7 +512,7 @@ have_group_in(group_t g, group_t *groups, int ngroups)
 }
 
 static int
-group_neighbors(struct board *b, coord_t to, group_t *neighbors)
+group_neighbors(board_t *b, coord_t to, group_t *neighbors)
 {
 	group_t group = group_at(b, to);    assert(group);
 	enum stone color = board_at(b, to);
@@ -534,7 +534,7 @@ group_neighbors(struct board *b, coord_t to, group_t *neighbors)
 
 /* At least one neighbor is safe */
 bool
-neighbor_is_safe(struct board *b, group_t g)
+neighbor_is_safe(board_t *b, group_t g)
 {
 	group_t neighbors[BOARD_MAX_GROUPS];
 	int n = group_neighbors(b, g, neighbors);
@@ -546,14 +546,14 @@ neighbor_is_safe(struct board *b, group_t g)
 
 
 static int
-count_libs(struct board *b, enum stone color, coord_t c, void *data)
+count_libs(board_t *b, enum stone color, coord_t c, void *data)
 {	
 	int *libs = data;
 	(*libs)++;  return 0;
 }
 
 int
-dragon_liberties(struct board *b, enum stone color, coord_t to)
+dragon_liberties(board_t *b, enum stone color, coord_t to)
 {
 	int libs = 0;	
 	foreach_lib_in_connected_groups(b, color, to, count_libs, &libs);
@@ -562,14 +562,14 @@ dragon_liberties(struct board *b, enum stone color, coord_t to)
 
 
 static int
-dragon_at_handler(struct board *b, enum stone color, group_t g, void *data)
+dragon_at_handler(board_t *b, enum stone color, group_t g, void *data)
 {
 	group_t *d = data;
 	*d = (*d > g ? *d : g);  return 0;		
 }
 
 group_t
-dragon_at(struct board *b, coord_t to)
+dragon_at(board_t *b, coord_t to)
 {
 	group_t g = group_at(b, to);
 	group_t d = 0;
@@ -586,7 +586,7 @@ dragon_at(struct board *b, coord_t to)
 
 /* Vertical gap ? */
 static inline bool
-is_vert_gap(struct board *b, enum stone color, int *connected, int lx, int ly,    int x, int dy) 
+is_vert_gap(board_t *b, enum stone color, int *connected, int lx, int ly,    int x, int dy) 
 {
 	assert(dy);
 	for (int i = 0; i < GAP_LENGTH; i++) {
@@ -606,7 +606,7 @@ is_vert_gap(struct board *b, enum stone color, int *connected, int lx, int ly,  
 
 /* Horizontal gap ? */
 static inline bool
-is_horiz_gap(struct board *b, enum stone color, int *connected, int lx, int ly,   int y, int dx)
+is_horiz_gap(board_t *b, enum stone color, int *connected, int lx, int ly,   int y, int dx)
 {
 	assert(dx);
 	for (int i = 0; i < GAP_LENGTH; i++) {
@@ -636,7 +636,7 @@ is_horiz_gap(struct board *b, enum stone color, int *connected, int lx, int ly, 
  *    . O . X . .      
  */
 static bool
-two_stones_gap(struct board *b, enum stone color, coord_t lib, int *connected) 
+two_stones_gap(board_t *b, enum stone color, coord_t lib, int *connected) 
 {
 	int lx = coord_x(lib);
 	int ly = coord_y(lib);
@@ -656,21 +656,21 @@ two_stones_gap(struct board *b, enum stone color, coord_t lib, int *connected)
 }
 
 static int
-mark_connected(struct board *b,  enum stone color, coord_t c, void *data)
+mark_connected(board_t *b,  enum stone color, coord_t c, void *data)
 {
 	int *connected = data;
 	connected[c] = 1;  return 0;
 }
 
-struct surrounded_data {
+typedef struct {
 	int *connected;
 	bool surrounded;
-};
+} surrounded_data_t;
 
 static int 
-surrounded_check(struct board *b,  enum stone color, coord_t lib, void *data)
+surrounded_check(board_t *b,  enum stone color, coord_t lib, void *data)
 {    
-	struct surrounded_data *d = data;	
+	surrounded_data_t *d = data;	
 	if (two_stones_gap(b, color, lib, d->connected)) {	
 		d->surrounded = 0;    return -1;   
 	}
@@ -689,7 +689,7 @@ surrounded_check(struct board *b,  enum stone color, coord_t lib, void *data)
 }
 
 bool
-dragon_is_surrounded(struct board *b, coord_t to)
+dragon_is_surrounded(board_t *b, coord_t to)
 {
 	enum stone color = board_at(b, to);
 	assert(color == S_BLACK || color == S_WHITE);
@@ -698,7 +698,7 @@ dragon_is_surrounded(struct board *b, coord_t to)
 	/* Mark connected stones */
 	foreach_in_connected_groups(b, color, to, mark_connected, connected);
 	
-	struct surrounded_data d = { connected, 1 };
+	surrounded_data_t d = { connected, 1 };
 	foreach_lib_in_connected_groups(b, color, to, surrounded_check, &d);
 	return d.surrounded;
 }

--- a/tactics/dragon.c
+++ b/tactics/dragon.c
@@ -113,21 +113,21 @@ virtual_connection_at(struct board *b, enum stone color, coord_t lib, coord_t c2
 		return true;
 
 	/* Diagonal connection ? */
-	int x2 = coord_x(c2, b),          y2 = coord_y(c2, b);
+	int x2 = coord_x(c2),          y2 = coord_y(c2);
 	foreach_diag_neighbor(b, c2) {
 		if (board_at(b, c) != color || group_at(b, c) != g1)
 			continue;
-		int x = coord_x(c, b);    coord_t d1 = coord_xy(b, x, y2);
-		int y = coord_y(c, b);    coord_t d2 = coord_xy(b, x2, y);		   
+		int x = coord_x(c);    coord_t d1 = coord_xy(x, y2);
+		int y = coord_y(c);    coord_t d2 = coord_xy(x2, y);		   
 		if (no_stone_at(d1) && no_stone_at(d2))
 			return true;	
 	} foreach_diag_neighbor_end;
 
-	int x = coord_x(lib, b);          int dx = coord_dx(lib, c2, b);
-	int y = coord_y(lib, b);          int dy = coord_dy(lib, c2, b);
+	int x = coord_x(lib);          int dx = coord_dx(lib, c2);
+	int y = coord_y(lib);          int dy = coord_dy(lib, c2);
 	int x1 = x + dx;
 	int y1 = y + dy;
-	coord_t c1 = coord_xy(b, x1, y1);  // other side of lib wrt c2
+	coord_t c1 = coord_xy(x1, y1);  // other side of lib wrt c2
 	
 	/* Bamboo joint or stronger ? */
 	if ( own_stone_at(c1) && group_at(b, c1) == g1 && 
@@ -591,7 +591,7 @@ is_vert_gap(struct board *b, enum stone color, int *connected, int lx, int ly,  
 	assert(dy);
 	for (int i = 0; i < GAP_LENGTH; i++) {
 		int y = ly + dy * i;		
-		coord_t d = coord_xy(b, x, y);
+		coord_t d = coord_xy(x, y);
 		if (board_at(b, d) == S_NONE)
 			continue;
 		if (board_at(b, d) == color && !connected[d])
@@ -611,7 +611,7 @@ is_horiz_gap(struct board *b, enum stone color, int *connected, int lx, int ly, 
 	assert(dx);
 	for (int i = 0; i < GAP_LENGTH; i++) {
 		int x = lx + dx * i;
-		coord_t d = coord_xy(b, x, y);
+		coord_t d = coord_xy(x, y);
 		if (board_at(b, d) == S_NONE)
 			continue;
 		if (board_at(b, d) == color && !connected[d])
@@ -638,8 +638,8 @@ is_horiz_gap(struct board *b, enum stone color, int *connected, int lx, int ly, 
 static bool
 two_stones_gap(struct board *b, enum stone color, coord_t lib, int *connected) 
 {
-	int lx = coord_x(lib, b);
-	int ly = coord_y(lib, b);		
+	int lx = coord_x(lib);
+	int ly = coord_y(lib);
 
 	for (int dx = -1; dx <= 1; dx++)
 		for (int dy = -1; dy <= 1; dy++) {

--- a/tactics/dragon.c
+++ b/tactics/dragon.c
@@ -66,7 +66,7 @@ static char*
 print_dragons(board_t *board, coord_t c, void *data)
 {
 	static char buf[64];
-	group_t *dragons = data;
+	group_t *dragons = (group_t*)data;
 	group_t d = dragon_at(board, c);
 	char *before = "", *after = "";
 
@@ -240,7 +240,7 @@ typedef struct {
 static int 
 foreach_lib_handler(board_t *b, enum stone color, group_t g, void *data)
 {
-	foreach_lib_data_t *d = data;
+	foreach_lib_data_t *d = (foreach_lib_data_t*)data;
 	for (int i = 0; i < board_group_info(b, g).libs; i++) {
 		coord_t lib = board_group_info(b, g).lib[i];
 		if (d->visited[lib])
@@ -266,7 +266,7 @@ foreach_lib_in_connected_groups(board_t *b, enum stone color, coord_t to,
 static int
 stones_all_connected_handler(board_t *b,  enum stone color, coord_t c, void *data)
 {
-	int *connected = data;
+	int *connected = (int*)data;
 	connected[c] = 1;  return 0;
 }
 
@@ -385,7 +385,7 @@ is_controlled_eye_point(board_t *b, coord_t to, enum stone color)
 static bool
 real_eye_endpoint(board_t *board, coord_t to, enum stone color)
 {
-	enum stone color_diag_libs[S_MAX] = {0, 0, 0, 0};
+	int color_diag_libs[S_MAX] = {0, 0, 0, 0};
 	
 	foreach_diag_neighbor(board, to) {
 		color_diag_libs[(enum stone) board_at(board, c)]++;
@@ -453,7 +453,7 @@ typedef struct {
 static int
 count_eyes(board_t *b, enum stone color, coord_t lib, void *data)
 {	
-	safe_data_t *d = data;
+	safe_data_t *d = (safe_data_t*)data;
 	if (d->visited[lib])  /* Don't visit big eyes multiple times */
 		return 0;
 
@@ -548,7 +548,7 @@ neighbor_is_safe(board_t *b, group_t g)
 static int
 count_libs(board_t *b, enum stone color, coord_t c, void *data)
 {	
-	int *libs = data;
+	int *libs = (int*)data;
 	(*libs)++;  return 0;
 }
 
@@ -564,7 +564,7 @@ dragon_liberties(board_t *b, enum stone color, coord_t to)
 static int
 dragon_at_handler(board_t *b, enum stone color, group_t g, void *data)
 {
-	group_t *d = data;
+	group_t *d = (group_t*)data;
 	*d = (*d > g ? *d : g);  return 0;		
 }
 
@@ -658,7 +658,7 @@ two_stones_gap(board_t *b, enum stone color, coord_t lib, int *connected)
 static int
 mark_connected(board_t *b,  enum stone color, coord_t c, void *data)
 {
-	int *connected = data;
+	int *connected = (int*)data;
 	connected[c] = 1;  return 0;
 }
 
@@ -670,7 +670,7 @@ typedef struct {
 static int 
 surrounded_check(board_t *b,  enum stone color, coord_t lib, void *data)
 {    
-	surrounded_data_t *d = data;	
+	surrounded_data_t *d = (surrounded_data_t*)data;
 	if (two_stones_gap(b, color, lib, d->connected)) {	
 		d->surrounded = 0;    return -1;   
 	}

--- a/tactics/dragon.h
+++ b/tactics/dragon.h
@@ -13,16 +13,16 @@
  * may not match what we'd intuitively call a dragon: there are connections
  * it doesn't understand (dead cutting stones for instance) so it'll usually
  * be smaller. Doesn't need to be perfect though. */
-group_t dragon_at(struct board *b, coord_t to);
+group_t dragon_at(board_t *b, coord_t to);
 
 /* Returns total number of liberties of dragon at @to. */
-int dragon_liberties(struct board *b, enum stone color, coord_t to);
+int dragon_liberties(board_t *b, enum stone color, coord_t to);
 
 /* Print board highlighting given dragon */
-void dragon_print(struct board *board, FILE *f, group_t dragon);
+void dragon_print(board_t *board, FILE *f, group_t dragon);
 
 /* Like board_print() but use a different color for each dragon */
-void board_print_dragons(struct board *board, FILE *f);
+void board_print_dragons(board_t *board, FILE *f);
 
 /* Pick a color for dragon with index @i. Returns ansi color code.
  * Useful for writing custom board_print_dragons()-like functions. */
@@ -31,29 +31,29 @@ char *pick_dragon_color(int i, bool bold, bool white_ok);
 /* Try to find out if dragon has 2 eyes. Pretty conservative:
  * big eye areas are counted as one eye, must be completely enclosed and
  * have all surrounded stones connected. Doesn't need to be perfect though. */
-bool dragon_is_safe(struct board *b, group_t g, enum stone color);
+bool dragon_is_safe(board_t *b, group_t g, enum stone color);
 
 /* Like group_is_safe() but passing already visited stones / eyes. */
-bool dragon_is_safe_full(struct board *b, group_t g, enum stone color, int *visited, int *eyes);
+bool dragon_is_safe_full(board_t *b, group_t g, enum stone color, int *visited, int *eyes);
 
 /* Does one opposite color group neighbor of @g have 2 eyes ? */
-bool neighbor_is_safe(struct board *b, group_t g);
+bool neighbor_is_safe(board_t *b, group_t g);
 
 /* Try to detect big eye area, ie:
  *  - completely enclosed area, not too big,
  *  - surrounding stones all connected to each other
  *  - size >= 2  (so no false eye issues)
  * Returns size of the area, or 0 if doesn't match.  */
-int big_eye_area(struct board *b, enum stone color, coord_t around, int *visited);
+int big_eye_area(board_t *b, enum stone color, coord_t around, int *visited);
 
 /* Point we control: 
  * Opponent can't play there or we can capture if he does. */
-bool is_controlled_eye_point(struct board *b, coord_t to, enum stone color);
+bool is_controlled_eye_point(board_t *b, coord_t to, enum stone color);
 
 /* Try to find out if dragon is completely surrounded:
  * Look for outwards 2-stones gap from our external liberties. 
  * (hack, but works pretty well in practice) */
-bool dragon_is_surrounded(struct board *b, coord_t to);
+bool dragon_is_surrounded(board_t *b, coord_t to);
 
 
 #endif /* PACHI_TACTICS_DRAGON_H */

--- a/tactics/ladder.c
+++ b/tactics/ladder.c
@@ -20,7 +20,7 @@
 
 
 bool
-is_border_ladder(struct board *b, group_t laddered)
+is_border_ladder(board_t *b, group_t laddered)
 {
 	coord_t coord = board_group_info(b, laddered).lib[0];
 	enum stone lcolor = board_at(b, group_base(laddered));
@@ -73,10 +73,10 @@ is_border_ladder(struct board *b, group_t laddered)
 }
 
 
-static int middle_ladder_walk(struct board *b, group_t laddered, enum stone lcolor, coord_t prevmove, int len);
+static int middle_ladder_walk(board_t *b, group_t laddered, enum stone lcolor, coord_t prevmove, int len);
 
 static int
-middle_ladder_chase(struct board *b, group_t laddered, enum stone lcolor, coord_t prevmove, int len)
+middle_ladder_chase(board_t *b, group_t laddered, enum stone lcolor, coord_t prevmove, int len)
 {
 	laddered = group_at(b, laddered);
 	
@@ -133,7 +133,7 @@ middle_ladder_chase(struct board *b, group_t laddered, enum stone lcolor, coord_
 
 /* Can we escape by capturing chaser ? */
 static bool
-chaser_capture_escapes(struct board *b, group_t laddered, enum stone lcolor, struct move_queue *ccq)
+chaser_capture_escapes(board_t *b, group_t laddered, enum stone lcolor, move_queue_t *ccq)
 {
 	for (unsigned int i = 0; i < ccq->moves; i++) {
 		coord_t lib = ccq->move[i];
@@ -170,7 +170,7 @@ chaser_capture_escapes(struct board *b, group_t laddered, enum stone lcolor, str
  * group captured, false if not (i.e. for each branch, laddered group can
  * gain three liberties). */
 static int
-middle_ladder_walk(struct board *b, group_t laddered, enum stone lcolor, coord_t prevmove, int len)
+middle_ladder_walk(board_t *b, group_t laddered, enum stone lcolor, coord_t prevmove, int len)
 {
 	assert(board_group_info(b, laddered).libs == 1);
 
@@ -184,7 +184,7 @@ middle_ladder_walk(struct board *b, group_t laddered, enum stone lcolor, coord_t
 		});
 
 	/* Check countercaptures */
-	struct move_queue ccq;  mq_init(&ccq);
+	move_queue_t ccq;  mq_init(&ccq);
 	can_countercapture(b, laddered, &ccq, 0);
 	
 	if (chaser_capture_escapes(b, laddered, lcolor, &ccq))
@@ -203,7 +203,7 @@ middle_ladder_walk(struct board *b, group_t laddered, enum stone lcolor, coord_t
 static __thread int length = 0;
 
 bool
-is_middle_ladder(struct board *b, group_t laddered)
+is_middle_ladder(board_t *b, group_t laddered)
 {
 	coord_t coord = board_group_info(b, laddered).lib[0];
 	enum stone lcolor = board_at(b, group_base(laddered));
@@ -227,7 +227,7 @@ is_middle_ladder(struct board *b, group_t laddered)
 }
 
 bool
-is_middle_ladder_any(struct board *b, group_t laddered)
+is_middle_ladder_any(board_t *b, group_t laddered)
 {
 	enum stone lcolor = board_at(b, group_base(laddered));
 	
@@ -236,7 +236,7 @@ is_middle_ladder_any(struct board *b, group_t laddered)
 }
 
 bool
-wouldbe_ladder(struct board *b, group_t group, coord_t chaselib)
+wouldbe_ladder(board_t *b, group_t group, coord_t chaselib)
 {
 	assert(board_group_info(b, group).libs == 2);
 	
@@ -268,7 +268,7 @@ wouldbe_ladder(struct board *b, group_t group, coord_t chaselib)
 
 
 bool
-wouldbe_ladder_any(struct board *b, group_t group, coord_t chaselib)
+wouldbe_ladder_any(board_t *b, group_t group, coord_t chaselib)
 {
 	assert(board_group_info(b, group).libs == 2);
 	
@@ -300,7 +300,7 @@ wouldbe_ladder_any(struct board *b, group_t group, coord_t chaselib)
  *
  * XXX can also be useful in other situations ? Should be pretty rare hopefully */
 bool
-useful_ladder(struct board *b, group_t laddered)
+useful_ladder(board_t *b, group_t laddered)
 {
 	if (length >= 4 ||
 	    group_stone_count(b, laddered, 6) > 5 ||
@@ -356,7 +356,7 @@ useful_ladder(struct board *b, group_t laddered)
 }
 
 static bool
-is_double_atari(struct board *b, coord_t c, enum stone color)
+is_double_atari(board_t *b, coord_t c, enum stone color)
 {
 	if (board_at(b, c) != S_NONE ||
 	    immediate_liberty_count(b, c) < 2 ||  /* can't play there (hack) */
@@ -374,7 +374,7 @@ is_double_atari(struct board *b, coord_t c, enum stone color)
 }
 
 static bool
-ladder_with_tons_of_double_ataris(struct board *b, group_t laddered, enum stone color)
+ladder_with_tons_of_double_ataris(board_t *b, group_t laddered, enum stone color)
 {
 	assert(board_at(b, laddered) == stone_other(color));
 
@@ -391,7 +391,7 @@ ladder_with_tons_of_double_ataris(struct board *b, group_t laddered, enum stone 
 }
 
 bool
-harmful_ladder_atari(struct board *b, coord_t atari, enum stone color)
+harmful_ladder_atari(board_t *b, coord_t atari, enum stone color)
 {
 	assert(board_at(b, atari) == S_NONE);
 	

--- a/tactics/ladder.c
+++ b/tactics/ladder.c
@@ -28,7 +28,7 @@ is_border_ladder(struct board *b, group_t laddered)
 	if (can_countercapture(b, laddered, NULL, 0))
 		return false;
 	
-	int x = coord_x(coord, b), y = coord_y(coord, b);
+	int x = coord_x(coord), y = coord_y(coord);
 
 	if (DEBUGL(5))  fprintf(stderr, "border ladder\n");
 	
@@ -64,10 +64,10 @@ is_border_ladder(struct board *b, group_t laddered)
 	if (libs1 < 2 || libs2 < 2)  return false;
 	/* Would be self-atari? */
 	if (libs1 < 3 && (board_atxy(b, x + xd * 2, y + yd * 2) != S_NONE
-			  || coord_is_adjecent(board_group_info(b, g1).lib[0], board_group_info(b, g1).lib[1], b)))
+			  || coord_is_adjecent(board_group_info(b, g1).lib[0], board_group_info(b, g1).lib[1])))
 		return false;
 	if (libs2 < 3 && (board_atxy(b, x - xd * 2, y - yd * 2) != S_NONE
-			  || coord_is_adjecent(board_group_info(b, g2).lib[0], board_group_info(b, g2).lib[1], b)))
+			  || coord_is_adjecent(board_group_info(b, g2).lib[0], board_group_info(b, g2).lib[1])))
 		return false;
 	return true;
 }
@@ -82,7 +82,7 @@ middle_ladder_chase(struct board *b, group_t laddered, enum stone lcolor, coord_
 	
 	if (DEBUGL(8)) {
 		board_print(b, stderr);
-		fprintf(stderr, "%s c %d\n", coord2sstr(laddered, b), board_group_info(b, laddered).libs);
+		fprintf(stderr, "%s c %d\n", coord2sstr(laddered), board_group_info(b, laddered).libs);
 	}
 
 	if (!laddered || board_group_info(b, laddered).libs == 1) {
@@ -99,7 +99,7 @@ middle_ladder_chase(struct board *b, group_t laddered, enum stone lcolor, coord_
 	for (int i = 0; i < 2; i++) {
 		coord_t ataristone = board_group_info(b, laddered).lib[i];
 		coord_t escape = board_group_info(b, laddered).lib[1 - i];
-		if (immediate_liberty_count(b, escape) > 2 + coord_is_adjecent(ataristone, escape, b)) {
+		if (immediate_liberty_count(b, escape) > 2 + coord_is_adjecent(ataristone, escape)) {
 			/* Too much free space, ignore. */
 			continue;
 		}
@@ -121,7 +121,7 @@ middle_ladder_chase(struct board *b, group_t laddered, enum stone lcolor, coord_
 			if (!group_at(b, ataristone))
 					break;
 
-			if (DEBUGL(6))  fprintf(stderr, "(%d=0) ladder atari %s (%d libs)\n", i, coord2sstr(ataristone, b), board_group_info(b, group_at(b, ataristone)).libs);
+			if (DEBUGL(6))  fprintf(stderr, "(%d=0) ladder atari %s (%d libs)\n", i, coord2sstr(ataristone), board_group_info(b, group_at(b, ataristone)).libs);
 
 			int l = middle_ladder_walk(b, laddered, lcolor, prevmove, len);
 			if (l)  with_move_return(l);
@@ -146,7 +146,7 @@ chaser_capture_escapes(struct board *b, group_t laddered, enum stone lcolor, str
 
 		/* We can capture one of the ladder stones, investigate ... */
 		if (DEBUGL(6)) {
-			fprintf(stderr, "------------- can capture chaser, investigating %s -------------\n", coord2sstr(lib, b));
+			fprintf(stderr, "------------- can capture chaser, investigating %s -------------\n", coord2sstr(lib));
 			board_print(b, stderr);
 		}
 
@@ -155,7 +155,7 @@ chaser_capture_escapes(struct board *b, group_t laddered, enum stone lcolor, str
 				with_move_return(true); /* escape ! */		
 		});
 
-		if (DEBUGL(6))  fprintf(stderr, "-------------------------- done %s ------------------------------\n", coord2sstr(lib, b));
+		if (DEBUGL(6))  fprintf(stderr, "-------------------------- done %s ------------------------------\n", coord2sstr(lib));
 	}
 	
 	return false;
@@ -192,7 +192,7 @@ middle_ladder_walk(struct board *b, group_t laddered, enum stone lcolor, coord_t
 
 	/* Escape then */
 	coord_t nextmove = board_group_info(b, laddered).lib[0];
-	if (DEBUGL(6))  fprintf(stderr, "  ladder escape %s\n", coord2sstr(nextmove, b));
+	if (DEBUGL(6))  fprintf(stderr, "  ladder escape %s\n", coord2sstr(nextmove));
 	with_move_strict(b, nextmove, lcolor, {
 		len = middle_ladder_chase(b, laddered, lcolor, nextmove, len + 1);
 	});
@@ -245,7 +245,7 @@ wouldbe_ladder(struct board *b, group_t group, coord_t chaselib)
 	coord_t escapelib = board_group_other_lib(b, group, chaselib);
 
 	if (DEBUGL(6))  fprintf(stderr, "would-be ladder check - does %s %s play out chasing move %s?\n",
-				stone2str(lcolor), coord2sstr(escapelib, b), coord2sstr(chaselib, b));
+				stone2str(lcolor), coord2sstr(escapelib), coord2sstr(chaselib));
 
 	if (immediate_liberty_count(b, escapelib) != 2) {
 		if (DEBUGL(5))  fprintf(stderr, "no ladder, or overly trivial for a ladder\n");

--- a/tactics/ladder.c
+++ b/tactics/ladder.c
@@ -184,7 +184,7 @@ middle_ladder_walk(struct board *b, group_t laddered, enum stone lcolor, coord_t
 		});
 
 	/* Check countercaptures */
-	struct move_queue ccq = { .moves = 0 };
+	struct move_queue ccq;  mq_init(&ccq);
 	can_countercapture(b, laddered, &ccq, 0);
 	
 	if (chaser_capture_escapes(b, laddered, lcolor, &ccq))

--- a/tactics/ladder.h
+++ b/tactics/ladder.h
@@ -9,31 +9,31 @@
 /* Check if group in atari can be caught in a ladder.
  * Two ways of ladder reading can be enabled separately; simple first-line
  * ladders and trivial middle-board ladders. */
-static bool is_ladder(struct board *b, group_t laddered, bool test_middle);
+static bool is_ladder(board_t *b, group_t laddered, bool test_middle);
 
 /* Also consider unusual/very short ladders.
  * Note: same as is_ladder() if test_middle is false ... */
-static bool is_ladder_any(struct board *b, group_t laddered, bool test_middle);
+static bool is_ladder_any(board_t *b, group_t laddered, bool test_middle);
 
 /* Check if a 2-lib group would be caught in a ladder given opponent stone at @chaselib. */
-bool wouldbe_ladder(struct board *b, group_t group, coord_t chaselib);
+bool wouldbe_ladder(board_t *b, group_t group, coord_t chaselib);
 
 /* Like wouldbe_ladder() but also consider unusual/very short ladders.
  * Use this if you only care whether group can be captured. */
-bool wouldbe_ladder_any(struct board *b, group_t group, coord_t chaselib);
+bool wouldbe_ladder_any(board_t *b, group_t group, coord_t chaselib);
 
 /* Try to find out if playing out lost ladder could be useful for life&death. 
  * Call right after is_ladder(), uses static state. */
-bool useful_ladder(struct board *b, group_t laddered);
+bool useful_ladder(board_t *b, group_t laddered);
 
 /* Playing out non-working ladder and getting ugly ? */
-bool harmful_ladder_atari(struct board *b, coord_t atari, enum stone color);
+bool harmful_ladder_atari(board_t *b, coord_t atari, enum stone color);
 
-bool is_border_ladder(struct board *b, group_t laddered);
-bool is_middle_ladder(struct board *b, group_t laddered);
-bool is_middle_ladder_any(struct board *b, group_t laddered);
+bool is_border_ladder(board_t *b, group_t laddered);
+bool is_middle_ladder(board_t *b, group_t laddered);
+bool is_middle_ladder_any(board_t *b, group_t laddered);
 static inline bool
-is_ladder(struct board *b, group_t laddered, bool test_middle)
+is_ladder(board_t *b, group_t laddered, bool test_middle)
 {
 	assert(laddered);
 	assert(group_at(b, laddered) == laddered);
@@ -65,7 +65,7 @@ is_ladder(struct board *b, group_t laddered, bool test_middle)
 }
 
 static inline bool
-is_ladder_any(struct board *b, group_t laddered, bool test_middle)
+is_ladder_any(board_t *b, group_t laddered, bool test_middle)
 {
 	assert(laddered);
 	assert(group_at(b, laddered) == laddered);

--- a/tactics/ladder.h
+++ b/tactics/ladder.h
@@ -43,7 +43,7 @@ is_ladder(struct board *b, group_t laddered, bool test_middle)
 		coord_t coord = board_group_info(b, laddered).lib[0];
 		enum stone lcolor = board_at(b, group_base(laddered));
 		fprintf(stderr, "ladder check - does %s play out %s's laddered group %s?\n",
-			coord2sstr(coord, b), stone2str(lcolor), coord2sstr(laddered, b));
+			coord2sstr(coord), stone2str(lcolor), coord2sstr(laddered));
 	}
 
 	if (!test_middle) {
@@ -75,7 +75,7 @@ is_ladder_any(struct board *b, group_t laddered, bool test_middle)
 		coord_t coord = board_group_info(b, laddered).lib[0];
 		enum stone lcolor = board_at(b, group_base(laddered));
 		fprintf(stderr, "ladder check - does %s play out %s's laddered group %s?\n",
-			coord2sstr(coord, b), stone2str(lcolor), coord2sstr(laddered, b));
+			coord2sstr(coord), stone2str(lcolor), coord2sstr(laddered));
 	}
 
 	if (!test_middle) {

--- a/tactics/nakade.c
+++ b/tactics/nakade.c
@@ -55,7 +55,7 @@ get_neighbors(struct board *b, coord_t *area, int area_n, int *neighbors, int *p
         memset(neighbors, 0, area_n * sizeof(int));
 	for (int i = 0; i < area_n; i++) {
 		for (int j = i + 1; j < area_n; j++)
-			if (coord_is_adjecent(area[i], area[j], b)) {
+			if (coord_is_adjecent(area[i], area[j])) {
 				ptbynei[neighbors[i]]--;
 				neighbors[i]++;
 				ptbynei[neighbors[i]]++;

--- a/tactics/nakade.c
+++ b/tactics/nakade.c
@@ -12,7 +12,7 @@
 
 
 static inline int
-nakade_area(struct board *b, coord_t around, enum stone color, coord_t *area)
+nakade_area(board_t *b, coord_t around, enum stone color, coord_t *area)
 {
 	/* First, examine the nakade area. For sure, it must be at most
 	 * six points. And it must be within color group(s). */
@@ -47,7 +47,7 @@ nakade_area(struct board *b, coord_t around, enum stone color, coord_t *area)
 }
 
 static inline void
-get_neighbors(struct board *b, coord_t *area, int area_n, int *neighbors, int *ptbynei)
+get_neighbors(board_t *b, coord_t *area, int area_n, int *neighbors, int *ptbynei)
 {
 	/* We also collect adjecency information - how many neighbors
 	 * we have for each area point, and histogram of this. This helps
@@ -95,7 +95,7 @@ nakade_point_(coord_t *area, int area_n, int *neighbors, int *ptbynei)
 }
 
 coord_t
-nakade_point(struct board *b, coord_t around, enum stone color)
+nakade_point(board_t *b, coord_t around, enum stone color)
 {
 	assert(board_at(b, around) == S_NONE);	
 	coord_t area[NAKADE_MAX]; int area_n = 0;
@@ -111,7 +111,7 @@ nakade_point(struct board *b, coord_t around, enum stone color)
 
 
 bool
-nakade_dead_shape(struct board *b, coord_t around, enum stone color)
+nakade_dead_shape(board_t *b, coord_t around, enum stone color)
 {
 	assert(board_at(b, around) == S_NONE);
 	coord_t area[NAKADE_MAX]; int area_n = 0;

--- a/tactics/nakade.h
+++ b/tactics/nakade.h
@@ -9,9 +9,9 @@
 /* Find an eye-piercing point within the @around area of empty board
  * internal to group of color @color.
  * Returns pass if the area is not a nakade shape or not internal. */
-coord_t nakade_point(struct board *b, coord_t around, enum stone color);
+coord_t nakade_point(board_t *b, coord_t around, enum stone color);
 
 /* big eyespace can be reduced to one eye */
-bool nakade_dead_shape(struct board *b, coord_t around, enum stone color);
+bool nakade_dead_shape(board_t *b, coord_t around, enum stone color);
 
 #endif

--- a/tactics/nlib.c
+++ b/tactics/nlib.c
@@ -14,7 +14,7 @@
 
 
 void
-group_nlib_defense_check(struct board *b, group_t group, enum stone to_play, struct move_queue *q, int tag)
+group_nlib_defense_check(board_t *b, group_t group, enum stone to_play, move_queue_t *q, int tag)
 {
 	enum stone color = to_play;
 	assert(color != S_OFFBOARD && color != S_NONE

--- a/tactics/nlib.c
+++ b/tactics/nlib.c
@@ -20,9 +20,7 @@ group_nlib_defense_check(struct board *b, group_t group, enum stone to_play, str
 	assert(color != S_OFFBOARD && color != S_NONE
 	       && color == board_at(b, group_base(group)));
 
-	if (DEBUGL(5))
-		fprintf(stderr, "[%s] nlib defense check of color %d\n",
-			coord2sstr(group, b), color);
+	if (DEBUGL(5))  fprintf(stderr, "[%s] nlib defense check of color %d\n", coord2sstr(group), color);
 
 #if 0
 	/* XXX: The code below is specific for 3-liberty groups. Its impact

--- a/tactics/nlib.h
+++ b/tactics/nlib.h
@@ -6,8 +6,6 @@
 #include "board.h"
 #include "debug.h"
 
-struct move_queue;
-
-void group_nlib_defense_check(struct board *b, group_t group, enum stone to_play, struct move_queue *q, int tag);
+void group_nlib_defense_check(board_t *b, group_t group, enum stone to_play, move_queue_t *q, int tag);
 
 #endif

--- a/tactics/seki.c
+++ b/tactics/seki.c
@@ -101,7 +101,7 @@ breaking_corner_seki(struct board *b, coord_t coord, enum stone color)
 	if (!gi)  return false;
 
 	/* Other lib is corner eye ? */
-	int x = coord_x(lib2, b), y = coord_y(lib2, b);
+	int x = coord_x(lib2), y = coord_y(lib2);
 	if ((x != 1 && x != real_board_size(b)) ||
 	    (y != 1 && y != real_board_size(b)) ||
 	    !board_is_one_point_eye(b, lib2, color))

--- a/tactics/seki.c
+++ b/tactics/seki.c
@@ -19,7 +19,7 @@
  *   O X . O . |     - b groups 2 libs
  *  -----------+     - dead shape after filling eye    */
 bool
-breaking_false_eye_seki(struct board *b, coord_t coord, enum stone color)
+breaking_false_eye_seki(board_t *b, coord_t coord, enum stone color)
 {
 	enum stone other_color = stone_other(color);	
 	if (!board_is_eyelike(b, coord, color))
@@ -68,7 +68,7 @@ breaking_false_eye_seki(struct board *b, coord_t coord, enum stone color)
  *     O X O . |      O X O . |      - w makes a dead shape selfatari by playing at @coord
  *    ---------+     ---------+        (selfatari checks passed, so we know shape is dead)   */
 bool
-breaking_corner_seki(struct board *b, coord_t coord, enum stone color)
+breaking_corner_seki(board_t *b, coord_t coord, enum stone color)
 {
 	enum stone other_color = stone_other(color);	
 
@@ -139,7 +139,7 @@ breaking_corner_seki(struct board *b, coord_t coord, enum stone color)
  *   O . X X X |
  *   . O O O O |   */
 bool
-breaking_3_stone_seki(struct board *b, coord_t coord, enum stone color)
+breaking_3_stone_seki(board_t *b, coord_t coord, enum stone color)
 {
 	enum stone other_color = stone_other(color);
 	

--- a/tactics/seki.h
+++ b/tactics/seki.h
@@ -11,8 +11,8 @@
 	(b->moves > MOGGY_ENDGAME && (random_move))
 
 
-bool breaking_3_stone_seki(struct board *b, coord_t coord, enum stone color);
-bool breaking_corner_seki(struct board *b, coord_t coord, enum stone color);
-bool breaking_false_eye_seki(struct board *b, coord_t coord, enum stone color);
+bool breaking_3_stone_seki(board_t *b, coord_t coord, enum stone color);
+bool breaking_corner_seki(board_t *b, coord_t coord, enum stone color);
+bool breaking_false_eye_seki(board_t *b, coord_t coord, enum stone color);
 
 #endif /* PACHI_TACTICS_SEKI_H */

--- a/tactics/selfatari.c
+++ b/tactics/selfatari.c
@@ -766,7 +766,7 @@ found:;
 
 		coord_t lib2;
 		/* Can we get liberties by capturing a neighbor? */
-		struct move_queue ccq; ccq.moves = 0;
+		struct move_queue ccq;  mq_init(&ccq);
 		if (board_at(b, group) == color &&
 		    can_countercapture(b, group, &ccq, 0)) {
 			lib2 = mq_pick(&ccq);

--- a/tactics/selfatari.c
+++ b/tactics/selfatari.c
@@ -53,7 +53,7 @@ three_liberty_suicide(struct board *b, group_t g, enum stone color, coord_t to, 
 	for (int i = 0, j = 0; i < 3; i++) {
 		coord_t lib = board_group_info(b, g).lib[i];
 		if (lib != to) {
-			other_libs_adj[j] = coord_is_adjecent(lib, to, b);
+			other_libs_adj[j] = coord_is_adjecent(lib, to);
 			other_libs[j++] = lib;
 		}
 	}
@@ -86,7 +86,7 @@ three_liberty_suicide(struct board *b, group_t g, enum stone color, coord_t to, 
 	/* Therefore, the final suicidal test is: (After filling this
 	 * liberty,) when opponent fills liberty [0], playing liberty
 	 * [1] will not help the group, or vice versa. */
-	bool other_libs_neighbors = coord_is_adjecent(other_libs[0], other_libs[1], b);
+	bool other_libs_neighbors = coord_is_adjecent(other_libs[0], other_libs[1]);
 	for (int i = 0; i < 2; i++) {
 		int null_libs = other_libs_neighbors + other_libs_adj[i];
 		if (board_is_one_point_eye(b, other_libs[1 - i], color)) {
@@ -117,7 +117,7 @@ next_lib:
 		 * before wasting a liberty. So no need to check. */
 		/* Ok, the last liberty has no way to get out. */
 		if (DEBUGL(6))
-			fprintf(stderr, "3-lib dangerous: %s\n", coord2sstr(other_libs[i], b));
+			fprintf(stderr, "3-lib dangerous: %s\n", coord2sstr(other_libs[i]));
 		return true;
 	}
 
@@ -164,7 +164,7 @@ examine_friendly_groups(struct board *b, enum stone color, coord_t to, struct se
 			return false;
 		/* ...or one liberty, but not lib2. */
 		if (s->groupcts[S_NONE] > 0
-		    && !coord_is_adjecent(lib2, to, b))
+		    && !coord_is_adjecent(lib2, to))
 			return false;
 
 		/* ...ok, then we can still contribute a liberty
@@ -682,7 +682,7 @@ bool
 is_bad_selfatari_slow(struct board *b, enum stone color, coord_t to, int flags)
 {
 	if (DEBUGL(5))
-		fprintf(stderr, "sar check %s %s\n", stone2str(color), coord2sstr(to, b));
+		fprintf(stderr, "sar check %s %s\n", stone2str(color), coord2sstr(to));
 	/* Assess if we actually gain any liberties by this escape route.
 	 * Note that this is not 100% as we cannot check whether we are
 	 * connecting out or just to ourselves. */
@@ -735,7 +735,7 @@ selfatari_cousin(struct board *b, enum stone color, coord_t coord, group_t *bygr
 			groups[groups_n++] = g;
 			groupsbycolor[s]++;
 			if (DEBUGL(6))
-				fprintf(stderr, "%s(%s) ", coord2sstr(c, b), stone2str(s));
+				fprintf(stderr, "%s(%s) ", coord2sstr(c), stone2str(s));
 		}
 	});
 	if (DEBUGL(6))

--- a/tactics/selfatari.c
+++ b/tactics/selfatari.c
@@ -15,7 +15,7 @@
 #include "nakade.h"
 
 
-struct selfatari_state {
+typedef struct {
 	int groupcts[S_MAX];
 	group_t groupids[S_MAX][4];
 	coord_t groupneis[S_MAX][4];
@@ -30,10 +30,10 @@ struct selfatari_state {
 	/* ID of the first liberty, providing it again is not
 	 * interesting. */
 	coord_t needs_more_lib_except;
-};
+} selfatari_state_t;
 
 static bool
-three_liberty_suicide(struct board *b, group_t g, enum stone color, coord_t to, struct selfatari_state *s)
+three_liberty_suicide(board_t *b, group_t g, enum stone color, coord_t to, selfatari_state_t *s)
 {
 	/* If a group has three liberties, by playing on one of
 	 * them it is possible to kill the group clumsily. Check
@@ -125,7 +125,7 @@ next_lib:
 }
 
 static int
-examine_friendly_groups(struct board *b, enum stone color, coord_t to, struct selfatari_state *s, int flags)
+examine_friendly_groups(board_t *b, enum stone color, coord_t to, selfatari_state_t *s, int flags)
 {
 	for (int i = 0; i < s->groupcts[color]; i++) {
 		/* We can escape by connecting to this group if it's
@@ -178,7 +178,7 @@ examine_friendly_groups(struct board *b, enum stone color, coord_t to, struct se
 }
 
 static int
-examine_enemy_groups(struct board *b, enum stone color, coord_t to, struct selfatari_state *s)
+examine_enemy_groups(board_t *b, enum stone color, coord_t to, selfatari_state_t *s)
 {
 	/* We may be able to gain a liberty by capturing this group. */
 	group_t can_capture = 0;
@@ -228,7 +228,7 @@ examine_enemy_groups(struct board *b, enum stone color, coord_t to, struct selfa
 }
 
 static inline bool
-is_neighbor_group(struct board *b, enum stone color, group_t g, struct selfatari_state *s)
+is_neighbor_group(board_t *b, enum stone color, group_t g, selfatari_state_t *s)
 {
 	for (int i = 0; i < s->groupcts[color]; i++)
 		if (g == s->groupids[color][i])
@@ -240,7 +240,7 @@ is_neighbor_group(struct board *b, enum stone color, group_t g, struct selfatari
 /* Instead of playing this self-atari, could we have connected/escaped by 
  * playing on the other liberty of a neighboring group ? */
 static inline bool
-is_bad_nakade(struct board *b, enum stone color, coord_t to, coord_t lib2, struct selfatari_state *s)
+is_bad_nakade(board_t *b, enum stone color, coord_t to, coord_t lib2, selfatari_state_t *s)
 {
 	/* Let's look at neighbors of the other liberty: */
 	foreach_neighbor(b, lib2, {
@@ -278,7 +278,7 @@ is_bad_nakade(struct board *b, enum stone color, coord_t to, coord_t lib2, struc
 /* Instead of playing this self-atari, could we have connected/escaped by 
  * playing on the other liberty of a neighboring group ? */
 static inline bool
-can_escape_instead(struct board *b, enum stone color, coord_t to, struct selfatari_state *s)
+can_escape_instead(board_t *b, enum stone color, coord_t to, selfatari_state_t *s)
 {
 	for (int i = 0; i < s->groupcts[color]; i++) {
 		group_t g = s->groupids[color][i];
@@ -295,7 +295,7 @@ can_escape_instead(struct board *b, enum stone color, coord_t to, struct selfata
 }
 
 static inline bool
-unreachable_lib_from_neighbors(struct board *b, enum stone color, coord_t to, struct selfatari_state *s,
+unreachable_lib_from_neighbors(board_t *b, enum stone color, coord_t to, selfatari_state_t *s,
 			       coord_t lib)
 {
 	for (int i = 0; i < s->groupcts[color]; i++) {
@@ -309,7 +309,7 @@ unreachable_lib_from_neighbors(struct board *b, enum stone color, coord_t to, st
 
 /* This only looks at existing empty spots, not captures */
 static inline bool
-capture_would_make_extra_eye(struct board *b, enum stone color, coord_t to, struct selfatari_state *s)
+capture_would_make_extra_eye(board_t *b, enum stone color, coord_t to, selfatari_state_t *s)
 {
 	foreach_neighbor(b, to, {
 		if (board_at(b, c) == S_NONE)
@@ -321,7 +321,7 @@ capture_would_make_extra_eye(struct board *b, enum stone color, coord_t to, stru
 
 /* Only cares about dead shape. */
 static bool
-nakade_making_dead_shape(struct board *b, enum stone color, coord_t to, int stones)
+nakade_making_dead_shape(board_t *b, enum stone color, coord_t to, int stones)
 {
 	assert(stones >= 1);
 	assert(stones <= 5);
@@ -340,7 +340,7 @@ nakade_making_dead_shape(struct board *b, enum stone color, coord_t to, int ston
 }
 
 static bool
-useful_nakade_making_dead_shape(struct board *b, enum stone color, coord_t to, struct selfatari_state *s,
+useful_nakade_making_dead_shape(board_t *b, enum stone color, coord_t to, selfatari_state_t *s,
 				bool atariing_group, int stones)
 {
 	int cap_would_make_eye = false;
@@ -435,7 +435,7 @@ useful_nakade_making_dead_shape(struct board *b, enum stone color, coord_t to, s
  * We also allow to only nakade if the created shape is dead
  * (http://senseis.xmp.net/?Nakade). */
 static int
-setup_nakade(struct board *b, enum stone color, coord_t to, struct selfatari_state *s)
+setup_nakade(board_t *b, enum stone color, coord_t to, selfatari_state_t *s)
 {
 	/* Look at the enemy groups and determine the other contended
 	 * liberty. We must make sure the liberty:
@@ -516,7 +516,7 @@ setup_nakade(struct board *b, enum stone color, coord_t to, struct selfatari_sta
 }
 
 static int
-setup_nakade_big_group_only(struct board *b, enum stone color, coord_t to, struct selfatari_state *s)
+setup_nakade_big_group_only(board_t *b, enum stone color, coord_t to, selfatari_state_t *s)
 {
 	// Throwing a single stone in ? Fine.
 	if (!s->groupcts[color])
@@ -560,8 +560,8 @@ setup_nakade_big_group_only(struct board *b, enum stone color, coord_t to, struc
 /* Fast but there are issues with this (triangle six is not dead !)
  * We also need to know status if opponent plays first */
 static inline int
-nakade_making_dead_shape_hack(struct board *b, enum stone color, coord_t to, int lib2,
-			      struct selfatari_state *s, int stones)
+nakade_making_dead_shape_hack(board_t *b, enum stone color, coord_t to, int lib2,
+			      selfatari_state_t *s, int stones)
 {
 	/* It also remains to be seen whether it is nakade
 	 * and not seki destruction. To do this properly, we
@@ -610,7 +610,7 @@ nakade_making_dead_shape_hack(struct board *b, enum stone color, coord_t to, int
 
 
 static int
-check_throwin(struct board *b, enum stone color, coord_t to, struct selfatari_state *s)
+check_throwin(board_t *b, enum stone color, coord_t to, selfatari_state_t *s)
 {
 	/* We can be throwing-in to false eye:
 	 * X X X O X X X O X X X X X
@@ -658,7 +658,7 @@ check_throwin(struct board *b, enum stone color, coord_t to, struct selfatari_st
 }
 
 static void
-init_selfatari_state(struct board *b, enum stone color, coord_t to, struct selfatari_state *s)
+init_selfatari_state(board_t *b, enum stone color, coord_t to, selfatari_state_t *s)
 {
 	memset(s, 0, sizeof(*s));
 
@@ -679,7 +679,7 @@ init_selfatari_state(struct board *b, enum stone color, coord_t to, struct selfa
 }
 
 bool
-is_bad_selfatari_slow(struct board *b, enum stone color, coord_t to, int flags)
+is_bad_selfatari_slow(board_t *b, enum stone color, coord_t to, int flags)
 {
 	if (DEBUGL(5))
 		fprintf(stderr, "sar check %s %s\n", stone2str(color), coord2sstr(to));
@@ -687,7 +687,7 @@ is_bad_selfatari_slow(struct board *b, enum stone color, coord_t to, int flags)
 	 * Note that this is not 100% as we cannot check whether we are
 	 * connecting out or just to ourselves. */
 
-	struct selfatari_state s;
+	selfatari_state_t s;
 	init_selfatari_state(b, color, to, &s);
 	
 	/* We have shortage of liberties; that's the point. */
@@ -722,7 +722,7 @@ is_bad_selfatari_slow(struct board *b, enum stone color, coord_t to, int flags)
 
 
 coord_t
-selfatari_cousin(struct board *b, enum stone color, coord_t coord, group_t *bygroup)
+selfatari_cousin(board_t *b, enum stone color, coord_t coord, group_t *bygroup)
 {
 	group_t groups[4]; int groups_n = 0;
 	int groupsbycolor[4] = {0, 0, 0, 0};
@@ -766,7 +766,7 @@ found:;
 
 		coord_t lib2;
 		/* Can we get liberties by capturing a neighbor? */
-		struct move_queue ccq;  mq_init(&ccq);
+		move_queue_t ccq;  mq_init(&ccq);
 		if (board_at(b, group) == color &&
 		    can_countercapture(b, group, &ccq, 0)) {
 			lib2 = mq_pick(&ccq);

--- a/tactics/selfatari.h
+++ b/tactics/selfatari.h
@@ -11,15 +11,15 @@
  * want to avoid these moves. The function actually does a rather elaborate
  * tactical check, allowing self-atari moves that are nakade, eye falsification
  * or throw-ins. */
-static bool is_bad_selfatari(struct board *b, enum stone color, coord_t to);
+static bool is_bad_selfatari(board_t *b, enum stone color, coord_t to);
 
 /* Check if this move is a really bad self-atari, allowing opponent to capture
  * 3 stones or more that could have been saved / don't look like useful nakade.
  * Doesn't care much about 1 stone / 2 stones business unlike is_bad_selfatari(). */
-static bool is_really_bad_selfatari(struct board *b, enum stone color, coord_t to);
+static bool is_really_bad_selfatari(board_t *b, enum stone color, coord_t to);
 
 /* Check if move results in self-atari. */
-static bool is_selfatari(struct board *b, enum stone color, coord_t to);
+static bool is_selfatari(board_t *b, enum stone color, coord_t to);
 
 /* Move (color, coord) is a selfatari; this means that it puts a group of
  * ours in atari; i.e., the group has two liberties now. Return the other
@@ -27,16 +27,16 @@ static bool is_selfatari(struct board *b, enum stone color, coord_t to);
  * if that one is not a self-atari.
  * (In case (color, coord) is a multi-selfatari, consider a randomly chosen
  * candidate.) */
-coord_t selfatari_cousin(struct board *b, enum stone color, coord_t coord, group_t *bygroup);
+coord_t selfatari_cousin(board_t *b, enum stone color, coord_t coord, group_t *bygroup);
 
 
 #define SELFATARI_3LIB_SUICIDE		1
 #define SELFATARI_BIG_GROUPS_ONLY	2
 
-bool is_bad_selfatari_slow(struct board *b, enum stone color, coord_t to, int flags);
+bool is_bad_selfatari_slow(board_t *b, enum stone color, coord_t to, int flags);
 
 static inline bool
-is_bad_selfatari(struct board *b, enum stone color, coord_t to)
+is_bad_selfatari(board_t *b, enum stone color, coord_t to)
 {
 	/* More than one immediate liberty, thumbs up! */
 	if (immediate_liberty_count(b, to) > 1)
@@ -46,7 +46,7 @@ is_bad_selfatari(struct board *b, enum stone color, coord_t to)
 }
 
 static inline bool
-is_really_bad_selfatari(struct board *b, enum stone color, coord_t to)
+is_really_bad_selfatari(board_t *b, enum stone color, coord_t to)
 {
 	/* More than one immediate liberty, thumbs up! */
 	if (immediate_liberty_count(b, to) > 1)
@@ -56,7 +56,7 @@ is_really_bad_selfatari(struct board *b, enum stone color, coord_t to)
 }
 
 static inline bool
-is_selfatari(struct board *b, enum stone color, coord_t to)
+is_selfatari(board_t *b, enum stone color, coord_t to)
 {
         /* More than one immediate liberty, thumbs up! */
         if (immediate_liberty_count(b, to) > 1)

--- a/tactics/util.c
+++ b/tactics/util.c
@@ -11,7 +11,7 @@
 bool
 board_stone_radar(struct board *b, coord_t coord, int distance)
 {
-	int cx = coord_x(coord, b), cy = coord_y(coord, b);
+	int cx = coord_x(coord), cy = coord_y(coord);
 	int bounds[4] = { cx - distance, cy - distance,
 			  cx + distance, cy + distance  };
 	for (int i = 0; i < 4; i++)
@@ -21,11 +21,11 @@ board_stone_radar(struct board *b, coord_t coord, int distance)
 			bounds[i] = board_size(b) - 2;
 	for (int x = bounds[0]; x <= bounds[2]; x++)
 		for (int y = bounds[1]; y <= bounds[3]; y++) {
-			coord_t c = coord_xy(b, x, y);
+			coord_t c = coord_xy(x, y);
 			if (c != coord && board_at(b, c) != S_NONE) {
 				/* fprintf(stderr, "radar %d,%d,%d: %d,%d (%d)\n",
-					coord_x(coord, b), coord_y(coord, b),
-					distance, x, y, board_atxy(b, x, y)); */
+					coord_x(coord), coord_y(coord),
+					distance, x, y, board_atxy(x, y)); */
 				return true;
 			}
 		}

--- a/tactics/util.c
+++ b/tactics/util.c
@@ -9,7 +9,7 @@
 
 
 bool
-board_stone_radar(struct board *b, coord_t coord, int distance)
+board_stone_radar(board_t *b, coord_t coord, int distance)
 {
 	int cx = coord_x(coord), cy = coord_y(coord);
 	int bounds[4] = { cx - distance, cy - distance,
@@ -34,7 +34,7 @@ board_stone_radar(struct board *b, coord_t coord, int distance)
 
 
 void
-cfg_distances(struct board *b, coord_t start, int *distances, int maxdist)
+cfg_distances(board_t *b, coord_t start, int *distances, int maxdist)
 {
 	/* Queue for d+1 spots; no two spots of the same group
 	 * should appear in the queue. */
@@ -84,7 +84,7 @@ cfg_distances(struct board *b, coord_t start, int *distances, int maxdist)
 
 
 floating_t
-board_effective_handicap(struct board *b, int first_move_value)
+board_effective_handicap(board_t *b, int first_move_value)
 {
 	/* This can happen if the opponent passes during handicap
 	 * placing phase. */
@@ -104,7 +104,7 @@ board_effective_handicap(struct board *b, int first_move_value)
 
 /* Returns estimated number of remaining moves for one player until end of game. */
 int
-board_estimated_moves_left(struct board *b)
+board_estimated_moves_left(board_t *b)
 {
 	int total_points = (board_size(b)-2)*(board_size(b)-2);
 	int moves_left = (b->flen - total_points*EXPECTED_FINAL_EMPTY_PERCENT/100)/2;

--- a/tactics/util.h
+++ b/tactics/util.h
@@ -6,10 +6,8 @@
 #include "board.h"
 #include "debug.h"
 
-struct move_queue;
-
 /* Checks if there are any stones in n-vincinity of coord. */
-bool board_stone_radar(struct board *b, coord_t coord, int distance);
+bool board_stone_radar(board_t *b, coord_t coord, int distance);
 
 /* Measure various distances on the board: */
 /* Distance from the edge; on edge returns 0. */
@@ -18,23 +16,23 @@ static int coord_edge_distance(coord_t c);
  * circle-like structures on the square grid. */
 static int coord_gridcular_distance(coord_t c1, coord_t c2);
 
-/* Construct a "common fate graph" from given coordinate; that is, a weighted
+/* Cona_t "common fate graph" from given coordinate; that is, a weighted
  * graph of intersections where edges between all neighbors have weight 1,
  * but edges between neighbors of same color have weight 0. Thus, this is
  * "stone chain" metric in a sense. */
 /* The output are distances from start stored in given [board_size2()] array;
  * intersections further away than maxdist have all distance maxdist+1 set. */
-void cfg_distances(struct board *b, coord_t start, int *distances, int maxdist);
+void cfg_distances(board_t *b, coord_t start, int *distances, int maxdist);
 
 /* Compute an extra komi describing the "effective handicap" black receives
  * (returns 0 for even game with 7.5 komi). @stone_value is value of single
  * handicap stone, 7 is a good default. */
 /* This is just an approximation since in reality, handicap seems to be usually
  * non-linear. */
-floating_t board_effective_handicap(struct board *b, int first_move_value);
+floating_t board_effective_handicap(board_t *b, int first_move_value);
 
 /* Returns estimated number of remaining moves for one player until end of game. */
-int board_estimated_moves_left(struct board *b);
+int board_estimated_moves_left(board_t *b);
 
 /* To avoid running out of time, assume we always have at least 30 more moves
  * to play if we don't have more precise information from gtp time_left: */
@@ -46,7 +44,7 @@ int board_estimated_moves_left(struct board *b);
  * The value is normalized to [0,1]. */
 /* We can also take into account surrounding stones, e.g. to
  * encourage taking off external liberties during a semeai. */
-static double board_local_value(bool scan_neis, struct board *b, coord_t coord, enum stone color);
+static double board_local_value(bool scan_neis, board_t *b, coord_t coord, enum stone color);
 
 
 static inline int
@@ -66,7 +64,7 @@ coord_gridcular_distance(coord_t c1, coord_t c2)
 }
 
 static inline double
-board_local_value(bool scan_neis, struct board *b, coord_t coord, enum stone color)
+board_local_value(bool scan_neis, board_t *b, coord_t coord, enum stone color)
 {
 	if (scan_neis) {
 		/* Count surrounding friendly stones and our eyes. */

--- a/tactics/util.h
+++ b/tactics/util.h
@@ -13,10 +13,10 @@ bool board_stone_radar(struct board *b, coord_t coord, int distance);
 
 /* Measure various distances on the board: */
 /* Distance from the edge; on edge returns 0. */
-static int coord_edge_distance(coord_t c, struct board *b);
+static int coord_edge_distance(coord_t c);
 /* Distance of two points in gridcular metric - this metric defines
  * circle-like structures on the square grid. */
-static int coord_gridcular_distance(coord_t c1, coord_t c2, struct board *b);
+static int coord_gridcular_distance(coord_t c1, coord_t c2);
 
 /* Construct a "common fate graph" from given coordinate; that is, a weighted
  * graph of intersections where edges between all neighbors have weight 1,
@@ -50,18 +50,18 @@ static double board_local_value(bool scan_neis, struct board *b, coord_t coord, 
 
 
 static inline int
-coord_edge_distance(coord_t c, struct board *b)
+coord_edge_distance(coord_t c)
 {
-	int x = coord_x(c, b), y = coord_y(c, b);
-	int dx = x > board_size(b) / 2 ? board_size(b) - 1 - x : x;
-	int dy = y > board_size(b) / 2 ? board_size(b) - 1 - y : y;
+	int x = coord_x(c), y = coord_y(c);
+	int dx = x > the_board_size() / 2 ? the_board_size() - 1 - x : x;
+	int dy = y > the_board_size() / 2 ? the_board_size() - 1 - y : y;
 	return (dx < dy ? dx : dy) - 1 /* S_OFFBOARD */;
 }
 
 static inline int
-coord_gridcular_distance(coord_t c1, coord_t c2, struct board *b)
+coord_gridcular_distance(coord_t c1, coord_t c2)
 {
-	int dx = abs(coord_dx(c1, c2, b)), dy = abs(coord_dy(c1, c2, b));
+	int dx = abs(coord_dx(c1, c2)), dy = abs(coord_dy(c1, c2));
 	return dx + dy + (dx > dy ? dx : dy);
 }
 

--- a/timeinfo.c
+++ b/timeinfo.c
@@ -485,7 +485,9 @@ fuseki_moves(struct board *b)
 	return moves;
 }
 
-struct time_info ti_fuseki = { .period = TT_NULL };
+const struct time_info ti_none   = { TT_NULL };
+
+struct time_info ti_fuseki = { TT_NULL };
 
 struct time_info *time_info_genmove(struct board *b, struct time_info *ti, enum stone color)
 {

--- a/timeinfo.h
+++ b/timeinfo.h
@@ -13,7 +13,7 @@
 
 #include "board.h"
 
-struct time_info {
+typedef struct {
 	/* For how long we can spend the time? */
 	enum time_period {
 		TT_NULL, // No time limit. Other structure elements are undef.
@@ -61,12 +61,12 @@ struct time_info {
 	 * which will be ignored. This is the case if the time settings were
 	 * forced on the command line. */
 	bool ignore_gtp;
-};
+} time_info_t;
 
-extern const struct time_info ti_none;
+extern const time_info_t ti_none;
 
 // XXX ugly
-static inline struct time_info ti_unlimited();
+static inline time_info_t ti_unlimited();
 
 
 /* Parse time information provided in custom format:
@@ -75,21 +75,21 @@ static inline struct time_info ti_unlimited();
  *   _NUM - number of seconds to spend per game
  *
  * Returns false on parse error.  */
-bool time_parse(struct time_info *ti, char *s);
+bool time_parse(time_info_t *ti, char *s);
 
 /* Update time settings according to gtp time_settings command.
  * main_time < 0 implies no time limit. */
-void time_settings(struct time_info *ti, int main_time, int byoyomi_time, int byoyomi_stones, int byoyomi_periods);
+void time_settings(time_info_t *ti, int main_time, int byoyomi_time, int byoyomi_stones, int byoyomi_periods);
 
 /* Update time information according to gtp time_left command. */
-void time_left(struct time_info *ti, int time_left, int stones_left);
+void time_left(time_info_t *ti, int time_left, int stones_left);
 
 /* Start our timer. kgs does this (correctly) on "play" not "genmove"
  * unless we are making the first move of the game. */
-void time_start_timer(struct time_info *ti);
+void time_start_timer(time_info_t *ti);
 
 /* Subtract given amount of elapsed time from time settings. */
-void time_sub(struct time_info *ti, double interval, bool new_move);
+void time_sub(time_info_t *ti, double interval, bool new_move);
 
 /* Returns the current time. */
 double time_now(void);
@@ -108,7 +108,7 @@ void time_sleep(double interval);
  * available than netlag safety margin) and consequently need to choose
  * a move ASAP. */
 
-struct time_stop {
+typedef struct {
 	/* spend this amount of time if possible */
 	union {
 		double time; // TD_WALLTIME
@@ -119,25 +119,25 @@ struct time_stop {
 		double time; // TD_WALLTIME
 		int playouts; // TD_GAMES
 	} worst;
-};
+} time_stop_t;
 
 /* fuseki_end and yose_start are percentages of expected game length. */
-void time_stop_conditions(struct time_info *ti, struct board *b, int fuseki_end, int yose_start,
-			  floating_t max_maintime_ratio, struct time_stop *stop);
+void time_stop_conditions(time_info_t *ti, board_t *b, int fuseki_end, int yose_start,
+			  floating_t max_maintime_ratio, time_stop_t *stop);
 
 /* Time settings to use during fuseki */
-extern struct time_info ti_fuseki;
+extern time_info_t ti_fuseki;
 
 /* time_info to use for genmove() */
-struct time_info *time_info_genmove(struct board *b, struct time_info *ti, enum stone color);
+time_info_t *time_info_genmove(board_t *b, time_info_t *ti, enum stone color);
 
 /* set number of moves for fuseki for --fuseki-time */
 void set_fuseki_moves(int moves);
 
 
-static inline struct time_info ti_unlimited()
+static inline time_info_t ti_unlimited()
 {
-	struct time_info ti = { 0, };
+	time_info_t ti = { 0, };
 	ti.period = TT_MOVE;
 	ti.dim = TD_GAMES;
 	ti.len.games = INT_MAX;

--- a/timeinfo.h
+++ b/timeinfo.h
@@ -9,6 +9,7 @@
  * with all engines. */
 
 #include <stdbool.h>
+#include <limits.h>
 
 #include "board.h"
 
@@ -61,6 +62,12 @@ struct time_info {
 	 * forced on the command line. */
 	bool ignore_gtp;
 };
+
+extern const struct time_info ti_none;
+
+// XXX ugly
+static inline struct time_info ti_unlimited();
+
 
 /* Parse time information provided in custom format:
  *   =NUM - fixed number of simulations per move
@@ -126,5 +133,16 @@ struct time_info *time_info_genmove(struct board *b, struct time_info *ti, enum 
 
 /* set number of moves for fuseki for --fuseki-time */
 void set_fuseki_moves(int moves);
+
+
+static inline struct time_info ti_unlimited()
+{
+	struct time_info ti = { 0, };
+	ti.period = TT_MOVE;
+	ti.dim = TD_GAMES;
+	ti.len.games = INT_MAX;
+	ti.len.games_max = 0;
+	return ti;
+}
 
 #endif

--- a/timeinfo.h
+++ b/timeinfo.h
@@ -13,18 +13,22 @@
 
 #include "board.h"
 
+enum time_period {
+	TT_NULL, // No time limit. Other structure elements are undef.
+	TT_MOVE, // Time for the next move.
+	TT_TOTAL, // Time for the rest of the game. Never seen by engine.
+};
+
+enum time_dimension {
+	TD_GAMES, // Fixed number of simulations to perform.
+	TD_WALLTIME, // Wall time to spend performing simulations.
+};
+
 typedef struct {
 	/* For how long we can spend the time? */
-	enum time_period {
-		TT_NULL, // No time limit. Other structure elements are undef.
-		TT_MOVE, // Time for the next move.
-		TT_TOTAL, // Time for the rest of the game. Never seen by engine.
-	} period;
+	enum time_period period;
 	/* How are we counting the time? */
-	enum time_dimension {
-		TD_GAMES, // Fixed number of simulations to perform.
-		TD_WALLTIME, // Wall time to spend performing simulations.
-	} dim;
+	enum time_dimension dim;
 	/* The actual time count. */
 	struct {
 		int games;     // TD_GAMES
@@ -137,8 +141,7 @@ void set_fuseki_moves(int moves);
 
 static inline time_info_t ti_unlimited()
 {
-	time_info_t ti = { 0, };
-	ti.period = TT_MOVE;
+	time_info_t ti = { TT_MOVE, };
 	ti.dim = TD_GAMES;
 	ti.len.games = INT_MAX;
 	ti.len.games_max = 0;

--- a/uct/dynkomi.c
+++ b/uct/dynkomi.c
@@ -26,7 +26,7 @@ generic_done(uct_dynkomi_t *d)
 uct_dynkomi_t *
 uct_dynkomi_init_none(uct_t *u, char *arg, board_t *b)
 {
-	uct_dynkomi_t *d = calloc2(1, sizeof(*d));
+	uct_dynkomi_t *d = calloc2(1, uct_dynkomi_t);
 	d->uct = u;
 	d->permove = NULL;
 	d->persim = NULL;
@@ -153,13 +153,13 @@ linear_moves(board_t *b, enum stone color)
 uct_dynkomi_t *
 uct_dynkomi_init_linear(uct_t *u, char *arg, board_t *b)
 {
-	uct_dynkomi_t *d = calloc2(1, sizeof(*d));
+	uct_dynkomi_t *d = calloc2(1, uct_dynkomi_t);
 	d->uct = u;
 	d->permove = linear_permove;
 	d->persim = linear_persim;
 	d->done = generic_done;
 
-	dynkomi_linear_t *l = calloc2(1, sizeof(*l));
+	dynkomi_linear_t *l = calloc2(1, dynkomi_linear_t);
 	d->data = l;
 
 	/* Force white to feel behind and try harder, but not to the
@@ -500,13 +500,13 @@ adaptive_persim(uct_dynkomi_t *d, board_t *b, tree_t *tree, tree_node_t *node)
 uct_dynkomi_t *
 uct_dynkomi_init_adaptive(uct_t *u, char *arg, board_t *b)
 {
-	uct_dynkomi_t *d = calloc2(1, sizeof(*d));
+	uct_dynkomi_t *d = calloc2(1, uct_dynkomi_t);
 	d->uct = u;
 	d->permove = adaptive_permove;
 	d->persim = adaptive_persim;
 	d->done = generic_done;
 
-	dynkomi_adaptive_t *a = calloc2(1, sizeof(*a));
+	dynkomi_adaptive_t *a = calloc2(1, dynkomi_adaptive_t);
 	d->data = a;
 
 	a->lead_moves = board_large(b) ? 20 : 4; // XXX

--- a/uct/dynkomi.c
+++ b/uct/dynkomi.c
@@ -74,7 +74,7 @@ linear_simple(dynkomi_linear_t *l, board_t *b, enum stone color)
 static floating_t
 linear_permove(uct_dynkomi_t *d, board_t *b, tree_t *tree)
 {
-	dynkomi_linear_t *l = d->data;
+	dynkomi_linear_t *l = (dynkomi_linear_t*)d->data;
 	enum stone color = d->uct->pondering ? tree->root_color : stone_other(tree->root_color);
 	int lmoves = l->moves[color];
 
@@ -125,7 +125,7 @@ linear_permove(uct_dynkomi_t *d, board_t *b, tree_t *tree)
 static floating_t
 linear_persim(uct_dynkomi_t *d, board_t *b, tree_t *tree, tree_node_t *node)
 {
-	dynkomi_linear_t *l = d->data;
+	dynkomi_linear_t *l = (dynkomi_linear_t*)d->data;
 	if (l->rootbased)
 		return tree->extra_komi;
 
@@ -301,7 +301,7 @@ board_game_portion(dynkomi_adaptive_t *a, board_t *b)
 static floating_t
 adapter_sigmoid(uct_dynkomi_t *d, board_t *b)
 {
-	dynkomi_adaptive_t *a = d->data;
+	dynkomi_adaptive_t *a = (dynkomi_adaptive_t*)d->data;
 	/* Figure out how much to adjust the komi based on the game
 	 * stage. The adaptation rate is 0 at the beginning,
 	 * at game stage a->adapt_phase crosses though 0.5 and
@@ -315,7 +315,7 @@ adapter_sigmoid(uct_dynkomi_t *d, board_t *b)
 static floating_t
 adapter_linear(uct_dynkomi_t *d, board_t *b)
 {
-	dynkomi_adaptive_t *a = d->data;
+	dynkomi_adaptive_t *a = (dynkomi_adaptive_t*)d->data;
 	/* Figure out how much to adjust the komi based on the game
 	 * stage. We just linearly increase/decrease the adaptation
 	 * rate for first N moves. */
@@ -330,7 +330,7 @@ adapter_linear(uct_dynkomi_t *d, board_t *b)
 static floating_t
 komi_by_score(uct_dynkomi_t *d, board_t *b, tree_t *tree, enum stone color)
 {
-	dynkomi_adaptive_t *a = d->data;
+	dynkomi_adaptive_t *a = (dynkomi_adaptive_t*)d->data;
 	if (d->score.playouts < TRUSTWORTHY_KOMI_PLAYOUTS)
 		return tree->extra_komi;
 
@@ -351,7 +351,7 @@ komi_by_score(uct_dynkomi_t *d, board_t *b, tree_t *tree, enum stone color)
 static floating_t
 komi_by_value(uct_dynkomi_t *d, board_t *b, tree_t *tree, enum stone color)
 {
-	dynkomi_adaptive_t *a = d->data;
+	dynkomi_adaptive_t *a = (dynkomi_adaptive_t*)d->data;
 	if (d->value.playouts < TRUSTWORTHY_KOMI_PLAYOUTS)
 		return tree->extra_komi;
 
@@ -465,7 +465,7 @@ bounded_komi(dynkomi_adaptive_t *a, board_t *b,
 static floating_t
 adaptive_permove(uct_dynkomi_t *d, board_t *b, tree_t *tree)
 {
-	dynkomi_adaptive_t *a = d->data;
+	dynkomi_adaptive_t *a = (dynkomi_adaptive_t*)d->data;
 	enum stone color = stone_other(tree->root_color);
 
 	/* We do not use extra komi at the game end - we are not

--- a/uct/dynkomi.c
+++ b/uct/dynkomi.c
@@ -14,7 +14,7 @@
 
 
 static void
-generic_done(struct uct_dynkomi *d)
+generic_done(uct_dynkomi_t *d)
 {
 	if (d->data) free(d->data);
 	free(d);
@@ -23,10 +23,10 @@ generic_done(struct uct_dynkomi *d)
 
 /* NONE dynkomi strategy - never fiddle with komi values. */
 
-struct uct_dynkomi *
-uct_dynkomi_init_none(struct uct *u, char *arg, struct board *b)
+uct_dynkomi_t *
+uct_dynkomi_init_none(uct_t *u, char *arg, board_t *b)
 {
-	struct uct_dynkomi *d = calloc2(1, sizeof(*d));
+	uct_dynkomi_t *d = calloc2(1, sizeof(*d));
 	d->uct = u;
 	d->permove = NULL;
 	d->persim = NULL;
@@ -46,7 +46,7 @@ uct_dynkomi_init_none(struct uct *u, char *arg, struct board *b)
  * becomes zero but we increase the extra komi when winning big. This reduces
  * the number of point-wasting moves and makes the game more enjoyable for humans. */
 
-struct dynkomi_linear {
+typedef struct {
 	int handicap_value[S_MAX];
 	int moves[S_MAX];
 	bool rootbased;
@@ -61,10 +61,10 @@ struct dynkomi_linear {
 	floating_t green_zone;
 	floating_t orange_zone;
 	floating_t drop_step;
-};
+} dynkomi_linear_t;
 
 static floating_t
-linear_simple(struct dynkomi_linear *l, struct board *b, enum stone color)
+linear_simple(dynkomi_linear_t *l, board_t *b, enum stone color)
 {
 	int lmoves = l->moves[color];
 	floating_t base_komi = board_effective_handicap(b, l->handicap_value[color]);
@@ -72,9 +72,9 @@ linear_simple(struct dynkomi_linear *l, struct board *b, enum stone color)
 }
 
 static floating_t
-linear_permove(struct uct_dynkomi *d, struct board *b, struct tree *tree)
+linear_permove(uct_dynkomi_t *d, board_t *b, tree_t *tree)
 {
-	struct dynkomi_linear *l = d->data;
+	dynkomi_linear_t *l = d->data;
 	enum stone color = d->uct->pondering ? tree->root_color : stone_other(tree->root_color);
 	int lmoves = l->moves[color];
 
@@ -123,9 +123,9 @@ linear_permove(struct uct_dynkomi *d, struct board *b, struct tree *tree)
 }
 
 static floating_t
-linear_persim(struct uct_dynkomi *d, struct board *b, struct tree *tree, struct tree_node *node)
+linear_persim(uct_dynkomi_t *d, board_t *b, tree_t *tree, tree_node_t *node)
 {
-	struct dynkomi_linear *l = d->data;
+	dynkomi_linear_t *l = d->data;
 	if (l->rootbased)
 		return tree->extra_komi;
 
@@ -142,7 +142,7 @@ linear_persim(struct uct_dynkomi *d, struct board *b, struct tree *tree, struct 
 }
 
 static int
-linear_moves(struct board *b, enum stone color)
+linear_moves(board_t *b, enum stone color)
 {
 	if (board_small(b))            return 15;
 	if (real_board_size(b) == 15)  return 100;
@@ -150,16 +150,16 @@ linear_moves(struct board *b, enum stone color)
 	else                           return (board_large(b) ? 150 : 50);
 }
 
-struct uct_dynkomi *
-uct_dynkomi_init_linear(struct uct *u, char *arg, struct board *b)
+uct_dynkomi_t *
+uct_dynkomi_init_linear(uct_t *u, char *arg, board_t *b)
 {
-	struct uct_dynkomi *d = calloc2(1, sizeof(*d));
+	uct_dynkomi_t *d = calloc2(1, sizeof(*d));
 	d->uct = u;
 	d->permove = linear_permove;
 	d->persim = linear_persim;
 	d->done = generic_done;
 
-	struct dynkomi_linear *l = calloc2(1, sizeof(*l));
+	dynkomi_linear_t *l = calloc2(1, sizeof(*l));
 	d->data = l;
 
 	/* Force white to feel behind and try harder, but not to the
@@ -246,7 +246,7 @@ uct_dynkomi_init_linear(struct uct *u, char *arg, struct board *b)
  * (b) Continuous, new extra komi value is periodically re-determined
  * and adjusted throughout a single tree search. */
 
-struct dynkomi_adaptive {
+typedef struct {
 	/* Do not take measured average score into regard for
 	 * first @lead_moves - the variance is just too much.
 	 * (Instead, we consider the handicap-based komi provided
@@ -261,7 +261,7 @@ struct dynkomi_adaptive {
 	bool no_komi_at_game_end;
 	/* Alternative game portion determination. */
 	bool adapt_aport;
-	floating_t (*indicator)(struct uct_dynkomi *d, struct board *b, struct tree *tree, enum stone color);
+	floating_t (*indicator)(uct_dynkomi_t *d, board_t *b, tree_t *tree, enum stone color);
 
 	/* Value-based adaptation. */
 	floating_t zone_red, zone_green;
@@ -275,7 +275,7 @@ struct dynkomi_adaptive {
 	floating_t komi_ratchet;
 
 	/* Score-based adaptation. */
-	floating_t (*adapter)(struct uct_dynkomi *d, struct board *b);
+	floating_t (*adapter)(uct_dynkomi_t *d, board_t *b);
 	floating_t adapt_base; // [0,1)
 	/* Sigmoid adaptation rate parameter; see below for details. */
 	floating_t adapt_phase; // [0,1]
@@ -283,11 +283,11 @@ struct dynkomi_adaptive {
 	/* Linear adaptation rate parameter. */
 	int adapt_moves;
 	floating_t adapt_dir; // [-1,1]
-};
+} dynkomi_adaptive_t;
 #define TRUSTWORTHY_KOMI_PLAYOUTS 200
 
 static floating_t
-board_game_portion(struct dynkomi_adaptive *a, struct board *b)
+board_game_portion(dynkomi_adaptive_t *a, board_t *b)
 {
 	if (!a->adapt_aport) {
 		int total_moves = b->moves + 2 * board_estimated_moves_left(b);
@@ -299,9 +299,9 @@ board_game_portion(struct dynkomi_adaptive *a, struct board *b)
 }
 
 static floating_t
-adapter_sigmoid(struct uct_dynkomi *d, struct board *b)
+adapter_sigmoid(uct_dynkomi_t *d, board_t *b)
 {
-	struct dynkomi_adaptive *a = d->data;
+	dynkomi_adaptive_t *a = d->data;
 	/* Figure out how much to adjust the komi based on the game
 	 * stage. The adaptation rate is 0 at the beginning,
 	 * at game stage a->adapt_phase crosses though 0.5 and
@@ -313,9 +313,9 @@ adapter_sigmoid(struct uct_dynkomi *d, struct board *b)
 }
 
 static floating_t
-adapter_linear(struct uct_dynkomi *d, struct board *b)
+adapter_linear(uct_dynkomi_t *d, board_t *b)
 {
-	struct dynkomi_adaptive *a = d->data;
+	dynkomi_adaptive_t *a = d->data;
 	/* Figure out how much to adjust the komi based on the game
 	 * stage. We just linearly increase/decrease the adaptation
 	 * rate for first N moves. */
@@ -328,13 +328,13 @@ adapter_linear(struct uct_dynkomi *d, struct board *b)
 }
 
 static floating_t
-komi_by_score(struct uct_dynkomi *d, struct board *b, struct tree *tree, enum stone color)
+komi_by_score(uct_dynkomi_t *d, board_t *b, tree_t *tree, enum stone color)
 {
-	struct dynkomi_adaptive *a = d->data;
+	dynkomi_adaptive_t *a = d->data;
 	if (d->score.playouts < TRUSTWORTHY_KOMI_PLAYOUTS)
 		return tree->extra_komi;
 
-	struct move_stats score = d->score;
+	move_stats_t score = d->score;
 	/* Almost-reset tree->score to gather fresh stats. */
 	d->score.playouts = 1;
 
@@ -349,13 +349,13 @@ komi_by_score(struct uct_dynkomi *d, struct board *b, struct tree *tree, enum st
 }
 
 static floating_t
-komi_by_value(struct uct_dynkomi *d, struct board *b, struct tree *tree, enum stone color)
+komi_by_value(uct_dynkomi_t *d, board_t *b, tree_t *tree, enum stone color)
 {
-	struct dynkomi_adaptive *a = d->data;
+	dynkomi_adaptive_t *a = d->data;
 	if (d->value.playouts < TRUSTWORTHY_KOMI_PLAYOUTS)
 		return tree->extra_komi;
 
-	struct move_stats value = d->value;
+	move_stats_t value = d->value;
 	/* Almost-reset tree->value to gather fresh stats. */
 	d->value.playouts = 1;
 	/* Correct color POV. */
@@ -390,7 +390,7 @@ komi_by_value(struct uct_dynkomi *d, struct board *b, struct tree *tree, enum st
 	int score_step_green = a->score_step;
 
 	if (a->score_step_byavg != 0) {
-		struct move_stats score = d->score;
+		move_stats_t score = d->score;
 		/* Almost-reset tree->score to gather fresh stats. */
 		d->score.playouts = 1;
 		/* Correct color POV. */
@@ -444,7 +444,7 @@ komi_by_value(struct uct_dynkomi *d, struct board *b, struct tree *tree, enum st
 }
 
 static floating_t
-bounded_komi(struct dynkomi_adaptive *a, struct board *b,
+bounded_komi(dynkomi_adaptive_t *a, board_t *b,
              enum stone color, floating_t komi, floating_t max_losing_komi)
 {
 	/* At the end of game, disallow losing komi. */
@@ -463,9 +463,9 @@ bounded_komi(struct dynkomi_adaptive *a, struct board *b,
 }
 
 static floating_t
-adaptive_permove(struct uct_dynkomi *d, struct board *b, struct tree *tree)
+adaptive_permove(uct_dynkomi_t *d, board_t *b, tree_t *tree)
 {
-	struct dynkomi_adaptive *a = d->data;
+	dynkomi_adaptive_t *a = d->data;
 	enum stone color = stone_other(tree->root_color);
 
 	/* We do not use extra komi at the game end - we are not
@@ -492,21 +492,21 @@ adaptive_permove(struct uct_dynkomi *d, struct board *b, struct tree *tree)
 }
 
 static floating_t
-adaptive_persim(struct uct_dynkomi *d, struct board *b, struct tree *tree, struct tree_node *node)
+adaptive_persim(uct_dynkomi_t *d, board_t *b, tree_t *tree, tree_node_t *node)
 {
 	return tree->extra_komi;
 }
 
-struct uct_dynkomi *
-uct_dynkomi_init_adaptive(struct uct *u, char *arg, struct board *b)
+uct_dynkomi_t *
+uct_dynkomi_init_adaptive(uct_t *u, char *arg, board_t *b)
 {
-	struct uct_dynkomi *d = calloc2(1, sizeof(*d));
+	uct_dynkomi_t *d = calloc2(1, sizeof(*d));
 	d->uct = u;
 	d->permove = adaptive_permove;
 	d->persim = adaptive_persim;
 	d->done = generic_done;
 
-	struct dynkomi_adaptive *a = calloc2(1, sizeof(*a));
+	dynkomi_adaptive_t *a = calloc2(1, sizeof(*a));
 	d->data = a;
 
 	a->lead_moves = board_large(b) ? 20 : 4; // XXX

--- a/uct/dynkomi.h
+++ b/uct/dynkomi.h
@@ -19,10 +19,7 @@
  * rest of UCT implementation. */
 
 struct board;
-struct tree;
-struct tree_node;
-struct uct;
-struct uct_dynkomi;
+typedef struct uct_dynkomi uct_dynkomi_t;
 
 /* Compute effective komi value for given color: Positive value
  * means giving komi, negative value means taking komi. */
@@ -31,17 +28,17 @@ struct uct_dynkomi;
 /* Determine base dynamic komi for this genmove run. The returned
  * value is stored in tree->extra_komi and by itself used just for
  * user information. */
-typedef floating_t (*uctd_permove)(struct uct_dynkomi *d, struct board *b, struct tree *tree);
+typedef floating_t (*uctd_permove)(uct_dynkomi_t *d, board_t *b, tree_t *tree);
 /* Determine actual dynamic komi for this simulation (run on board @b
  * from node @node). In some cases, this function will just return
  * tree->extra_komi, in other cases it might want to adjust the komi
  * according to the actual move depth. */
-typedef floating_t (*uctd_persim)(struct uct_dynkomi *d, struct board *b, struct tree *tree, struct tree_node *node);
+typedef floating_t (*uctd_persim)(uct_dynkomi_t *d, board_t *b, tree_t *tree, tree_node_t *node);
 /* Destroy the uct_dynkomi structure. */
-typedef void (*uctd_done)(struct uct_dynkomi *d);
+typedef void (*uctd_done)(uct_dynkomi_t *d);
 
 struct uct_dynkomi {
-	struct uct *uct;
+	uct_t *uct;
 	uctd_permove permove;
 	uctd_persim persim;
 	uctd_done done;
@@ -50,14 +47,14 @@ struct uct_dynkomi {
 	/* Game state for dynkomi use: */
 	/* Information on average score at the simulation end (black's
 	 * perspective) since last dynkomi adjustment. */
-	struct move_stats score;
+	move_stats_t score;
 	/* Information on average winrate of simulations since last
 	 * dynkomi adjustment. */
-	struct move_stats value;
+	move_stats_t value;
 };
 
-struct uct_dynkomi *uct_dynkomi_init_none(struct uct *u, char *arg, struct board *b);
-struct uct_dynkomi *uct_dynkomi_init_linear(struct uct *u, char *arg, struct board *b);
-struct uct_dynkomi *uct_dynkomi_init_adaptive(struct uct *u, char *arg, struct board *b);
+uct_dynkomi_t *uct_dynkomi_init_none(uct_t *u, char *arg, board_t *b);
+uct_dynkomi_t *uct_dynkomi_init_linear(uct_t *u, char *arg, board_t *b);
+uct_dynkomi_t *uct_dynkomi_init_adaptive(uct_t *u, char *arg, board_t *b);
 
 #endif

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -12,16 +12,17 @@
 #include "playout.h"
 #include "stats.h"
 #include "mq.h"
+#include "uct/tree.h"
+#include "uct/prior.h"
 
-struct tree;
-struct tree_node;
-struct uct_policy;
 struct uct_prior;
 struct uct_dynkomi;
 struct uct_pluginset;
 
+typedef struct uct_policy uct_policy_t;
+
 /* Internal engine state. */
-struct uct {
+typedef struct uct {
 	int debug_level;
 	enum uct_reporting {
 		UR_TEXT,
@@ -108,15 +109,15 @@ struct uct {
 
 	char *banner;
 
-	struct uct_policy *policy;
-	struct uct_policy *random_policy;
-	struct playout_policy *playout;
-	struct uct_prior *prior;
+	uct_policy_t *policy;
+	uct_policy_t *random_policy;
+	playout_policy_t *playout;
+	uct_prior_t *prior;
 	struct uct_pluginset *plugins;
-	struct pattern_config pc;
+	pattern_config_t pc;
 
 	/* Used within frame of single genmove. */
-	struct ownermap ownermap;
+	ownermap_t ownermap;
 
 	/* Used for coordination among slaves of the distributed engine. */
 	int stats_hbits;
@@ -127,52 +128,52 @@ struct uct {
 	int played_all; /* games played by all slaves */
 
 	/* Saved dead groups, for final_status_list dead */
-	struct move_queue dead_groups;
+	move_queue_t dead_groups;
 	int pass_moveno;
 	
 	/* Timing */
 	double mcts_time_start;
 
 	/* Game state - maintained by setup_state(), reset_state(). */
-	struct tree *t;
+	tree_t *t;
 	bool tree_ready;
-};
+} uct_t;
 
 #define UDEBUGL(n) DEBUGL_(u->debug_level, n)
 
-bool uct_pass_is_safe(struct uct *u, struct board *b, enum stone color, bool pass_all_alive, char **msg);
-void uct_prepare_move(struct uct *u, struct board *b, enum stone color);
-void uct_genmove_setup(struct uct *u, struct board *b, enum stone color);
-void uct_pondering_stop(struct uct *u);
-void uct_get_best_moves(struct uct *u, coord_t *best_c, float *best_r, int nbest, bool winrates);
-void uct_get_best_moves_at(struct uct *u, struct tree_node *n, coord_t *best_c, float *best_r, int nbest, bool winrates);
-void uct_mcowner_playouts(struct uct *u, struct board *b, enum stone color);
+bool uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, char **msg);
+void uct_prepare_move(uct_t *u, board_t *b, enum stone color);
+void uct_genmove_setup(uct_t *u, board_t *b, enum stone color);
+void uct_pondering_stop(uct_t *u);
+void uct_get_best_moves(uct_t *u, coord_t *best_c, float *best_r, int nbest, bool winrates);
+void uct_get_best_moves_at(uct_t *u, tree_node_t *n, coord_t *best_c, float *best_r, int nbest, bool winrates);
+void uct_mcowner_playouts(uct_t *u, board_t *b, enum stone color);
 
 /* This is the state used for descending the tree; we use this wrapper
  * structure in order to be able to easily descend in multiple trees
  * in parallel (e.g. main tree and local tree) or compute cummulative
  * "path value" throughout the tree descent. */
-struct uct_descent {
+typedef struct {
 	/* Active tree nodes: */
-	struct tree_node *node; /* Main tree. */
-	struct tree_node *lnode; /* Local tree. */
+	tree_node_t *node; /* Main tree. */
+	tree_node_t *lnode; /* Local tree. */
 	/* Value of main tree node (with all value factors, but unbiased
 	 * - without exploration factor), from black's perspective. */
-	struct move_stats value;
-};
+	move_stats_t value;
+} uct_descent_t;
 
 #define uct_descent(node, lnode)  { node, lnode }
 
-typedef struct tree_node *(*uctp_choose)(struct uct_policy *p, struct tree_node *node, struct board *b, enum stone color, coord_t exclude);
-typedef floating_t (*uctp_evaluate)(struct uct_policy *p, struct tree *tree, struct uct_descent *descent, int parity);
-typedef void (*uctp_descend)(struct uct_policy *p, struct tree *tree, struct uct_descent *descent, int parity, bool allow_pass);
-typedef void (*uctp_winner)(struct uct_policy *p, struct tree *tree, struct uct_descent *descent);
-typedef void (*uctp_prior)(struct uct_policy *p, struct tree *tree, struct tree_node *node, struct board *b, enum stone color, int parity);
-typedef void (*uctp_update)(struct uct_policy *p, struct tree *tree, struct tree_node *node, enum stone node_color, enum stone player_color, struct playout_amafmap *amaf, struct board *final_board, floating_t result);
-typedef void (*uctp_done)(struct uct_policy *p);
+typedef tree_node_t *(*uctp_choose)(uct_policy_t *p, tree_node_t *node, board_t *b, enum stone color, coord_t exclude);
+typedef floating_t (*uctp_evaluate)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity);
+typedef void (*uctp_descend)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity, bool allow_pass);
+typedef void (*uctp_winner)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent);
+typedef void (*uctp_prior)(uct_policy_t *p, tree_t *tree, tree_node_t *node, board_t *b, enum stone color, int parity);
+typedef void (*uctp_update)(uct_policy_t *p, tree_t *tree, tree_node_t *node, enum stone node_color, enum stone player_color, playout_amafmap_t *amaf, board_t *final_board, floating_t result);
+typedef void (*uctp_done)(uct_policy_t *p);
 
 struct uct_policy {
-	struct uct *uct;
+	uct_t *uct;
 	uctp_choose choose;
 	uctp_winner winner;
 	uctp_evaluate evaluate;

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -161,6 +161,7 @@ struct uct_descent {
 	struct move_stats value;
 };
 
+#define uct_descent(node, lnode)  { node, lnode }
 
 typedef struct tree_node *(*uctp_choose)(struct uct_policy *p, struct tree_node *node, struct board *b, enum stone color, coord_t exclude);
 typedef floating_t (*uctp_evaluate)(struct uct_policy *p, struct tree *tree, struct uct_descent *descent, int parity);

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -21,15 +21,28 @@ struct uct_pluginset;
 
 typedef struct uct_policy uct_policy_t;
 
+typedef enum uct_reporting {
+	UR_TEXT,
+	UR_JSON,
+	UR_JSON_BIG,
+	UR_LEELAZ,
+} uct_reporting_t;
+
+typedef enum uct_thread_model {
+	TM_TREE, /* Tree parallelization w/o virtual loss. */
+	TM_TREEVL, /* Tree parallelization with virtual loss. */
+} uct_thread_model_t;
+
+typedef enum local_tree_eval {
+	LTE_ROOT,
+	LTE_EACH,
+	LTE_TOTAL,
+} local_tree_eval_t;
+
 /* Internal engine state. */
 typedef struct uct {
 	int debug_level;
-	enum uct_reporting {
-		UR_TEXT,
-		UR_JSON,
-		UR_JSON_BIG,
-		UR_LEELAZ,
-	} reporting;
+	enum uct_reporting reporting;
 	int reportfreq;
 
 	int games, gamelen;
@@ -55,10 +68,7 @@ typedef struct uct {
 	bool genmove_reset_tree;
 
 	int threads;
-	enum uct_thread_model {
-		TM_TREE, /* Tree parallelization w/o virtual loss. */
-		TM_TREEVL, /* Tree parallelization with virtual loss. */
-	} thread_model;
+	enum uct_thread_model thread_model;
 	int virtual_loss;
 	bool slave; /* Act as slave in distributed engine. */
 	int max_slaves; /* Optional, -1 if not set */
@@ -95,11 +105,7 @@ typedef struct uct {
 	floating_t local_tree_depth_decay;
 	bool local_tree_allseq;
 	bool local_tree_neival;
-	enum {
-		LTE_ROOT,
-		LTE_EACH,
-		LTE_TOTAL,
-	} local_tree_eval;
+	enum local_tree_eval local_tree_eval;
 	bool local_tree_rootchoose;
 
 	struct {

--- a/uct/plugin/example.c
+++ b/uct/plugin/example.c
@@ -28,17 +28,17 @@
 #include "tactics/selfatari.h"
 
 /* Our context structure. */
-struct context {
+typedef struct {
 	int eqex;
 	bool selfatari;
-};
+} context_t;
 
 
 void
-pachi_plugin_prior(void *data, struct tree_node *node, struct prior_map *map, int eqex)
+pachi_plugin_prior(void *data, tree_node_t *node, prior_map_t *map, int eqex)
 {
-	struct context *ctx = data;
-	struct board *b = map->b;
+	context_t *ctx = data;
+	board_t *b = map->b;
 	if (ctx->eqex >= 0)
 		eqex = ctx->eqex; // override Pachi default
 
@@ -100,9 +100,9 @@ set_prior:
 }
 
 void *
-pachi_plugin_init(char *arg, struct board *b, int seed)
+pachi_plugin_init(char *arg, board_t *b, int seed)
 {
-	struct context *ctx = calloc(1, sizeof(*ctx));
+	context_t *ctx = calloc(1, sizeof(*ctx));
 
 	/* Initialize ctx defaults here. */
 	ctx->eqex = -1;
@@ -142,7 +142,7 @@ pachi_plugin_init(char *arg, struct board *b, int seed)
 void
 pachi_plugin_done(void *data)
 {
-	struct context *ctx = data;
+	context_t *ctx = data;
 	/* No big magic. */
 	free(ctx);
 }

--- a/uct/plugin/wolf.c
+++ b/uct/plugin/wolf.c
@@ -197,14 +197,14 @@ typedef char byte_board[MAXBOARDSIZE+2][MAXBOARDSIZE+2]; // The array indices ar
 typedef floating_t influ_board[MAXBOARDSIZE][MAXBOARDSIZE];
 
 /* Our context structure. */
-struct context {
+typedef struct {
 	int eqex;
 
 	void *dlh;
 	void (*SETPARAM)(double sv, double omega, uint16_t mi);
 	void (*EVALFUN1)(char *javp, char *InfluField);
 	void (*FINDMOVE2)(int fa, char *mi, char *mj, floating_t *mxscore, influ_board *SB, byte_board **PChainNo);
-};
+} context_t;
 
 
 char
@@ -232,10 +232,10 @@ coord2digit(enum stone color, int coord)
 }
 
 void
-pachi_plugin_prior(void *data, struct tree_node *node, struct prior_map *map, int eqex)
+pachi_plugin_prior(void *data, tree_node_t *node, prior_map_t *map, int eqex)
 {
-	struct context *ctx = data;
-	struct board *b = map->b;
+	context_t *ctx = data;
+	board_t *b = map->b;
 	if (ctx->eqex >= 0)
 		eqex = ctx->eqex; // override Pachi default
 
@@ -304,9 +304,9 @@ pachi_plugin_prior(void *data, struct tree_node *node, struct prior_map *map, in
 
 
 void *
-pachi_plugin_init(char *arg, struct board *b, int seed)
+pachi_plugin_init(char *arg, board_t *b, int seed)
 {
-	struct context *ctx = calloc(1, sizeof(*ctx));
+	context_t *ctx = calloc(1, sizeof(*ctx));
 
 	/* Initialize ctx defaults here. */
 	char *file = NULL;
@@ -371,7 +371,7 @@ pachi_plugin_init(char *arg, struct board *b, int seed)
 void
 pachi_plugin_done(void *data)
 {
-	struct context *ctx = data;
+	context_t *ctx = data;
 	dlclose(ctx->dlh);
 	free(ctx);
 }

--- a/uct/plugins.c
+++ b/uct/plugins.c
@@ -10,9 +10,9 @@
 #include "debug.h"
 #include "move.h"
 #include "random.h"
-#include "uct/plugins.h"
 #include "uct/prior.h"
 #include "uct/tree.h"
+#include "uct/plugins.h"
 
 /* Plugin interface for UCT. External plugins may hook callbacks on various
  * events and e.g. bias the tree. */
@@ -20,37 +20,37 @@
 
 /* Keep the API typedefs in sync with <uct/plugin.h>. */
 
-struct plugin {
+typedef struct {
 	char *path;
 	char *args;
 	void *dlh;
 	void *data;
 
-	void *(*init)(char *args, struct board *b, int seed);
-	void (*prior)(void *data, struct tree_node *node, struct prior_map *map, int eqex);
+	void *(*init)(char *args, board_t *b, int seed);
+	void (*prior)(void *data, tree_node_t *node, prior_map_t *map, int eqex);
 	void (*done)(void *data);
-};
+} plugin_t;
 
-struct uct_pluginset {
-	struct plugin *plugins;
+typedef struct uct_pluginset {
+	plugin_t *plugins;
 	int n_plugins;
-	struct board *b;
-};
+	board_t *b;
+} uct_pluginset_t;
 
 
-struct uct_pluginset *
-pluginset_init(struct board *b)
+uct_pluginset_t *
+pluginset_init(board_t *b)
 {
-	struct uct_pluginset *ps = calloc(1, sizeof(*ps));
+	uct_pluginset_t *ps = calloc(1, sizeof(*ps));
 	ps->b = b;
 	return ps;
 }
 
 void
-pluginset_done(struct uct_pluginset *ps)
+pluginset_done(uct_pluginset_t *ps)
 {
 	for (int i = 0; i < ps->n_plugins; i++) {
-		struct plugin *p = &ps->plugins[i];
+		plugin_t *p = &ps->plugins[i];
 		p->done(p->data);
 		dlclose(p->dlh);
 		free(p->path);
@@ -61,10 +61,10 @@ pluginset_done(struct uct_pluginset *ps)
 
 
 void
-plugin_load(struct uct_pluginset *ps, char *path, char *args)
+plugin_load(uct_pluginset_t *ps, char *path, char *args)
 {
 	ps->plugins = realloc(ps->plugins, ++ps->n_plugins * sizeof(ps->plugins[0]));
-	struct plugin *p = &ps->plugins[ps->n_plugins - 1];
+	plugin_t *p = &ps->plugins[ps->n_plugins - 1];
 	p->path = strdup(path);
 	p->args = args ? strdup(args) : args;
 
@@ -84,10 +84,10 @@ plugin_load(struct uct_pluginset *ps, char *path, char *args)
 }
 
 void
-plugin_prior(struct uct_pluginset *ps, struct tree_node *node, struct prior_map *map, int eqex)
+plugin_prior(uct_pluginset_t *ps, tree_node_t *node, prior_map_t *map, int eqex)
 {
 	for (int i = 0; i < ps->n_plugins; i++) {
-		struct plugin *p = &ps->plugins[i];
+		plugin_t *p = &ps->plugins[i];
 		p->prior(p->data, node, map, eqex);
 	}
 }

--- a/uct/plugins.c
+++ b/uct/plugins.c
@@ -41,7 +41,7 @@ typedef struct uct_pluginset {
 uct_pluginset_t *
 pluginset_init(board_t *b)
 {
-	uct_pluginset_t *ps = calloc(1, sizeof(*ps));
+	uct_pluginset_t *ps = calloc(1, uct_pluginset_t);
 	ps->b = b;
 	return ps;
 }

--- a/uct/plugins.h
+++ b/uct/plugins.h
@@ -1,20 +1,16 @@
 #ifndef PACHI_UCT_PLUGINS_H
 #define PACHI_UCT_PLUGINS_H
 
-struct tree_node;
-struct board;
-struct prior_map;
-
 
 /* The pluginset structure of current UCT context. */
 struct uct_pluginset;
-struct uct_pluginset *pluginset_init(struct board *b);
+struct uct_pluginset *pluginset_init(board_t *b);
 void pluginset_done(struct uct_pluginset *ps);
 
 /* Load a new plugin with DLL at path, passed arguments in args. */
 void plugin_load(struct uct_pluginset *ps, char *path, char *args);
 
 /* Query plugins for priors of a node's leaves. */
-void plugin_prior(struct uct_pluginset *ps, struct tree_node *node, struct prior_map *map, int eqex);
+void plugin_prior(struct uct_pluginset *ps, tree_node_t *node, prior_map_t *map, int eqex);
 
 #endif

--- a/uct/policy/generic.c
+++ b/uct/policy/generic.c
@@ -12,16 +12,16 @@
 #include "uct/tree.h"
 #include "uct/policy/generic.h"
 
-struct tree_node *
-uctp_generic_choose(struct uct_policy *p, struct tree_node *node, struct board *b, enum stone color, coord_t exclude)
+tree_node_t *
+uctp_generic_choose(uct_policy_t *p, tree_node_t *node, board_t *b, enum stone color, coord_t exclude)
 {
-	struct tree_node *nbest = node->children;
+	tree_node_t *nbest = node->children;
 	if (!nbest) return NULL;
-	struct tree_node *nbest2 = nbest->sibling;
+	tree_node_t *nbest2 = nbest->sibling;
 
 	/* This function is called while the tree is updated by other threads.
 	 * We rely on node->children being set only after the node has been fully expanded. */
-	for (struct tree_node *ni = nbest2; ni; ni = ni->sibling) {
+	for (tree_node_t *ni = nbest2; ni; ni = ni->sibling) {
 		// we compare playouts and choose the best-explored
 		// child; comparing values is more brittle
 		if (node_coord(ni) == exclude || ni->hints & TREE_HINT_INVALID)
@@ -51,7 +51,7 @@ uctp_generic_choose(struct uct_policy *p, struct tree_node *node, struct board *
  * nodes evaluated rarely.
  * This function is called while the tree is updated by other threads */
 void
-uctp_generic_winner(struct uct_policy *p, struct tree *tree, struct uct_descent *descent)
+uctp_generic_winner(uct_policy_t *p, tree_t *tree, uct_descent_t *descent)
 {
 	if (!p->evaluate)
 		return;

--- a/uct/policy/generic.h
+++ b/uct/policy/generic.h
@@ -25,10 +25,10 @@ void uctp_generic_winner(struct uct_policy *p, struct tree *tree, struct uct_des
 #define uctd_try_node_children(tree, descent, allow_pass, parity, tenuki_d, di, urgency) \
 	/* Information abound best children. */ \
 	/* XXX: We assume board <=25x25. */ \
-	struct uct_descent dbest[BOARD_MAX_MOVES + 1] = { { .node = descent->node->children, .lnode = NULL } }; int dbests = 1; \
+	struct uct_descent dbest[BOARD_MAX_MOVES + 1] = { uct_descent(descent->node->children, NULL) }; int dbests = 1; \
 	floating_t best_urgency = -9999; \
 	/* Descent children iterator. */ \
-	struct uct_descent dci = { .node = descent->node->children, .lnode = descent->lnode ? descent->lnode->children : NULL }; \
+	struct uct_descent dci = uct_descent(descent->node->children, (descent->lnode ? descent->lnode->children : NULL)); \
 	\
 	for (; dci.node; dci.node = dci.node->sibling) { \
 		floating_t urgency; \

--- a/uct/policy/generic.h
+++ b/uct/policy/generic.h
@@ -10,8 +10,8 @@
 struct board;
 struct tree_node;
 
-struct tree_node *uctp_generic_choose(struct uct_policy *p, struct tree_node *node, struct board *b, enum stone color, coord_t exclude);
-void uctp_generic_winner(struct uct_policy *p, struct tree *tree, struct uct_descent *descent);
+tree_node_t *uctp_generic_choose(uct_policy_t *p, tree_node_t *node, board_t *b, enum stone color, coord_t exclude);
+void uctp_generic_winner(uct_policy_t *p, tree_t *tree, uct_descent_t *descent);
 
 
 /* Some generic stitching for tree descent. */
@@ -25,10 +25,10 @@ void uctp_generic_winner(struct uct_policy *p, struct tree *tree, struct uct_des
 #define uctd_try_node_children(tree, descent, allow_pass, parity, tenuki_d, di, urgency) \
 	/* Information abound best children. */ \
 	/* XXX: We assume board <=25x25. */ \
-	struct uct_descent dbest[BOARD_MAX_MOVES + 1] = { uct_descent(descent->node->children, NULL) }; int dbests = 1; \
+	uct_descent_t dbest[BOARD_MAX_MOVES + 1] = { uct_descent(descent->node->children, NULL) }; int dbests = 1; \
 	floating_t best_urgency = -9999; \
 	/* Descent children iterator. */ \
-	struct uct_descent dci = uct_descent(descent->node->children, (descent->lnode ? descent->lnode->children : NULL)); \
+	uct_descent_t dci = uct_descent(descent->node->children, (descent->lnode ? descent->lnode->children : NULL)); \
 	\
 	for (; dci.node; dci.node = dci.node->sibling) { \
 		floating_t urgency; \
@@ -43,7 +43,7 @@ void uctp_generic_winner(struct uct_policy *p, struct tree *tree, struct uct_des
 		 * one, and usually is similar to dci. However, in case of local
 		 * trees, we may keep next-candidate pointer in dci while storing
 		 * actual-specimen in di. */ \
-		struct uct_descent di = dci; \
+		uct_descent_t di = dci; \
 		if (dci.lnode) { \
 			/* Set lnode to local tree node corresponding
 			 * to node (dci.lnode, pass-lnode or NULL). */ \
@@ -65,7 +65,7 @@ void uctp_generic_winner(struct uct_policy *p, struct tree *tree, struct uct_des
 			if (dbests == 1 && is_pass(node_coord(dbest[0].node))) { \
 				dbests--; \
 			} \
-			struct uct_descent db = di; \
+			uct_descent_t db = di; \
 			/* Make sure lnode information is meaningful. */ \
 			if (db.lnode && is_pass(node_coord(db.lnode))) \
 				db.lnode = NULL; \

--- a/uct/policy/ucb1.c
+++ b/uct/policy/ucb1.c
@@ -14,7 +14,7 @@
 
 /* This implements the basic UCB1 policy. */
 
-struct ucb1_policy {
+typedef struct {
 	/* This is what the Modification of UCT with Patterns in Monte Carlo Go
 	 * paper calls 'p'. Original UCB has this on 2, but this seems to
 	 * produce way too wide searches; reduce this to get deeper and
@@ -24,25 +24,25 @@ struct ucb1_policy {
 	 * above reports 1.0 as the best), new branches are explored only
 	 * if none of the existing ones has higher urgency than fpu. */
 	floating_t fpu;
-};
+} ucb1_policy_t;
 
 
 void
-ucb1_descend(struct uct_policy *p, struct tree *tree, struct uct_descent *descent, int parity, bool allow_pass)
+ucb1_descend(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity, bool allow_pass)
 {
-	/* We want to count in the prior stats here after all. Otherwise,
-	 * nodes with positive prior will get explored _LESS_ since the
-	 * urgency will be always higher; even with normal FPU because
+	/* we want to count in the prior stats here after all. otherwise,
+	 * nodes with positive prior will get explored _less_ since the
+	 * urgency will be always higher; even with normal fpu because
 	 * of the explore coefficient. */
 
-	struct ucb1_policy *b = p->data;
+	ucb1_policy_t *b = p->data;
 	floating_t xpl = log(descent->node->u.playouts + descent->node->prior.playouts);
 
 	uctd_try_node_children(tree, descent, allow_pass, parity, p->uct->tenuki_d, di, urgency) {
-		struct tree_node *ni = di.node;
+		tree_node_t *ni = di.node;
 		int uct_playouts = ni->u.playouts + ni->prior.playouts + ni->descents;
 
-		/* XXX: We don't take local-tree information into account. */
+		/* xxx: we don't take local-tree information into account. */
 
 		if (uct_playouts) {
 			urgency = (ni->u.playouts * tree_node_get_value(tree, parity, ni->u.value)
@@ -59,9 +59,9 @@ ucb1_descend(struct uct_policy *p, struct tree *tree, struct uct_descent *descen
 }
 
 void
-ucb1_update(struct uct_policy *p, struct tree *tree, struct tree_node *node, enum stone node_color, enum stone player_color, struct playout_amafmap *map, struct board *final_board, floating_t result)
+ucb1_update(uct_policy_t *p, tree_t *tree, tree_node_t *node, enum stone node_color, enum stone player_color, playout_amafmap_t *map, board_t *final_board, floating_t result)
 {
-	/* It is enough to iterate by a single chain; we will
+	/* it is enough to iterate by a single chain; we will
 	 * update all the preceding positions properly since
 	 * they had to all occur in all branches, only in
 	 * different order. */
@@ -78,17 +78,17 @@ ucb1_update(struct uct_policy *p, struct tree *tree, struct tree_node *node, enu
 }
 
 void
-ucb1_done(struct uct_policy *p)
+ucb1_done(uct_policy_t *p)
 {
 	free(p->data);
 	free(p);
 }
 
-struct uct_policy *
-policy_ucb1_init(struct uct *u, char *arg)
+uct_policy_t *
+policy_ucb1_init(uct_t *u, char *arg)
 {
-	struct uct_policy *p = calloc2(1, sizeof(*p));
-	struct ucb1_policy *b = calloc2(1, sizeof(*b));
+	uct_policy_t *p = calloc2(1, sizeof(*p));
+	ucb1_policy_t *b = calloc2(1, sizeof(*b));
 	p->uct = u;
 	p->data = b;
 	p->done = ucb1_done;

--- a/uct/policy/ucb1.c
+++ b/uct/policy/ucb1.c
@@ -35,7 +35,7 @@ ucb1_descend(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity, 
 	 * urgency will be always higher; even with normal fpu because
 	 * of the explore coefficient. */
 
-	ucb1_policy_t *b = p->data;
+	ucb1_policy_t *b = (ucb1_policy_t*)p->data;
 	floating_t xpl = log(descent->node->u.playouts + descent->node->prior.playouts);
 
 	uctd_try_node_children(tree, descent, allow_pass, parity, p->uct->tenuki_d, di, urgency) {

--- a/uct/policy/ucb1.c
+++ b/uct/policy/ucb1.c
@@ -87,8 +87,8 @@ ucb1_done(uct_policy_t *p)
 uct_policy_t *
 policy_ucb1_init(uct_t *u, char *arg)
 {
-	uct_policy_t *p = calloc2(1, sizeof(*p));
-	ucb1_policy_t *b = calloc2(1, sizeof(*b));
+	uct_policy_t *p = calloc2(1, uct_policy_t);
+	ucb1_policy_t *b = calloc2(1, ucb1_policy_t);
 	p->uct = u;
 	p->data = b;
 	p->done = ucb1_done;

--- a/uct/policy/ucb1amaf.c
+++ b/uct/policy/ucb1amaf.c
@@ -348,8 +348,8 @@ ucb1amaf_done(uct_policy_t *p)
 uct_policy_t *
 policy_ucb1amaf_init(uct_t *u, char *arg, board_t *board)
 {
-	uct_policy_t *p = calloc2(1, sizeof(*p));
-	ucb1_policy_amaf_t *b = calloc2(1, sizeof(*b));
+	uct_policy_t *p = calloc2(1, uct_policy_t);
+	ucb1_policy_amaf_t *b = calloc2(1, ucb1_policy_amaf_t);
 	p->uct = u;
 	p->data = b;
 	p->done = ucb1amaf_done;

--- a/uct/policy/ucb1amaf.c
+++ b/uct/policy/ucb1amaf.c
@@ -132,8 +132,8 @@ ucb1rave_evaluate(struct uct_policy *p, struct tree *tree, struct uct_descent *d
 		struct move_stats l = lnode->u;
 		l.playouts = ((floating_t) l.playouts) * b->ltree_rave / LTREE_PLAYOUTS_MULTIPLIER;
 		URAVE_DEBUG fprintf(stderr, "[ltree] adding [%s] %f%%%d to [%s] RAVE %f%%%d\n",
-			coord2sstr(node_coord(lnode), tree->board), l.value, l.playouts,
-			coord2sstr(node_coord(node), tree->board), r.value, r.playouts);
+			coord2sstr(node_coord(lnode)), l.value, l.playouts,
+			coord2sstr(node_coord(node)), r.value, r.playouts);
 		stats_merge(&r, &l);
 	}
 
@@ -152,7 +152,7 @@ ucb1rave_evaluate(struct uct_policy *p, struct tree *tree, struct uct_descent *d
 							 crit * r.playouts * b->crit_rave);
 			URAVE_DEBUG fprintf(stderr, "[crit] adding %f%%%d to [%s] RAVE %f%%%d\n",
 				c.value, c.playouts,
-				coord2sstr(node_coord(node), tree->board), r.value, r.playouts);
+				coord2sstr(node_coord(node)), r.value, r.playouts);
 			stats_merge(&r, &c);
 		}
 	}
@@ -173,16 +173,16 @@ ucb1rave_evaluate(struct uct_policy *p, struct tree *tree, struct uct_descent *d
 
 			value = beta * r.value + (1.f - beta) * n.value;
 			URAVE_DEBUG fprintf(stderr, "\t%s value = %f * %f + (1 - %f) * %f (prior %f)\n",
-			        coord2sstr(node_coord(node), tree->board), beta, r.value, beta, n.value, node->prior.value);
+			        coord2sstr(node_coord(node)), beta, r.value, beta, n.value, node->prior.value);
 		} else {
 			value = n.value;
 			URAVE_DEBUG fprintf(stderr, "\t%s value = %f (prior %f)\n",
-			        coord2sstr(node_coord(node), tree->board), n.value, node->prior.value);
+			        coord2sstr(node_coord(node)), n.value, node->prior.value);
 		}
 	} else if (r.playouts) {
 		value = r.value;
 		URAVE_DEBUG fprintf(stderr, "\t%s value = rave %f (prior %f)\n",
-			coord2sstr(node_coord(node), tree->board), r.value, node->prior.value);
+			coord2sstr(node_coord(node)), r.value, node->prior.value);
 	}
 	descent->value.playouts = r.playouts + n.playouts;
 	descent->value.value = value;
@@ -266,7 +266,7 @@ ucb1amaf_update(struct uct_policy *p, struct tree *tree, struct tree_node *node,
 #if 0
 	struct board bb; bb.size = 9+2;
 	for (struct tree_node *ni = node; ni; ni = ni->parent)
-		fprintf(stderr, "%s ", coord2sstr(node_coord(ni), &bb));
+		fprintf(stderr, "%s ", coord2sstr(node_coord(ni)));
 	fprintf(stderr, "[color %d] update result %d (color %d)\n",
 			node_color, result, player_color);
 #endif
@@ -323,8 +323,8 @@ ucb1amaf_update(struct uct_policy *p, struct tree *tree, struct tree_node *node,
 #if 0
 			struct board bb; bb.size = 9+2;
 			fprintf(stderr, "* %s<%"PRIhash"> -> %s<%"PRIhash"> [%d/%f => %d/%f]\n",
-				coord2sstr(node_coord(node), &bb), node->hash,
-				coord2sstr(node_coord(ni), &bb), ni->hash,
+				coord2sstr(node_coord(node)), node->hash,
+				coord2sstr(node_coord(ni)), ni->hash,
 				player_color, result, move, res);
 #endif
 		}

--- a/uct/policy/ucb1amaf.c
+++ b/uct/policy/ucb1amaf.c
@@ -105,7 +105,7 @@ static inline floating_t fast_sqrt(unsigned int x)
 static inline floating_t
 ucb1rave_evaluate(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity)
 {
-	ucb1_policy_amaf_t *b = p->data;
+	ucb1_policy_amaf_t *b = (ucb1_policy_amaf_t*)p->data;
 	tree_node_t *node = descent->node;
 	tree_node_t *lnode = descent->lnode;
 
@@ -193,7 +193,7 @@ ucb1rave_evaluate(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int par
 void
 ucb1rave_descend(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity, bool allow_pass)
 {
-	ucb1_policy_amaf_t *b = p->data;
+	ucb1_policy_amaf_t *b = (ucb1_policy_amaf_t*)p->data;
 	floating_t nconf = 1.f;
 	if (b->explore_p > 0)
 		nconf = sqrt(log(descent->node->u.playouts + descent->node->prior.playouts));
@@ -252,7 +252,7 @@ ucb1amaf_update(uct_policy_t *p, tree_t *tree, tree_node_t *node,
 		playout_amafmap_t *map, board_t *final_board,
 		floating_t result)
 {
-	ucb1_policy_amaf_t *b = p->data;
+	ucb1_policy_amaf_t *b = (ucb1_policy_amaf_t*)p->data;
 	enum stone winner_color = result > 0.5 ? S_BLACK : S_WHITE;
 
 	/* Record of the random playout - for each intersection coord,
@@ -322,7 +322,7 @@ ucb1amaf_update(uct_policy_t *p, tree_t *tree, tree_node_t *node,
 			}
 #if 0
 			board_t bb; bb.size = 9+2;
-			fprintf(stderr, "* %s<%"PRIhash"> -> %s<%"PRIhash"> [%d/%f => %d/%f]\n",
+			fprintf(stderr, "* %s<%" PRIhash "> -> %s<%" PRIhash "> [%d/%f => %d/%f]\n",
 				coord2sstr(node_coord(node)), node->hash,
 				coord2sstr(node_coord(ni)), ni->hash,
 				player_color, result, move, res);

--- a/uct/policy/ucb1amaf.c
+++ b/uct/policy/ucb1amaf.c
@@ -121,7 +121,7 @@ ucb1rave_evaluate(struct uct_policy *p, struct tree *tree, struct uct_descent *d
 		 * other threads from visiting this node in case of multiple
 		 * threads doing the tree search. */
 		floating_t vloss_coeff = b->vloss_sqrt ? sqrt(p->uct->threads) / p->uct->threads : 1.;
-		struct move_stats c = { .value = parity > 0 ? 0. : 1., .playouts = node->descents * vloss_coeff };
+		struct move_stats c = move_stats((parity > 0 ? 0. : 1.), node->descents * vloss_coeff);
 		stats_merge(&n, &c);
 	}
 
@@ -148,10 +148,8 @@ ucb1rave_evaluate(struct uct_policy *p, struct tree *tree, struct uct_descent *d
 				val = 0;
 				crit = -crit;
 			}
-			struct move_stats c = {
-				.value = tree_node_get_value(tree, parity, val),
-				.playouts = crit * r.playouts * b->crit_rave
-			};
+			struct move_stats c = move_stats(tree_node_get_value(tree, parity, val),
+							 crit * r.playouts * b->crit_rave);
 			URAVE_DEBUG fprintf(stderr, "[crit] adding %f%%%d to [%s] RAVE %f%%%d\n",
 				c.value, c.playouts,
 				coord2sstr(node_coord(node), tree->board), r.value, r.playouts);

--- a/uct/prior.c
+++ b/uct/prior.c
@@ -326,7 +326,7 @@ uct_prior(uct_t *u, tree_node_t *node, prior_map_t *map)
 uct_prior_t *
 uct_prior_init(char *arg, board_t *b, uct_t *u)
 {
-	uct_prior_t *p = calloc2(1, sizeof(uct_prior_t));
+	uct_prior_t *p = calloc2(1, uct_prior_t);
 
 	p->even_eqex = p->policy_eqex = p->b19_eqex = p->eye_eqex = p->ko_eqex = p->plugin_eqex = -100;
 	/* FIXME: Optimal pattern_eqex is about -1000 with small playout counts
@@ -378,7 +378,7 @@ uct_prior_init(char *arg, board_t *b, uct_t *u)
 				 * 20 wins, 2nd-level neighbors 20 wins;
 				 * neighbors are group-transitive. */
 				p->cfgdn = atoi(optval); optval += strcspn(optval, "%");
-				p->cfgd_eqex = calloc2(p->cfgdn + 1, sizeof(*p->cfgd_eqex));
+				p->cfgd_eqex = calloc2(p->cfgdn + 1, int);
 				p->cfgd_eqex[0] = 0;
 				int i;
 				for (i = 1; *optval; i++, optval += strcspn(optval, "%")) {
@@ -432,7 +432,7 @@ uct_prior_init(char *arg, board_t *b, uct_t *u)
 		static int large_bonuses[] = { 0, 55, 50, 15 };
 		static int small_bonuses[] = { 0, 45, 40, 15 };
 		p->cfgdn = 3;
-		p->cfgd_eqex = calloc2(p->cfgdn + 1, sizeof(*p->cfgd_eqex));
+		p->cfgd_eqex = calloc2(p->cfgdn + 1, int);
 		memcpy(p->cfgd_eqex, board_large(b) ? large_bonuses : small_bonuses, sizeof(large_bonuses));
 	}
 	if (p->cfgdn > TREE_NODE_D_MAX)

--- a/uct/prior.c
+++ b/uct/prior.c
@@ -141,7 +141,7 @@ uct_prior_dcnn(struct uct *u, struct tree_node *node, struct prior_map *map)
 		if (!map->consider[c])
 			continue;
 		
-		int k = coord2dcnn_idx(c, map->b);
+		int k = coord2dcnn_idx(c);
 		float val = r[k];
 		if (isnan(val) || val < 0.001)
 			continue;
@@ -160,7 +160,7 @@ uct_prior_ko(struct uct *u, struct tree_node *node, struct prior_map *map)
 	coord_t ko = map->b->last_ko.coord;
 	if (is_pass(ko) || map->b->moves - map->b->last_ko_age > 10 || !map->consider[ko])
 		return;
-	// fprintf(stderr, "prior ko-fight @ %s %s\n", stone2str(map->to_play), coord2sstr(ko, map->b));
+	// fprintf(stderr, "prior ko-fight @ %s %s\n", stone2str(map->to_play), coord2sstr(ko));
 	add_prior_value(map, ko, 1, u->prior->ko_eqex);
 }
 
@@ -172,7 +172,7 @@ uct_prior_b19(struct uct *u, struct tree_node *node, struct prior_map *map)
 	foreach_free_point(map->b) {
 		if (!map->consider[c])
 			continue;
-		int d = coord_edge_distance(c, map->b);
+		int d = coord_edge_distance(c);
 		if (d != 0 && d != 2)
 			continue;
 		/* The bonus applies only with no stones in immediate
@@ -255,7 +255,7 @@ uct_prior_pattern(struct uct *u, struct tree_node *node, struct prior_map *map)
 	}		
 
 	if (UDEBUGL(5)) {
-		fprintf(stderr, "Pattern prior at node %s\n", coord2sstr(node->coord, b));
+		fprintf(stderr, "Pattern prior at node %s\n", coord2sstr(node->coord));
 		board_print(b, stderr);
 	}
 
@@ -265,7 +265,7 @@ uct_prior_pattern(struct uct *u, struct tree_node *node, struct prior_map *map)
 		assert(!is_pass(b->f[f]));
 		if (UDEBUGL(5)) {
 			char s[256]; pattern2str(s, &pats[f]);
-			fprintf(stderr, "\t%s: %.3f %s\n", coord2sstr(b->f[f], b), probs[f], s);
+			fprintf(stderr, "\t%s: %.3f %s\n", coord2sstr(b->f[f]), probs[f], s);
 		}
 		add_prior_value(map, b->f[f], 1.0, sqrt(probs[f]) * u->prior->pattern_eqex);
 	}
@@ -285,7 +285,7 @@ uct_prior(struct uct *u, struct tree_node *node, struct prior_map *map)
 			group_t atari_neighbor = board_get_atari_neighbor(b, c, map->to_play);
 			if (atari_neighbor && is_ladder(b, atari_neighbor, true) &&
 			    !useful_ladder(b, atari_neighbor)) {
-				if (UDEBUGL(5))	fprintf(stderr, "Pruning ladder move %s\n", coord2sstr(c, b));
+				if (UDEBUGL(5))	fprintf(stderr, "Pruning ladder move %s\n", coord2sstr(c));
 				map->consider[c] = false;  continue;
 			}
 

--- a/uct/prior.h
+++ b/uct/prior.h
@@ -12,7 +12,7 @@ struct board;
 /* Applying heuristic values to the tree nodes, skewing the reading in
  * most interesting directions. */
 
-struct uct_prior {
+typedef struct {
 	/* Equivalent experience for prior knowledge. MoGo paper recommends
 	 * 50 playouts per source; in practice, esp. with RAVE, about 6
 	 * playouts per source seems best. */
@@ -22,43 +22,43 @@ struct uct_prior {
 	int cfgdn; int *cfgd_eqex;
 	bool prune_ladders;
 	bool boost_pass;
-};
+} uct_prior_t;
 
-struct prior_map {
-	struct board *b;
+typedef struct prior_map {
+	board_t *b;
 	enum stone to_play;
 	int parity;
 	/* [board_size2(b)] array, move_stats are the prior
 	 * values to be assigned to individual moves;
 	 * move_stats.value is not updated. */
-	struct move_stats *prior;
+	move_stats_t *prior;
 	/* [board_size2(b)] array, whether to compute
 	 * prior for the given value. */
 	bool *consider;
 	/* [board_size2(b)] array from cfg_distances() */
 	int *distances;
-};
+} prior_map_t;
 
 /* @value is the value, @playouts is its weight. */
-static void add_prior_value(struct prior_map *map, coord_t c, floating_t value, int playouts);
+static void add_prior_value(prior_map_t *map, coord_t c, floating_t value, int playouts);
 
-void uct_prior(struct uct *u, struct tree_node *node, struct prior_map *map);
+void uct_prior(struct uct *u, tree_node_t *node, prior_map_t *map);
 
-struct uct_prior *uct_prior_init(char *arg, struct board *b, struct uct *u);
-void uct_prior_done(struct uct_prior *p);
+uct_prior_t *uct_prior_init(char *arg, board_t *b, struct uct *u);
+void uct_prior_done(uct_prior_t *p);
 
 
 static inline void
-add_prior_value(struct prior_map *map, coord_t c, floating_t value, int playouts)
+add_prior_value(prior_map_t *map, coord_t c, floating_t value, int playouts)
 {
 	floating_t v = map->parity > 0 ? value : 1 - value;
 	/* We don't need atomicity: */
-	struct move_stats s = move_stats(v, playouts);
+	move_stats_t s = move_stats(v, playouts);
 	stats_merge(&map->prior[c], &s);
 }
 
 /* Display node's priors best moves */
-void print_node_prior_best_moves(struct board *b, struct tree_node *parent);
-void get_node_prior_best_moves(struct tree_node *parent, coord_t *best_c, float *best_r, int nbest);
+void print_node_prior_best_moves(board_t *b, tree_node_t *parent);
+void get_node_prior_best_moves(tree_node_t *parent, coord_t *best_c, float *best_r, int nbest);
 
 #endif

--- a/uct/prior.h
+++ b/uct/prior.h
@@ -53,7 +53,7 @@ add_prior_value(struct prior_map *map, coord_t c, floating_t value, int playouts
 {
 	floating_t v = map->parity > 0 ? value : 1 - value;
 	/* We don't need atomicity: */
-	struct move_stats s = { .playouts = playouts, .value = v };
+	struct move_stats s = move_stats(v, playouts);
 	stats_merge(&map->prior[c], &s);
 }
 

--- a/uct/search.c
+++ b/uct/search.c
@@ -97,7 +97,7 @@ static void *
 spawn_worker(void *ctx_)
 {
 	/* Setup */
-	uct_thread_ctx_t *ctx = ctx_;
+	uct_thread_ctx_t *ctx = (uct_thread_ctx_t*)ctx_;
 	uct_t *u = ctx->u;
 	board_t *b = ctx->b;
 	enum stone color = ctx->color;
@@ -168,7 +168,7 @@ static void *
 spawn_thread_manager(void *ctx_)
 {
 	/* In thread_manager, we use only some of the ctx fields. */
-	uct_thread_ctx_t *mctx = ctx_;
+	uct_thread_ctx_t *mctx = (uct_thread_ctx_t*)ctx_;
 	uct_t *u = mctx->u;
 	tree_t *t = mctx->t;
 	fast_srandom(mctx->seed);
@@ -244,7 +244,7 @@ spawn_thread_manager(void *ctx_)
 static void *
 spawn_logger(void *ctx_)
 {
-	uct_thread_ctx_t *ctx = ctx_;
+	uct_thread_ctx_t *ctx = (uct_thread_ctx_t*)ctx_;
 	uct_t *u = ctx->u;
 	tree_t *t = ctx->t;
 	board_t *b = ctx->b;

--- a/uct/search.c
+++ b/uct/search.c
@@ -322,7 +322,7 @@ uct_expand_next_best_moves(struct uct *u, struct tree *t, struct board *b, enum 
 	if (DEBUGL(2)) {  /* Show guesses. */
 		fprintf(stderr, "dcnn eval %s ", stone2str(color));
 		for (unsigned int i = 0; i < q.moves; i++)
-			fprintf(stderr, "%s ", coord2sstr(q.move[i], b));
+			fprintf(stderr, "%s ", coord2sstr(q.move[i]));
 		fflush(stderr);
 	}
 
@@ -546,9 +546,9 @@ uct_search_keep_looking(struct uct *u, struct tree *t, struct board *b,
 		 * does not have also highest value. */
 		if (UDEBUGL(3))
 			fprintf(stderr, "[%d] best %3s [%d] %f != winner %3s [%d] %f\n", i,
-				coord2sstr(node_coord(best), t->board),
+				coord2sstr(node_coord(best)),
 				best->u.playouts, tree_node_get_value(t, 1, best->u.value),
-				coord2sstr(node_coord(winner), t->board),
+				coord2sstr(node_coord(winner)),
 				winner->u.playouts, tree_node_get_value(t, 1, winner->u.value));
 		return true;
 	}
@@ -677,7 +677,7 @@ uct_search_result(struct uct *u, struct board *b, enum stone color,
 
 	if (UDEBUGL(1))
 		fprintf(stderr, "*** WINNER is %s with score %1.4f (%d/%d:%d/%d games), extra komi %f\n",
-			coord2sstr(node_coord(best), b), winrate,
+			coord2sstr(node_coord(best)), winrate,
 			best->u.playouts, u->t->root->u.playouts,
 			u->t->root->u.playouts - base_playouts, played_games,
 			u->t->extra_komi);

--- a/uct/search.c
+++ b/uct/search.c
@@ -12,9 +12,7 @@
 #define DEBUG
 
 #include "debug.h"
-#include "pachi.h"
-#include "distributed/distributed.h"
-#include "move.h"
+#include "board.h"
 #include "joseki.h"
 #include "random.h"
 #include "timeinfo.h"
@@ -27,7 +25,9 @@
 #include "uct/uct.h"
 #include "uct/walk.h"
 #include "uct/prior.h"
+#include "distributed/distributed.h"
 #include "dcnn.h"
+#include "pachi.h"
 
 
 /* Default time settings for the UCT engine. In distributed mode, slaves are
@@ -35,7 +35,7 @@
  * or with total number of playouts over all slaves. (It is also possible but
  * not recommended to limit only the slaves; the master then decides the move
  * when a majority of slaves have made their choice.) */
-static struct time_info default_ti;
+static time_info_t default_ti;
 static __attribute__((constructor)) void
 default_ti_init(void)
 {
@@ -90,16 +90,16 @@ static pthread_cond_t finish_cond = PTHREAD_COND_INITIALIZER;
 static volatile int finish_thread;
 static pthread_mutex_t finish_serializer = PTHREAD_MUTEX_INITIALIZER;
 
-static void  uct_expand_next_best_moves(struct uct *u, struct tree *t, struct board *b, enum stone color);
+static void  uct_expand_next_best_moves(uct_t *u, tree_t *t, board_t *b, enum stone color);
 static void *spawn_logger(void *ctx_);
 
 static void *
 spawn_worker(void *ctx_)
 {
 	/* Setup */
-	struct uct_thread_ctx *ctx = ctx_;
-	struct uct *u = ctx->u;
-	struct board *b = ctx->b;
+	uct_thread_ctx_t *ctx = ctx_;
+	uct_t *u = ctx->u;
+	board_t *b = ctx->b;
 	enum stone color = ctx->color;
 	fast_srandom(ctx->seed);
 
@@ -123,8 +123,8 @@ spawn_worker(void *ctx_)
 
 	/* Expand root node (dcnn). Other threads wait till it's ready. 
 	 * For dcnn pondering we also need dcnn values for opponent's best moves. */
-	struct tree *t = ctx->t;
-	struct tree_node *n = t->root;
+	tree_t *t = ctx->t;
+	tree_node_t *n = t->root;
 	if (!ctx->tid) {
 		enum stone node_color = stone_other(color);
 		assert(node_color == t->root_color);
@@ -168,9 +168,9 @@ static void *
 spawn_thread_manager(void *ctx_)
 {
 	/* In thread_manager, we use only some of the ctx fields. */
-	struct uct_thread_ctx *mctx = ctx_;
-	struct uct *u = mctx->u;
-	struct tree *t = mctx->t;
+	uct_thread_ctx_t *mctx = ctx_;
+	uct_t *u = mctx->u;
+	tree_t *t = mctx->t;
 	fast_srandom(mctx->seed);
 
 	int played_games = 0;
@@ -192,7 +192,7 @@ spawn_thread_manager(void *ctx_)
 	
 	/* Spawn threads... */
 	for (int ti = 0; ti < u->threads; ti++) {
-		struct uct_thread_ctx *ctx = malloc2(sizeof(*ctx));
+		uct_thread_ctx_t *ctx = malloc2(sizeof(*ctx));
 		ctx->u = u; ctx->b = mctx->b; ctx->color = mctx->color;
 		mctx->t = ctx->t = t;
 		ctx->tid = ti; ctx->seed = fast_random(65536) + ti;
@@ -221,7 +221,7 @@ spawn_thread_manager(void *ctx_)
 			continue;
 		}
 		/* ...and gather its remnants. */
-		struct uct_thread_ctx *ctx;
+		uct_thread_ctx_t *ctx;
 		pthread_join(threads[finish_thread], (void **) &ctx);
 		played_games += ctx->games;
 		joined++;
@@ -244,13 +244,13 @@ spawn_thread_manager(void *ctx_)
 static void *
 spawn_logger(void *ctx_)
 {
-	struct uct_thread_ctx *ctx = ctx_;
-	struct uct *u = ctx->u;
-	struct tree *t = ctx->t;
-	struct board *b = ctx->b;
+	uct_thread_ctx_t *ctx = ctx_;
+	uct_t *u = ctx->u;
+	tree_t *t = ctx->t;
+	board_t *b = ctx->b;
 	enum stone color = ctx->color;
-	struct uct_search_state *s = ctx->s;
-	struct time_info *ti = ctx->ti;
+	uct_search_state_t *s = ctx->s;
+	time_info_t *ti = ctx->ti;
 
 	// Similar to uct_search() code when pondering
 	while (!uct_halt) {
@@ -270,15 +270,15 @@ spawn_logger(void *ctx_)
 
 /* Expand next move node (dcnn pondering) */
 static void
-uct_expand_next_move(struct uct *u, struct tree *t, struct board *board, enum stone color, coord_t c)
+uct_expand_next_move(uct_t *u, tree_t *t, board_t *board, enum stone color, coord_t c)
 {
-	struct tree_node *n = tree_get_node(t->root, c);
+	tree_node_t *n = tree_get_node(t->root, c);
 	assert(n && tree_leaf_node(n) && !n->is_expanded);
 	
-	struct board b;
+	board_t b;
 	board_copy(&b, board);
 
-	struct move m = move(c, color);
+	move_t m = move(c, color);
 	int res = board_play(&b, &m);
 	if (res < 0) goto done;
 		
@@ -294,10 +294,10 @@ uct_expand_next_move(struct uct *u, struct tree *t, struct board *board, enum st
  * guess wrong pondering will not be useful for this move, search results
  * will be discarded. */
 static void
-uct_expand_next_best_moves(struct uct *u, struct tree *t, struct board *b, enum stone color)
+uct_expand_next_best_moves(uct_t *u, tree_t *t, board_t *b, enum stone color)
 {
 	assert(using_dcnn(b));
-	struct move_queue q;  mq_init(&q);
+	move_queue_t q;  mq_init(&q);
 	
 	{  /* Prior best moves (dcnn policy mostly) */
 		int nbest = u->dcnn_pondering_prior;
@@ -340,15 +340,15 @@ uct_expand_next_best_moves(struct uct *u, struct tree *t, struct board *b, enum 
 
 
 int
-uct_search_games(struct uct_search_state *s)
+uct_search_games(uct_search_state_t *s)
 {
 	return s->ctx->t->root->u.playouts;
 }
 
 void
-uct_search_start(struct uct *u, struct board *b, enum stone color,
-		 struct tree *t, struct time_info *ti,
-		 struct uct_search_state *s)
+uct_search_start(uct_t *u, board_t *b, enum stone color,
+		 tree_t *t, time_info_t *ti,
+		 uct_search_state_t *s)
 {
 	/* Set up search state. */
 	s->base_playouts = s->last_dynkomi = s->last_print = t->root->u.playouts;
@@ -371,8 +371,8 @@ uct_search_start(struct uct *u, struct board *b, enum stone color,
 	 * spawn the searching threads. */
 	assert(u->threads > 0);
 	assert(!thread_manager_running);
-	static struct uct_thread_ctx mctx;
-	mctx = (struct uct_thread_ctx) { 0, u, b, color, t, fast_random(65536), 0, ti, s };
+	static uct_thread_ctx_t mctx;
+	mctx = (uct_thread_ctx_t) { 0, u, b, color, t, fast_random(65536), 0, ti, s };
 	s->ctx = &mctx;
 	pthread_mutex_lock(&finish_serializer);
 	pthread_mutex_lock(&finish_mutex);
@@ -380,7 +380,7 @@ uct_search_start(struct uct *u, struct board *b, enum stone color,
 	thread_manager_running = true;
 }
 
-struct uct_thread_ctx *
+uct_thread_ctx_t *
 uct_search_stop(void)
 {
 	assert(thread_manager_running);
@@ -392,7 +392,7 @@ uct_search_stop(void)
 	pthread_mutex_unlock(&finish_mutex);
 
 	/* Collect the thread manager. */
-	struct uct_thread_ctx *pctx;
+	uct_thread_ctx_t *pctx;
 	thread_manager_running = false;
 	pthread_join(thread_manager, (void **) &pctx);
 	return pctx;
@@ -400,11 +400,11 @@ uct_search_stop(void)
 
 
 void
-uct_search_progress(struct uct *u, struct board *b, enum stone color,
-		    struct tree *t, struct time_info *ti,
-		    struct uct_search_state *s, int i)
+uct_search_progress(uct_t *u, board_t *b, enum stone color,
+		    tree_t *t, time_info_t *ti,
+		    uct_search_state_t *s, int i)
 {
-	struct uct_thread_ctx *ctx = s->ctx;
+	uct_thread_ctx_t *ctx = s->ctx;
 
 	/* Adjust dynkomi? */
 	int di = u->dynkomi_interval * u->threads;
@@ -439,9 +439,9 @@ uct_search_progress(struct uct *u, struct board *b, enum stone color,
 
 /* Determine whether we should terminate the search early. */
 static bool
-uct_search_stop_early(struct uct *u, struct tree *t, struct board *b,
-		struct time_info *ti, struct time_stop *stop,
-		struct tree_node *best, struct tree_node *best2,
+uct_search_stop_early(uct_t *u, tree_t *t, board_t *b,
+		time_info_t *ti, time_stop_t *stop,
+		tree_node_t *best, tree_node_t *best2,
 		int played, bool fullmem)
 {
 	/* If the memory is full, stop immediately. Since the tree
@@ -493,10 +493,10 @@ uct_search_stop_early(struct uct *u, struct tree *t, struct board *b,
 
 /* Determine whether we should terminate the search later than expected. */
 static bool
-uct_search_keep_looking(struct uct *u, struct tree *t, struct board *b,
-		struct time_info *ti, struct time_stop *stop,
-		struct tree_node *best, struct tree_node *best2,
-		struct tree_node *bestr, struct tree_node *winner, int i)
+uct_search_keep_looking(uct_t *u, tree_t *t, board_t *b,
+		time_info_t *ti, time_stop_t *stop,
+		tree_node_t *best, tree_node_t *best2,
+		tree_node_t *bestr, tree_node_t *winner, int i)
 {
 	if (!best) {
 		if (UDEBUGL(2))
@@ -558,11 +558,11 @@ uct_search_keep_looking(struct uct *u, struct tree *t, struct board *b,
 }
 
 bool
-uct_search_check_stop(struct uct *u, struct board *b, enum stone color,
-		      struct tree *t, struct time_info *ti,
-		      struct uct_search_state *s, int i)
+uct_search_check_stop(uct_t *u, board_t *b, enum stone color,
+		      tree_t *t, time_info_t *ti,
+		      uct_search_state_t *s, int i)
 {
-	struct uct_thread_ctx *ctx = s->ctx;
+	uct_thread_ctx_t *ctx = s->ctx;
 
 	/* Never consider stopping if we played too few simulations.
 	 * Maybe we risk losing on time when playing in super-extreme
@@ -573,10 +573,10 @@ uct_search_check_stop(struct uct *u, struct board *b, enum stone color,
 	if (i < GJ_MINGAMES)
 		return false;
 
-	struct tree_node *best = NULL;
-	struct tree_node *best2 = NULL; // Second-best move.
-	struct tree_node *bestr = NULL; // best's best child.
-	struct tree_node *winner = NULL;
+	tree_node_t *best = NULL;
+	tree_node_t *best2 = NULL; // Second-best move.
+	tree_node_t *bestr = NULL; // best's best child.
+	tree_node_t *winner = NULL;
 
 	best = u->policy->choose(u->policy, ctx->t->root, b, color, resign);
 	if (best) best2 = u->policy->choose(u->policy, ctx->t->root, b, color, node_coord(best));
@@ -602,7 +602,7 @@ uct_search_check_stop(struct uct *u, struct board *b, enum stone color,
 	 * if we aren't completely sure about the winner yet. */
 	if (desired_done) {
 		if (u->policy->winner && u->policy->evaluate) {
-			struct uct_descent descent = uct_descent(ctx->t->root, NULL);
+			uct_descent_t descent = uct_descent(ctx->t->root, NULL);
 			u->policy->winner(u->policy, ctx->t, &descent);
 			winner = descent.node;
 		}
@@ -620,14 +620,14 @@ uct_search_check_stop(struct uct *u, struct board *b, enum stone color,
 
 /* uct_pass_is_safe() also called by uct policy, beware.  */
 static bool
-uct_search_pass_is_safe(struct uct *u, struct board *b, enum stone color, bool pass_all_alive, char **msg)
+uct_search_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, char **msg)
 {
 	bool res = uct_pass_is_safe(u, b, color, pass_all_alive, msg);
 
 	/* Save dead groups for final_status_list dead. */
 	if (res) {
-		struct move_queue unclear;
-		struct move_queue *dead = &u->dead_groups;
+		move_queue_t unclear;
+		move_queue_t *dead = &u->dead_groups;
 		u->pass_moveno = b->moves + 1;
 		get_dead_groups(b, &u->ownermap, dead, &unclear);
 	}
@@ -635,7 +635,7 @@ uct_search_pass_is_safe(struct uct *u, struct board *b, enum stone color, bool p
 }
 
 static bool
-uct_pass_first(struct uct *u, struct board *b, enum stone color, bool pass_all_alive, coord_t coord)
+uct_pass_first(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, coord_t coord)
 {	
 	/* For kgs: must not pass first in main game phase. */
 	bool can_pass_first = (!nopassfirst || pass_all_alive);
@@ -649,7 +649,7 @@ uct_pass_first(struct uct *u, struct board *b, enum stone color, bool pass_all_a
 	if (capturing || atariing || board_playing_ko_threat(b))  return false;
 
 	/* Find dames left */
-	struct move_queue dead, unclear;
+	move_queue_t dead, unclear;
 	uct_mcowner_playouts(u, b, color);
 	get_dead_groups(b, &u->ownermap, &dead, &unclear);
 	if (unclear.moves)  return false;
@@ -661,13 +661,13 @@ uct_pass_first(struct uct *u, struct board *b, enum stone color, bool pass_all_a
 	return (!dame && move_owner == other_color); /* play in opponent territory */
 }
 
-struct tree_node *
-uct_search_result(struct uct *u, struct board *b, enum stone color,
+tree_node_t *
+uct_search_result(uct_t *u, board_t *b, enum stone color,
 		  bool pass_all_alive, int played_games, int base_playouts,
 		  coord_t *best_coord)
 {
 	/* Choose the best move from the tree. */
-	struct tree_node *best = u->policy->choose(u->policy, u->t->root, b, color, resign);
+	tree_node_t *best = u->policy->choose(u->policy, u->t->root, b, color, resign);
 	if (!best) {
 		*best_coord = pass;
 		return NULL;

--- a/uct/search.c
+++ b/uct/search.c
@@ -192,7 +192,7 @@ spawn_thread_manager(void *ctx_)
 	
 	/* Spawn threads... */
 	for (int ti = 0; ti < u->threads; ti++) {
-		uct_thread_ctx_t *ctx = malloc2(sizeof(*ctx));
+		uct_thread_ctx_t *ctx = malloc2(uct_thread_ctx_t);
 		ctx->u = u; ctx->b = mctx->b; ctx->color = mctx->color;
 		mctx->t = ctx->t = t;
 		ctx->tid = ti; ctx->seed = fast_random(65536) + ti;

--- a/uct/search.h
+++ b/uct/search.h
@@ -32,22 +32,21 @@ extern volatile sig_atomic_t uct_halt;
 extern bool thread_manager_running;
 
 /* Search thread context */
-struct uct_thread_ctx {
+typedef struct uct_thread_ctx {
 	int tid;
-	struct uct *u;
-	struct board *b;
+	uct_t *u;
+	board_t *b;
 	enum stone color;
-	struct tree *t;
+	tree_t *t;
 	unsigned long seed;
 	int games;
-	struct time_info *ti;
+	time_info_t *ti;
 	struct uct_search_state *s;
-};
-
+} uct_thread_ctx_t;
 
 /* Progress information of the on-going MCTS search - when did we
  * last adjusted dynkomi, printed out stuff, etc. */
-struct uct_search_state {
+typedef struct uct_search_state {
 	/* Number of games simulated for this simulation before
 	 * we started the search. (We have simulated them earlier.) */
 	int base_playouts;
@@ -60,19 +59,20 @@ struct uct_search_state {
 	/* Printed notification about full memory? */
 	bool fullmem;
 
-	struct time_stop stop;
-	struct uct_thread_ctx *ctx;
-};
+	time_stop_t stop;
+	uct_thread_ctx_t *ctx;
+} uct_search_state_t;
 
-int uct_search_games(struct uct_search_state *s);
 
-void uct_search_start(struct uct *u, struct board *b, enum stone color, struct tree *t, struct time_info *ti, struct uct_search_state *s);
-struct uct_thread_ctx *uct_search_stop(void);
+int uct_search_games(uct_search_state_t *s);
 
-void uct_search_progress(struct uct *u, struct board *b, enum stone color, struct tree *t, struct time_info *ti, struct uct_search_state *s, int i);
+void uct_search_start(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti, uct_search_state_t *s);
+uct_thread_ctx_t *uct_search_stop(void);
 
-bool uct_search_check_stop(struct uct *u, struct board *b, enum stone color, struct tree *t, struct time_info *ti, struct uct_search_state *s, int i);
+void uct_search_progress(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti, uct_search_state_t *s, int i);
 
-struct tree_node *uct_search_result(struct uct *u, struct board *b, enum stone color, bool pass_all_alive, int played_games, int base_playouts, coord_t *best_coord);
+bool uct_search_check_stop(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti, uct_search_state_t *s, int i);
+
+tree_node_t *uct_search_result(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, int played_games, int base_playouts, coord_t *best_coord);
 
 #endif

--- a/uct/search.h
+++ b/uct/search.h
@@ -44,6 +44,7 @@ typedef struct uct_thread_ctx {
 	struct uct_search_state *s;
 } uct_thread_ctx_t;
 
+
 /* Progress information of the on-going MCTS search - when did we
  * last adjusted dynkomi, printed out stuff, etc. */
 typedef struct uct_search_state {

--- a/uct/slave.c
+++ b/uct/slave.c
@@ -50,25 +50,25 @@
 /* UCT infrastructure for a distributed engine slave. */
 
 /* For debugging only. */
-static struct hash_counts h_counts;
+static hash_counts_t h_counts;
 static long parent_not_found = 0;
 static long parent_leaf = 0;
 static long node_not_found = 0;
 
 /* Hash table entry mapping path to node. */
-struct tree_hash {
+typedef struct tree_hash {
 	path_t coord_path;
-	struct tree_node *node;
-};
+	tree_node_t *node;
+} tree_hash_t;
 
 void *
 uct_htable_alloc(int hbits)
 {
-	return calloc2(1 << hbits, sizeof(struct tree_hash));
+	return calloc2(1 << hbits, sizeof(tree_hash_t));
 }
 
 /* Clear the hash table. Used only when running as slave for the distributed engine. */
-void uct_htable_reset(struct tree *t)
+void uct_htable_reset(tree_t *t)
 {
 	if (!t->htable) return;
 	double start = time_now();
@@ -93,8 +93,8 @@ void uct_htable_reset(struct tree *t)
  * prev is only used to optimize the tree search, given that calls to
  * tree_find_node are made with sorted coordinates (increasing levels
  * and increasing coord within a level). */
-static struct tree_node *
-tree_find_node(struct tree *t, struct incr_stats *is, struct tree_node *prev)
+static tree_node_t *
+tree_find_node(tree_t *t, incr_stats_t *is, tree_node_t *prev)
 {
 	assert(t && t->htable);
 	path_t path = is->coord_path;
@@ -104,7 +104,7 @@ tree_find_node(struct tree *t, struct incr_stats *is, struct tree_node *prev)
 	int hash, parent_hash;
 	bool found;
 	find_hash(hash, t->htable, t->hbits, path, found, h_counts);
-	struct tree_hash *hnode = &t->htable[hash];
+	tree_hash_t *hnode = &t->htable[hash];
 
 	if (DEBUGVV(7))
 		fprintf(stderr,
@@ -116,7 +116,7 @@ tree_find_node(struct tree *t, struct incr_stats *is, struct tree_node *prev)
 	/* The master sends parents before children so the parent should
 	 * already be in the hash table. */
 	path_t parent_p = parent_path(path, t->board);
-	struct tree_node *parent;
+	tree_node_t *parent;
 	if (parent_p) {
 		find_hash(parent_hash, t->htable, t->hbits,
 			  parent_p, found, h_counts);
@@ -124,7 +124,7 @@ tree_find_node(struct tree *t, struct incr_stats *is, struct tree_node *prev)
 	} else {
 		parent = t->root;
 	}
-	struct tree_node *node = NULL;
+	tree_node_t *node = NULL;
 	if (parent) {
 		/* Search for the node in parent's children. */
 		coord_t leaf = leaf_coord(path, t->board);
@@ -172,9 +172,9 @@ discard_bin_args(char *args)
 }
 
 enum parse_code
-uct_notify(struct engine *e, struct board *b, int id, char *cmd, char *args, char **reply)
+uct_notify(engine_t *e, board_t *b, int id, char *cmd, char *args, char **reply)
 {
-	struct uct *u = e->data;
+	uct_t *u = e->data;
 
 	static bool board_resized = true;
 	if (is_gamestart(cmd)) {
@@ -208,20 +208,20 @@ uct_notify(struct engine *e, struct board *b, int id, char *cmd, char *args, cha
  * Keep this code in sync with distributed/merge.c:output_stats()
  * Return true if ok, false if error. */
 static bool
-receive_stats(struct uct *u, int size)
+receive_stats(uct_t *u, int size)
 {
-	if (size % sizeof(struct incr_stats)) return false;
-	int nodes = size / sizeof(struct incr_stats);
+	if (size % sizeof(incr_stats_t)) return false;
+	int nodes = size / sizeof(incr_stats_t);
 	if (nodes > (1 << u->stats_hbits)) return false;
 
-	struct tree *t = u->t;
+	tree_t *t = u->t;
 	assert(nodes && t->htable);
-	struct tree_node *prev = NULL;
+	tree_node_t *prev = NULL;
 	double start_time = time_now();
 
 	for (int n = 0; n < nodes; n++) {
-		struct incr_stats is;
-		if (fread(&is, sizeof(struct incr_stats), 1, stdin) != 1)
+		incr_stats_t is;
+		if (fread(&is, sizeof(incr_stats_t), 1, stdin) != 1)
 			return false;
 
 		if (UDEBUGL(7))
@@ -229,7 +229,7 @@ receive_stats(struct uct *u, int size)
 				is.incr.playouts, is.incr.value, is.coord_path,
 				path2sstr(is.coord_path, t->board));
 
-		struct tree_node *node = tree_find_node(t, &is, prev);
+		tree_node_t *node = tree_find_node(t, &is, prev);
 		if (!node) continue;
 
 		/* node_total += others_incr */
@@ -247,11 +247,11 @@ receive_stats(struct uct *u, int size)
 }
 
 /* A tree traversal fills this array, then the nodes with most increments are sent. */
-struct stats_candidate {
+typedef struct {
 	path_t coord_path;
 	int playout_incr;
-	struct tree_node *node;
-};
+	tree_node_t *node;
+} stats_candidate_t;
 
 /* We maintain counts per bucket to avoid sorting stats_queue.
  * All nodes with n updates since last send go to bucket n.
@@ -267,12 +267,12 @@ static int bucket_count[MAX_BUCKETS];
  * have been made since the last send, and the level is not too deep.
  * Return the updated stats count. */
 static int
-append_stats(struct stats_candidate *stats_queue, struct tree_node *node, int stats_count,
-	     int max_count, path_t start_path, path_t max_path, int min_increment, struct board *b)
+append_stats(stats_candidate_t *stats_queue, tree_node_t *node, int stats_count,
+	     int max_count, path_t start_path, path_t max_path, int min_increment, board_t *b)
 {
 	/* The children field is set only after all children are created
 	 * so we can traverse the the tree while it is updated. */
-	for (struct tree_node *ni = node->children; ni; ni = ni->sibling) {
+	for (tree_node_t *ni = node->children; ni; ni = ni->sibling) {
 
 		if (is_pass(node_coord(ni))) continue;
 		if (ni->hints & TREE_HINT_INVALID) continue;
@@ -307,18 +307,18 @@ append_stats(struct stats_candidate *stats_queue, struct tree_node *node, int st
 static int
 coord_cmp(const void *p1, const void *p2)
 {
-	path_t diff = ((struct incr_stats *)p1)->coord_path
-		    - ((struct incr_stats *)p2)->coord_path;
+	path_t diff = ((incr_stats_t *)p1)->coord_path
+		    - ((incr_stats_t *)p2)->coord_path;
 	return (int)(diff >> 32) | !!(int)diff;
 }
 
 /* Select from stats_queue at most shared_nodes candidates with
  * biggest increments. Return a binary array sorted by coord path. */
-static struct incr_stats *
-select_best_stats(struct stats_candidate *stats_queue, int stats_count,
+static incr_stats_t *
+select_best_stats(stats_candidate_t *stats_queue, int stats_count,
 		  int shared_nodes, int *byte_size)
 {
-	static struct incr_stats *out_stats = NULL;
+	static incr_stats_t *out_stats = NULL;
 	if (!out_stats)
 		out_stats = malloc2(shared_nodes * sizeof(*out_stats));
 
@@ -332,13 +332,13 @@ select_best_stats(struct stats_candidate *stats_queue, int stats_count,
 
 	/* Send all all increments > min_incr plus whatever we can at min_incr. */
 	int min_count = bucket_count[min_incr] - (out_count - shared_nodes);
-	struct incr_stats *os = out_stats;
+	incr_stats_t *os = out_stats;
 	out_count = 0;
 	for (int count = 0; count < stats_count; count++) {
 		int delta = stats_queue[count].playout_incr - min_incr;
 		if (delta < 0 || (delta == 0 && --min_count < 0)) continue;
 
-		struct tree_node *node = stats_queue[count].node;
+		tree_node_t *node = stats_queue[count].node;
 		os->incr = node->u;
 		stats_rm_result(&os->incr, node->pu.value, node->pu.playouts);
 
@@ -371,18 +371,18 @@ select_best_stats(struct stats_candidate *stats_queue, int stats_count,
  * called while the tree is updated by the worker threads. Keep this
  * code in sync with distributed/merge.c:merge_new_stats(). */
 static void *
-report_incr_stats(struct uct *u, int *stats_size)
+report_incr_stats(uct_t *u, int *stats_size)
 {
 	double start_time = time_now();
 
-	struct tree_node *root = u->t->root;
-	struct board *b = u->t->board;
+	tree_node_t *root = u->t->root;
+	board_t *b = u->t->board;
 
 	/* The factor 3 below has experimentally been found to be
 	 * sufficient. At worst if we fill stats_queue we will
 	 * discard some stats updates but this is rare. */
 	int max_nodes = 3 * u->shared_nodes;
-	static struct stats_candidate *stats_queue = NULL;
+	static stats_candidate_t *stats_queue = NULL;
 	if (!stats_queue) stats_queue = malloc2(max_nodes * sizeof(*stats_queue));
 
 	memset(bucket_count, 0, sizeof(bucket_count));
@@ -413,7 +413,7 @@ report_incr_stats(struct uct *u, int *stats_size)
 		fprintf(stderr,
 			"min_incr %d games %d stats_queue %d/%d sending %d/%d in %.3fms\n",
 			min_increment, root->u.playouts - root->pu.playouts, stats_count,
-			max_nodes, *stats_size / (int)sizeof(struct incr_stats), u->shared_nodes,
+			max_nodes, *stats_size / (int)sizeof(incr_stats_t), u->shared_nodes,
 			(time_now() - start_time)*1000);
 	root->pu = root->u;
 	return buf;
@@ -429,13 +429,13 @@ report_incr_stats(struct uct *u, int *stats_size)
  * called while the tree is updated by the worker threads. Keep this
  * code in sync with distributed/distributed.c:select_best_move(). */
 static char *
-report_stats(struct uct *u, struct board *b, coord_t c,
+report_stats(uct_t *u, board_t *b, coord_t c,
 	     bool keep_looking, int bin_size)
 {
 	static char reply[10240];
 	char *r = reply;
 	char *end = reply + sizeof(reply);
-	struct tree_node *root = u->t->root;
+	tree_node_t *root = u->t->root;
 	r += snprintf(r, end - r, "%d %d %d %d @%d", u->played_own, root->u.playouts,
 		      u->threads, keep_looking, bin_size);
 	int min_playouts = root->u.playouts / 100;
@@ -445,7 +445,7 @@ report_stats(struct uct *u, struct board *b, coord_t c,
 
 	/* We rely on the fact that root->children is set only
 	 * after all children are created. */
-	for (struct tree_node *ni = root->children; ni; ni = ni->sibling) {
+	for (tree_node_t *ni = root->children; ni; ni = ni->sibling) {
 
 		if (is_pass(node_coord(ni))) continue;
 		assert(node_coord(ni) > 0 && node_coord(ni) < board_size2(b));
@@ -485,10 +485,10 @@ report_stats(struct uct *u, struct board *b, coord_t c,
  * except possibly for the first call at a given move number.
  * See report_stats() for the description of the return value. */
 char *
-uct_genmoves(struct engine *e, struct board *b, struct time_info *ti, enum stone color,
+uct_genmoves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 	     char *args, bool pass_all_alive, void **stats_buf, int *stats_size)
 {
-	struct uct *u = e->data;
+	uct_t *u = e->data;
 	assert(u->slave);
 	u->pass_all_alive |= pass_all_alive;
 
@@ -509,7 +509,7 @@ uct_genmoves(struct engine *e, struct board *b, struct time_info *ti, enum stone
 		return NULL;
 	}
 
-	static struct uct_search_state s;
+	static uct_search_state_t s;
 	if (!thread_manager_running) {
 		/* This is the first genmoves issue, start the MCTS
 		 * now and let it run while we receive stats. */

--- a/uct/slave.c
+++ b/uct/slave.c
@@ -64,7 +64,7 @@ typedef struct tree_hash {
 void *
 uct_htable_alloc(int hbits)
 {
-	return calloc2(1 << hbits, sizeof(tree_hash_t));
+	return calloc2(1 << hbits, tree_hash_t);
 }
 
 /* Clear the hash table. Used only when running as slave for the distributed engine. */
@@ -320,7 +320,7 @@ select_best_stats(stats_candidate_t *stats_queue, int stats_count,
 {
 	static incr_stats_t *out_stats = NULL;
 	if (!out_stats)
-		out_stats = malloc2(shared_nodes * sizeof(*out_stats));
+		out_stats = calloc2(shared_nodes, incr_stats_t);
 
 	/* Find the minimum increment to send. The bucket with minimum
          * increment may be sent only partially. */
@@ -383,7 +383,7 @@ report_incr_stats(uct_t *u, int *stats_size)
 	 * discard some stats updates but this is rare. */
 	int max_nodes = 3 * u->shared_nodes;
 	static stats_candidate_t *stats_queue = NULL;
-	if (!stats_queue) stats_queue = malloc2(max_nodes * sizeof(*stats_queue));
+	if (!stats_queue) stats_queue = calloc2(max_nodes, stats_candidate_t);
 
 	memset(bucket_count, 0, sizeof(bucket_count));
 

--- a/uct/slave.c
+++ b/uct/slave.c
@@ -61,7 +61,7 @@ typedef struct tree_hash {
 	tree_node_t *node;
 } tree_hash_t;
 
-void *
+tree_hash_t *
 uct_htable_alloc(int hbits)
 {
 	return calloc2(1 << hbits, tree_hash_t);
@@ -108,7 +108,7 @@ tree_find_node(tree_t *t, incr_stats_t *is, tree_node_t *prev)
 
 	if (DEBUGVV(7))
 		fprintf(stderr,
-			"find_node %"PRIpath" %s found %d hash %d playouts %d node %p\n", path,
+			"find_node %" PRIpath " %s found %d hash %d playouts %d node %p\n", path,
 			path2sstr(path, t->board), found, hash, is->incr.playouts, hnode->node);
 
 	if (found) return hnode->node;
@@ -135,7 +135,7 @@ tree_find_node(tree_t *t, incr_stats_t *is, tree_node_t *prev)
 	} else {
 		if (DEBUG_MODE) parent_not_found++;
 		if (DEBUGVV(7))
-			fprintf(stderr, "parent of %"PRIpath" %s not found\n",
+			fprintf(stderr, "parent of %" PRIpath " %s not found\n",
 				path, path2sstr(path, t->board));
 	}
 
@@ -143,7 +143,7 @@ tree_find_node(tree_t *t, incr_stats_t *is, tree_node_t *prev)
 	hnode->node = node;
 	if (DEBUG_MODE) h_counts.inserts++, h_counts.occupied++;
 	if (DEBUGVV(7))
-		fprintf(stderr, "insert path %"PRIpath" %s hash %d playouts %d node %p\n",
+		fprintf(stderr, "insert path %" PRIpath " %s hash %d playouts %d node %p\n",
 			path, path2sstr(path, t->board), hash, is->incr.playouts, node);
 
 	if (DEBUG_MODE && !node) node_not_found++;
@@ -174,7 +174,7 @@ discard_bin_args(char *args)
 enum parse_code
 uct_notify(engine_t *e, board_t *b, int id, char *cmd, char *args, char **reply)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 
 	static bool board_resized = true;
 	if (is_gamestart(cmd)) {
@@ -225,7 +225,7 @@ receive_stats(uct_t *u, int size)
 			return false;
 
 		if (UDEBUGL(7))
-			fprintf(stderr, "read %5d/%d %6d %.3f %"PRIpath" %s\n", n, nodes,
+			fprintf(stderr, "read %5d/%d %6d %.3f %" PRIpath " %s\n", n, nodes,
 				is.incr.playouts, is.incr.value, is.coord_path,
 				path2sstr(is.coord_path, t->board));
 
@@ -488,7 +488,7 @@ char *
 uct_genmoves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 	     char *args, bool pass_all_alive, void **stats_buf, int *stats_size)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 	assert(u->slave);
 	u->pass_all_alive |= pass_all_alive;
 

--- a/uct/slave.c
+++ b/uct/slave.c
@@ -459,7 +459,7 @@ report_stats(struct uct *u, struct board *b, coord_t c,
 
 		char buf[4];
 		/* We return the values as stored in the tree, so from black's view. */
-		r += snprintf(r, end - r, "\n%s %d %.16f", coord2bstr(buf, node_coord(ni), b),
+		r += snprintf(r, end - r, "\n%s %d %.16f", coord2bstr(buf, node_coord(ni)),
 			      ni->u.playouts, ni->u.value);
 	}
 	/* Give a large but not infinite weight to pass, resign or book move, to avoid
@@ -467,7 +467,7 @@ report_stats(struct uct *u, struct board *b, coord_t c,
 	if (c) {
 		double resign_value = u->t->root_color == S_WHITE ? 0.0 : 1.0;
 		double c_value = is_resign(c) ? resign_value : 1.0 - resign_value;
-		r += snprintf(r, end - r, "\n%s %d %.1f", coord2sstr(c, b),
+		r += snprintf(r, end - r, "\n%s %d %.1f", coord2sstr(c),
 			      2 * max_playouts, c_value);
 	}
 	return reply;

--- a/uct/slave.h
+++ b/uct/slave.h
@@ -6,15 +6,11 @@
 
 #ifdef DISTRIBUTED
 
-struct board;
-struct engine;
-struct time_info;
-
-enum parse_code uct_notify(struct engine *e, struct board *b, int id, char *cmd, char *args, char **reply);
-char *uct_genmoves(struct engine *e, struct board *b, struct time_info *ti, enum stone color,
+enum parse_code uct_notify(engine_t *e, board_t *b, int id, char *cmd, char *args, char **reply);
+char *uct_genmoves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 		   char *args, bool pass_all_alive, void **stats_buf, int *stats_size);
 void *uct_htable_alloc(int hbits);
-void uct_htable_reset(struct tree *t);
+void uct_htable_reset(tree_t *t);
 
 
 #else

--- a/uct/slave.h
+++ b/uct/slave.h
@@ -9,7 +9,7 @@
 enum parse_code uct_notify(engine_t *e, board_t *b, int id, char *cmd, char *args, char **reply);
 char *uct_genmoves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 		   char *args, bool pass_all_alive, void **stats_buf, int *stats_size);
-void *uct_htable_alloc(int hbits);
+struct tree_hash *uct_htable_alloc(int hbits);
 void uct_htable_reset(tree_t *t);
 
 

--- a/uct/tree.c
+++ b/uct/tree.c
@@ -584,18 +584,13 @@ tree_expand_node(struct tree *t, struct tree_node *node, struct board *b, enum s
 	else    // Pass - everything is too far.
 		foreach_point(b) { distances[c] = TREE_NODE_D_MAX + 1; } foreach_point_end;
 
+	/* Include pass in the prior map. */
+	struct move_stats map_prior[board_size2(b) + 1];      memset(map_prior, 0, sizeof(map_prior));
+	bool              map_consider[board_size2(b) + 1];   memset(map_consider, 0, sizeof(map_consider));
+	
 	/* Get a map of prior values to initialize the new nodes with. */
-	struct prior_map map = {
-		.b = b,
-		.to_play = color,
-		.parity = tree_parity(t, parity),
-		.distances = distances,
-	};
-	// Include pass in the prior map.
-	struct move_stats map_prior[board_size2(b) + 1]; map.prior = &map_prior[1];
-	bool map_consider[board_size2(b) + 1]; map.consider = &map_consider[1];
-	memset(map_prior, 0, sizeof(map_prior));
-	memset(map_consider, 0, sizeof(map_consider));
+	struct prior_map map = { b, color, tree_parity(t, parity), &map_prior[1], &map_consider[1], distances };
+	
 	map.consider[pass] = true;
 	int child_count = 1; // for pass
 	foreach_free_point(b) {

--- a/uct/tree.c
+++ b/uct/tree.c
@@ -35,7 +35,7 @@ tree_alloc_node(tree_t *t, int count, bool fast_alloc)
 		if (old_size + nsize > t->max_tree_size)
 			return NULL;
 		assert(t->nodes != NULL);
-		n = (tree_node_t *)(t->nodes + old_size);
+		n = (tree_node_t *)((char*)t->nodes + old_size);
 		memset(n, 0, nsize);
 	} else {
 		n = calloc2(count, tree_node_t);
@@ -130,7 +130,7 @@ typedef struct {
 static void *
 tree_done_node_worker(void *ctx_)
 {
-	subtree_ctx_t *ctx = ctx_;
+	subtree_ctx_t *ctx = (subtree_ctx_t*)ctx_;
 	char *str = coord2str(node_coord(ctx->n));
 
 	size_t tree_size = tree_done_node(ctx->t, ctx->n);
@@ -193,7 +193,7 @@ tree_node_dump(tree_t *tree, tree_node_t *node, int treeparity, int l, int thres
 		children++;
 	/* We use 1 as parity, since for all nodes we want to know the
 	 * win probability of _us_, not the node color. */
-	fprintf(stderr, "[%s] %.3f/%d [prior %.3f/%d amaf %.3f/%d crit %.3f vloss %d] h=%x c#=%d <%"PRIhash">\n",
+	fprintf(stderr, "[%s] %.3f/%d [prior %.3f/%d amaf %.3f/%d crit %.3f vloss %d] h=%x c#=%d <%" PRIhash ">\n",
 		coord2sstr(node_coord(node)),
 		tree_node_get_value(tree, treeparity, node->u.value), node->u.playouts,
 		tree_node_get_value(tree, treeparity, node->prior.value), node->prior.playouts,
@@ -259,7 +259,7 @@ tree_node_save(FILE *f, tree_node_t *node, int thres)
 		node->is_expanded = 0;
 
 	fputc(1, f);
-	fwrite(((void *) node) + offsetof(tree_node_t, u),
+	fwrite(((int *) node) + offsetof(tree_node_t, u),
 	       sizeof(tree_node_t) - offsetof(tree_node_t, u),
 	       1, f);
 
@@ -294,7 +294,7 @@ tree_node_load(FILE *f, tree_node_t *node, int *num)
 {
 	(*num)++;
 
-	checked_fread(((void *) node) + offsetof(tree_node_t, u),
+	checked_fread(((int *) node) + offsetof(tree_node_t, u),
 		      sizeof(tree_node_t) - offsetof(tree_node_t, u),
 		      1, f);
 

--- a/uct/tree.c
+++ b/uct/tree.c
@@ -38,7 +38,7 @@ tree_alloc_node(tree_t *t, int count, bool fast_alloc)
 		n = (tree_node_t *)(t->nodes + old_size);
 		memset(n, 0, nsize);
 	} else {
-		n = calloc2(count, sizeof(*n));
+		n = calloc2(count, tree_node_t);
 	}
 	return n;
 }
@@ -77,13 +77,13 @@ tree_t *
 tree_init(board_t *board, enum stone color, size_t max_tree_size,
 	  size_t max_pruned_size, size_t pruning_threshold, floating_t ltree_aging, int hbits)
 {
-	tree_t *t = calloc2(1, sizeof(*t));
+	tree_t *t = calloc2(1, tree_t);
 	t->board = board;
 	t->max_tree_size = max_tree_size;
 	t->max_pruned_size = max_pruned_size;
 	t->pruning_threshold = pruning_threshold;
 	if (max_tree_size != 0) {
-		t->nodes = malloc2(max_tree_size);
+		t->nodes = cmalloc(max_tree_size);
 		/* The nodes buffer doesn't need initialization. This is currently
 		 * done by tree_init_node to spread the load. Doing a memset for the
 		 * entire buffer here would be too slow for large trees (>10 GB). */
@@ -158,7 +158,7 @@ tree_done_node_detached(tree_t *t, tree_node_t *n)
 	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
 	pthread_t thread;
-	subtree_ctx_t *ctx = malloc2(sizeof(subtree_ctx_t));
+	subtree_ctx_t *ctx = malloc2(subtree_ctx_t);
 	ctx->t = t;
 	ctx->n = n;
 	pthread_create(&thread, &attr, tree_done_node_worker, ctx);
@@ -310,7 +310,7 @@ tree_node_load(FILE *f, tree_node_t *node, int *num)
 
 	tree_node_t *ni = NULL, *ni_prev = NULL;
 	while (fgetc(f)) {
-		ni_prev = ni; ni = calloc2(1, sizeof(*ni));
+		ni_prev = ni; ni = calloc2(1, tree_node_t);
 		if (!node->children)
 			node->children = ni;
 		else

--- a/uct/tree.c
+++ b/uct/tree.c
@@ -131,7 +131,7 @@ static void *
 tree_done_node_worker(void *ctx_)
 {
 	struct subtree_ctx *ctx = ctx_;
-	char *str = coord2str(node_coord(ctx->n), ctx->t->board);
+	char *str = coord2str(node_coord(ctx->n));
 
 	size_t tree_size = tree_done_node(ctx->t, ctx->n);
 	if (!tree_size)
@@ -194,7 +194,7 @@ tree_node_dump(struct tree *tree, struct tree_node *node, int treeparity, int l,
 	/* We use 1 as parity, since for all nodes we want to know the
 	 * win probability of _us_, not the node color. */
 	fprintf(stderr, "[%s] %.3f/%d [prior %.3f/%d amaf %.3f/%d crit %.3f vloss %d] h=%x c#=%d <%"PRIhash">\n",
-		coord2sstr(node_coord(node), tree->board),
+		coord2sstr(node_coord(node)),
 		tree_node_get_value(tree, treeparity, node->u.value), node->u.playouts,
 		tree_node_get_value(tree, treeparity, node->prior.value), node->prior.playouts,
 		tree_node_get_value(tree, treeparity, node->amaf.value), node->amaf.playouts,
@@ -618,7 +618,7 @@ tree_expand_node(struct tree *t, struct tree_node *node, struct board *b, enum s
 	/* The loop considers only the symmetry playground. */
 	if (UDEBUGL(6)) {
 		fprintf(stderr, "expanding %s within [%d,%d],[%d,%d] %d-%d\n",
-				coord2sstr(node_coord(node), b),
+				coord2sstr(node_coord(node)),
 				b->symmetry.x1, b->symmetry.y1,
 				b->symmetry.x2, b->symmetry.y2,
 				b->symmetry.type, b->symmetry.d);
@@ -635,7 +635,7 @@ tree_expand_node(struct tree *t, struct tree_node *node, struct board *b, enum s
 				}
 			}
 
-			coord_t c = coord_xy(t->board, i, j);
+			coord_t c = coord_xy(i, j);
 			if (!map.consider[c]) // Filter out invalid moves
 				continue;
 			assert(c != node_coord(node)); // I have spotted "C3 C3" in some sequence...
@@ -656,17 +656,11 @@ static coord_t
 flip_coord(struct board *b, coord_t c,
            bool flip_horiz, bool flip_vert, int flip_diag)
 {
-	int x = coord_x(c, b), y = coord_y(c, b);
-	if (flip_diag) {
-		int z = x; x = y; y = z;
-	}
-	if (flip_horiz) {
-		x = board_size(b) - 1 - x;
-	}
-	if (flip_vert) {
-		y = board_size(b) - 1 - y;
-	}
-	return coord_xy(b, x, y);
+	int x = coord_x(c), y = coord_y(c);
+	if (flip_diag)  {  int z = x; x = y; y = z;    }
+	if (flip_horiz) {  x = board_size(b) - 1 - x;  }
+	if (flip_vert)  {  y = board_size(b) - 1 - y;  }
+	return coord_xy(x, y);
 }
 
 static void
@@ -687,7 +681,7 @@ tree_fix_symmetry(struct tree *tree, struct board *b, coord_t c)
 		return;
 
 	struct board_symmetry *s = &tree->root_symmetry;
-	int cx = coord_x(c, b), cy = coord_y(c, b);
+	int cx = coord_x(c), cy = coord_y(c);
 
 	/* playground	X->h->v->d normalization
 	 * :::..	.d...
@@ -709,10 +703,10 @@ tree_fix_symmetry(struct tree *tree, struct board *b, coord_t c)
 
 	if (DEBUGL(4)) {
 		fprintf(stderr, "%s [%d,%d -> %d,%d;%d,%d] will flip %d %d %d -> %s, sym %d (%d) -> %d (%d)\n",
-			coord2sstr(c, b),
+			coord2sstr(c),
 			cx, cy, s->x1, s->y1, s->x2, s->y2,
 			flip_horiz, flip_vert, flip_diag,
-			coord2sstr(flip_coord(b, c, flip_horiz, flip_vert, flip_diag), b),
+			coord2sstr(flip_coord(b, c, flip_horiz, flip_vert, flip_diag)),
 			s->type, s->d, b->symmetry.type, b->symmetry.d);
 	}
 	if (flip_horiz || flip_vert || flip_diag)

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -147,7 +147,7 @@ uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, ch
 static void
 uct_board_print(engine_t *e, board_t *b, FILE *f)
 {
-	uct_t *u = b->es;
+	uct_t *u = (uct_t*)b->es;
 	board_print_ownermap(b, f, (u ? &u->ownermap : NULL));
 }
 
@@ -171,7 +171,7 @@ uct_mcowner_playouts(uct_t *u, board_t *b, enum stone color)
 static ownermap_t*
 uct_ownermap(engine_t *e, board_t *b)
 {
-	uct_t *u = b->es;
+	uct_t *u = (uct_t*)b->es;
 	
 	/* Make sure ownermap is well-seeded. */
 	enum stone color = (b->last_move.color ? stone_other(b->last_move.color) : S_BLACK);
@@ -183,7 +183,7 @@ uct_ownermap(engine_t *e, board_t *b)
 static char *
 uct_notify_play(engine_t *e, board_t *b, move_t *m, char *enginearg)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 	if (!u->t) {
 		/* No state, create one - this is probably game beginning
 		 * and we need to load the opening tbook right now. */
@@ -233,7 +233,7 @@ uct_notify_play(engine_t *e, board_t *b, move_t *m, char *enginearg)
 static char *
 uct_result(engine_t *e, board_t *b)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 	static char reply[1024];
 
 	if (!u->t)
@@ -250,7 +250,7 @@ uct_result(engine_t *e, board_t *b)
 static char *
 uct_chat(engine_t *e, board_t *b, bool opponent, char *from, char *cmd)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 
 	if (!u->t)
 		return generic_chat(b, opponent, from, cmd, S_NONE, pass, 0, 1, u->threads, 0.0, 0.0, "");
@@ -283,7 +283,7 @@ print_dead_groups(uct_t *u, board_t *b, move_queue_t *dead)
 static void
 uct_dead_group_list(engine_t *e, board_t *b, move_queue_t *dead)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 	
 	/* This means the game is probably over, no use pondering on. */
 	uct_pondering_stop(u);
@@ -316,7 +316,7 @@ uct_stop(engine_t *e)
 	/* This is called on game over notification. However, an undo
 	 * and game resume can follow, so don't panic yet and just
 	 * relax and stop thinking so that we don't waste CPU. */
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 	uct_pondering_stop(u);
 }
 
@@ -325,7 +325,7 @@ uct_stop(engine_t *e)
 static void
 uct_done(engine_t *e)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 
 	free(u->banner);
 	uct_pondering_stop(u);
@@ -492,7 +492,7 @@ uct_genmove_setup(uct_t *u, board_t *b, enum stone color)
 static void
 uct_livegfx_hook(engine_t *e)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 	/* Hack: Override reportfreq to get decent update rates in GoGui */
 	u->reportfreq = MIN(u->reportfreq, 1000);
 }
@@ -500,7 +500,7 @@ uct_livegfx_hook(engine_t *e)
 static tree_node_t *
 genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive, coord_t *best_coord)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 	double time_start = time_now();
 	u->pass_all_alive |= pass_all_alive;	
 
@@ -536,7 +536,7 @@ genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_al
 static coord_t
 uct_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
 {	
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 
 	coord_t best_coord;
 	tree_node_t *best = genmove(e, b, ti, color, pass_all_alive, &best_coord);
@@ -591,7 +591,7 @@ uct_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pas
 static void
 uct_analyze(engine_t *e, board_t *b, enum stone color, int start)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 
 	if (!start) {
 		if (u->pondering) uct_pondering_stop(u);
@@ -635,7 +635,7 @@ static void
 uct_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 	       coord_t *best_c, float *best_r, int nbest)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 	uct_pondering_stop(u);
 	if (u->t)
 		reset_state(u);	
@@ -651,7 +651,7 @@ uct_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 bool
 uct_gentbook(engine_t *e, board_t *b, time_info_t *ti, enum stone color)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 	if (!u->t) uct_prepare_move(u, b, color);
 	assert(u->t);
 
@@ -670,9 +670,9 @@ uct_gentbook(engine_t *e, board_t *b, time_info_t *ti, enum stone color)
 void
 uct_dumptbook(engine_t *e, board_t *b, enum stone color)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 	tree_t *t = tree_init(b, color, u->fast_alloc ? u->max_tree_size : 0,
-			 u->max_pruned_size, u->pruning_threshold, u->local_tree_aging, 0);
+			      u->max_pruned_size, u->pruning_threshold, u->local_tree_aging, 0);
 	tree_load(t, b);
 	tree_dump(t, 0);
 	tree_done(t);
@@ -682,7 +682,7 @@ uct_dumptbook(engine_t *e, board_t *b, enum stone color)
 floating_t
 uct_evaluate_one(engine_t *e, board_t *b, time_info_t *ti, coord_t c, enum stone color)
 {
-	uct_t *u = e->data;
+	uct_t *u = (uct_t*)e->data;
 
 	board_t b2;
 	board_copy(&b2, b);

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -427,7 +427,7 @@ uct_pondering_start(uct_t *u, board_t *b0, tree_t *t, enum stone color, coord_t 
 	u->genmove_pondering = genmove_pondering;
 
 	/* We need a local board copy to ponder upon. */
-	board_t *b = malloc2(sizeof(*b)); board_copy(b, b0);
+	board_t *b = malloc2(board_t); board_copy(b, b0);
 
 	/* Board needs updating ? (b0 did not have the genmove'd move played yet) */
 	if (our_move) {	          /* 0 never a real coord */
@@ -743,7 +743,7 @@ default_max_tree_size()
 uct_t *
 uct_state_init(char *arg, board_t *b)
 {
-	uct_t *u = calloc2(1, sizeof(uct_t));
+	uct_t *u = calloc2(1, uct_t);
 	bool pat_setup = false;
 	
 	u->debug_level = debug_level;

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -241,7 +241,7 @@ uct_result(struct engine *e, struct board *b)
 	enum stone color = u->t->root_color;
 	struct tree_node *n = u->t->root;
 	snprintf(reply, 1024, "%s %s %d %.2f %.1f",
-		 stone2str(color), coord2sstr(node_coord(n), b),
+		 stone2str(color), coord2sstr(node_coord(n)),
 		 n->u.playouts, tree_node_get_value(u->t, -1, n->u.value),
 		 u->t->use_extra_komi ? u->t->extra_komi : 0);
 	return reply;
@@ -273,7 +273,7 @@ print_dead_groups(struct uct *u, struct board *b, struct move_queue *dead)
 	for (unsigned int i = 0; i < dead->moves; i++) {
 		fprintf(stderr, "  ");
 		foreach_in_group(b, dead->move[i]) {
-			fprintf(stderr, "%s ", coord2sstr(c, b));
+			fprintf(stderr, "%s ", coord2sstr(c));
 		} foreach_in_group_end;
 		fprintf(stderr, "\n");
 	}

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -156,7 +156,7 @@ uct_board_print(struct engine *e, struct board *b, FILE *f)
 void
 uct_mcowner_playouts(struct uct *u, struct board *b, enum stone color)
 {
-	struct playout_setup ps = { .gamelen = u->gamelen, .mercymin = u->mercymin };
+	struct playout_setup ps = playout_setup(u->gamelen, u->mercymin);
 	
 	/* TODO pick random last move, better playouts randomness */
 
@@ -384,10 +384,9 @@ uct_search(struct uct *u, struct board *b, struct time_info *ti, enum stone colo
 
 	if (u->debug_after.playouts > 0) {
 		/* Now, start an additional run of playouts, single threaded. */
-		struct time_info debug_ti = {
-			.period = TT_MOVE,
-			.dim = TD_GAMES,
-		};
+		struct time_info debug_ti;
+		debug_ti.period = TT_MOVE;
+		debug_ti.dim = TD_GAMES;
 		debug_ti.len.games = t->root->u.playouts + u->debug_after.playouts;
 		debug_ti.len.games_max = 0;
 
@@ -432,7 +431,7 @@ uct_pondering_start(struct uct *u, struct board *b0, struct tree *t, enum stone 
 
 	/* Board needs updating ? (b0 did not have the genmove'd move played yet) */
 	if (our_move) {	          /* 0 never a real coord */
-		struct move m = { .coord = our_move, .color = stone_other(color) };
+		struct move m = move(our_move, stone_other(color));
 		int res = board_play(b, &m);
 		assert(res >= 0);
 	}

--- a/uct/uct.h
+++ b/uct/uct.h
@@ -2,13 +2,10 @@
 #define PACHI_UCT_UCT_H
 
 #include "engine.h"
-#include "move.h"
 
-void engine_uct_init(struct engine *e, char *arg, struct board *b);
+void engine_uct_init(engine_t *e, char *arg, board_t *b);
 
-struct board;
-struct time_info;
-bool uct_gentbook(struct engine *e, struct board *b, struct time_info *ti, enum stone color);
-void uct_dumptbook(struct engine *e, struct board *b, enum stone color);
+bool uct_gentbook(engine_t *e, board_t *b, time_info_t *ti, enum stone color);
+void uct_dumptbook(engine_t *e, board_t *b, enum stone color);
 
 #endif

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -318,10 +318,7 @@ uct_leaf_node(struct uct *u, struct board *b, enum stone player_color,
 			spaces, n->u.playouts, coord2sstr(node_coord(n), t->board),
 			tree_node_get_value(t, -parity, n->u.value));
 
-	struct playout_setup ps = {
-		.gamelen = u->gamelen,
-		.mercymin = u->mercymin,
-	};
+	struct playout_setup ps = playout_setup(u->gamelen, u->mercymin);
 	int result = playout_play_game(&ps, b, next_color,
 				       u->playout_amaf ? amaf : NULL,
 				       &u->ownermap, u->playout);
@@ -489,7 +486,7 @@ uct_playout_descent(struct uct *u, struct board *b, struct board *b2, enum stone
 	descent[0].node = n; descent[0].lnode = NULL;
 	int dlen = 1;
 	/* Total value of the sequence. */
-	struct move_stats seq_value = { .playouts = 0 };
+	struct move_stats seq_value = move_stats(0.0, 0);
 	/* The last "significant" node along the descent (i.e. node
 	 * with higher than configured number of playouts). For black
 	 * and white. */

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -555,7 +555,7 @@ uct_playout_descent(uct_t *u, board_t *b, board_t *b2, enum stone player_color, 
 		    || b2->superko_violation) {
 			if (UDEBUGL(4)) {
 				for (tree_node_t *ni = n; ni; ni = ni->parent)
-					fprintf(stderr, "%s<%"PRIhash"> ", coord2sstr(node_coord(ni)), ni->hash);
+					fprintf(stderr, "%s<%" PRIhash "> ", coord2sstr(node_coord(ni)), ni->hash);
 				fprintf(stderr, "marking invalid %s node %d,%d res %d group %d spk %d\n",
 				        stone2str(node_color), coord_x(node_coord(n)), coord_y(node_coord(n)),
 					res, group_at(b2, m.coord), b2->superko_violation);

--- a/uct/walk.h
+++ b/uct/walk.h
@@ -1,15 +1,11 @@
 #ifndef PACHI_UCT_WALK_H
 #define PACHI_UCT_WALK_H
 
-#include "move.h"
+#include "uct/internal.h"
 
-struct tree;
-struct uct;
-struct board;
+void uct_progress_status(uct_t *u, tree_t *t, enum stone color, int playouts, coord_t *final);
 
-void uct_progress_status(struct uct *u, struct tree *t, enum stone color, int playouts, coord_t *final);
-
-int uct_playout(struct uct *u, struct board *b, enum stone player_color, struct tree *t);
-int uct_playouts(struct uct *u, struct board *b, enum stone color, struct tree *t, struct time_info *ti);
+int uct_playout(uct_t *u, board_t *b, enum stone player_color, tree_t *t);
+int uct_playouts(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti);
 
 #endif

--- a/util.c
+++ b/util.c
@@ -175,15 +175,15 @@ strbuf_init(strbuf_t *buf, char *buffer, int size)
 strbuf_t *
 strbuf_init_alloc(strbuf_t *buf, int size)
 {
-	char *str = malloc(size);
+	char *str = (char*)malloc(size);
 	return strbuf_init(buf, str, size);
 }
 
 strbuf_t *
 new_strbuf(int size)
 {
-	strbuf_t *buf = malloc(sizeof(strbuf_t));
-	char *str = malloc(size);
+	strbuf_t *buf = (strbuf_t*)malloc(sizeof(strbuf_t));
+	char *str = (char*)malloc(size);
 	strbuf_init(buf, str, size);
 	return buf;	
 }

--- a/util.h
+++ b/util.h
@@ -11,6 +11,12 @@
 #define MIN(a, b) ((a) < (b) ? (a) : (b));
 #define MAX(a, b) ((a) > (b) ? (a) : (b));
 
+#ifdef __cplusplus
+#define typeof decltype
+#define restrict __restrict__
+#endif
+
+
 /* Returns true if @str starts with @prefix */
 int str_prefix(char *prefix, char *str);
 

--- a/util.h
+++ b/util.h
@@ -106,14 +106,16 @@ static inline void *
 checked_calloc(size_t nmemb, size_t size, const char *filename, unsigned int line, const char *func)
 {
 	void *p = calloc(nmemb, size);
-	if (!p)
-		die("%s:%u: %s: OUT OF MEMORY calloc(%u, %u)\n",
-		    filename, line, func, (unsigned) nmemb, (unsigned) size);
+	if (!p)  die("%s:%u: %s: OUT OF MEMORY calloc(%u, %u)\n",
+		     filename, line, func, (unsigned) nmemb, (unsigned) size);
 	return p;
 }
 
-#define malloc2(size)        checked_malloc((size), __FILE__, __LINE__, __func__)
-#define calloc2(nmemb, size) checked_calloc((nmemb), (size), __FILE__, __LINE__, __func__)
+/* casts: make c++ happy */
+#define cmalloc(size)        checked_malloc((size), __FILE__, __LINE__, __func__)
+#define ccalloc(nmemb, size) checked_calloc((nmemb), (size), __FILE__, __LINE__, __func__)
+#define malloc2(type)        ((type*)cmalloc(sizeof(type)))
+#define calloc2(nmemb, type) ((type*)ccalloc(nmemb, sizeof(type)))
 
 #define checked_write(fd, pt, size)	(assert(write((fd), (pt), (size)) == (size)))
 #define checked_fread(pt, size, n, f)   (assert(fread((pt), (size), (n), (f)) == (n)))


### PR DESCRIPTION
This makes Pachi [one step](https://github.com/lemonsqueeze/pachi/compare/c++_fixes...c++) away from compiling as a c++ project.

Started as a crazy hack to see if Pachi could be made to compile in c++.
I'm not turning it into a c++ project, but i think i like it. Opens up other crazy hacks and i like the idea of being able to compile it in c++ once in a while for extra type checking (c++ can distinguish between enums and ints for example).

Also took the opportunity to revisit low-level apis:
- coord functions don't need board argument to get board size.
- use init functions instead of designated intializers, cleaner and c++ doesn't support them.
- typedefs instead of structs as much as possible
- typed malloc() functions

Needless to say the diffs are huge, glad nobody is reviewing this =)