### PR TITLE
GTP Autoflush

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ DATADIR ?= $(PREFIX)/share/pachi
 # unless PROFILING=gprof.)
 OPT ?= -O3
 COMMON_FLAGS := -Wall -ggdb3 $(OPT) -D_GNU_SOURCE
-CFLAGS       := -std=gnu99 -pthread -Wsign-compare
+CFLAGS       := -std=gnu99 -pthread -Wsign-compare -Wno-format-zero-length
 CXXFLAGS     := -std=c++11
 
 

--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,9 @@ build.h: .git/HEAD .git/index Makefile
 test: FORCE
 	+@make -C t-unit test
 
+test_gtp: FORCE
+	+@make -C t-unit test_gtp
+
 test_board: FORCE
 	+@make -C t-unit test_board
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Or make your own:
 - Download [Pachi 12.30](https://github.com/pasky/pachi/releases/tag/pachi-12.30-jowa), extract in Lizzie folder
 - Edit Lizzie config.txt, make it use Pachi instead of Leela-Zero:
 
-        "engine-command": "pachi/pachi --version=0.16 reporting=leelaz,reportfreq=500",
+        "engine-command": "pachi/pachi --version=0.16 reporting=lz,reportfreq=500",
 
 Tweak reportfreq to change update speed.
 

--- a/chat.c
+++ b/chat.c
@@ -82,10 +82,10 @@ void chat_done(void) {
  * we pick randomly among all matching entries. */
 char *
 generic_chat(board_t *b, bool opponent, char *from, char *cmd, enum stone color, coord_t move,
-	      int playouts, int machines, int threads, double winrate, double extra_komi, char *score_est) {
-
-	static char buffer[1024];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	      int playouts, int machines, int threads, double winrate, double extra_komi, char *score_est)
+{
+	static_strbuf(buf, 1024);
+	
 	if (!chat_table) {
 		if (strncasecmp(cmd, "winrate", 7)) return NULL;
 		if (color == S_NONE) return not_playing;
@@ -98,6 +98,7 @@ generic_chat(board_t *b, bool opponent, char *from, char *cmd, enum stone color,
 		sbprintf(buf, ". Score Est: %s", score_est);
 		return buf->str;
 	}
+	
 	int matches = 0;
 	int undisplayed = 0;
 	for (chat_t *entry = chat_table; entry->regex[0]; entry++) {
@@ -113,6 +114,7 @@ generic_chat(board_t *b, bool opponent, char *from, char *cmd, enum stone color,
 		if (!entry->displayed) undisplayed++;
 	}
 	if (matches == 0) return default_reply;
+	
 	int choices = undisplayed > 0 ? undisplayed : matches;
 	int index = fast_random(choices);
 	for (chat_t *entry = chat_table; entry->regex[0]; entry++) {

--- a/engine.h
+++ b/engine.h
@@ -63,6 +63,7 @@ struct engine {
 	 * if all stones on the board can be considered alive, without regard to "dead"
 	 * considered stones. */
 	engine_genmove_t         genmove;
+	engine_genmove_t         genmove_analyze;
 
 	/* Used by distributed engine */
 	engine_genmoves_t        genmoves;

--- a/engines/patternplay.c
+++ b/engines/patternplay.c
@@ -51,8 +51,7 @@ debug_pattern_best_moves(patternplay_t *pp, board_t *b, enum stone color,
 		pattern_t p;
 		pattern_match(&pp->pc, &p, b, &m, &ownermap, locally);
 
-		char buffer[512];  strbuf_t strbuf;
-		strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+		strbuf(buf, 512);
 		dump_gammas(buf, &pp->pc, &p);
 		fprintf(stderr, "%3s gamma %s\n", coord2sstr(m.coord), buf->str);
 	}

--- a/gogui.c
+++ b/gogui.c
@@ -35,8 +35,7 @@ typedef enum {
 enum parse_code
 cmd_gogui_analyze_commands(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	char buffer[2000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 2000);
 
 	if (e->best_moves) {
 		sbprintf(buf, "gfx/Best Moves/gogui-best_moves\n");
@@ -347,8 +346,7 @@ cmd_gogui_color_palette(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 10000);
 
 	float   best_r[GOGUI_CANDIDATES] = { 0.0, };
 	coord_t best_c[GOGUI_CANDIDATES];
@@ -377,9 +375,7 @@ cmd_gogui_influence(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	ownermap_t *ownermap = engine_ownermap(e, b);
 	if (!ownermap)  {  gtp_error(gtp, "no ownermap", NULL);  return P_OK;  }
 	
-	char buffer[5000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-	
+	strbuf(buf, 5000);	
 	sbprintf(buf, "INFLUENCE");	
 	foreach_point(b) {
 		if (board_at(b, c) == S_OFFBOARD)
@@ -408,9 +404,7 @@ cmd_gogui_score_est(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	ownermap_t *ownermap = engine_ownermap(e, b);
 	if (!ownermap)  {  gtp_error(gtp, "no ownermap", NULL);  return P_OK;  }
 	
-	char buffer[5000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-	
+	strbuf(buf, 5000);	
 	sbprintf(buf, "INFLUENCE");
 	foreach_point(b) {
 		if (board_at(b, c) == S_OFFBOARD)  continue;
@@ -442,9 +436,8 @@ cmd_gogui_final_score(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	int dame, seki;
 	int ownermap[board_max_coords(b)];
 	floating_t score = board_official_score_details(b, &q, &dame, &seki, ownermap, NULL);
-	char buffer[5000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-	
+
+	strbuf(buf, 5000);	
 	sbprintf(buf, "INFLUENCE");
 	foreach_point(b) {
 		if (board_at(b, c) == S_OFFBOARD)  continue;
@@ -468,10 +461,8 @@ cmd_gogui_winrates(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	
-	char buffer[5000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
 
+	strbuf(buf, 5000);
 	gogui_reporting_t prev = gogui_livegfx;
 	gogui_set_livegfx(e, "winrates");
 	gogui_best_moves(buf, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
@@ -486,10 +477,8 @@ cmd_gogui_best_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-	
+
+	strbuf(buf, 10000);	
 	gogui_reporting_t prev = gogui_livegfx;
 	gogui_set_livegfx(e, "best_moves");
 	gogui_best_moves(buf, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
@@ -515,8 +504,7 @@ cmd_gogui_dcnn_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 10000);
 	gogui_best_moves(buf, dcnn_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 
 	gtp_reply(gtp, buf->str, NULL);
@@ -532,8 +520,7 @@ cmd_gogui_dcnn_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 10000);
 	gogui_best_moves(buf, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
 
 	gtp_reply(gtp, buf->str, NULL);
@@ -549,8 +536,7 @@ cmd_gogui_dcnn_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
-	char buffer[5000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 5000);
 	gogui_best_moves(buf, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 
 	gtp_reply(gtp, buf->str, NULL);
@@ -574,8 +560,7 @@ cmd_gogui_joseki_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 10000);
 
 	float joseki_map[BOARD_MAX_COORDS];
 	joseki_rate_moves(joseki_dict, b, color, joseki_map);
@@ -612,8 +597,7 @@ cmd_gogui_joseki_show_pattern(board_t *b, engine_t *e, time_info_t *ti, gtp_t *g
 	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
 	coord_t coord = str2coord(arg);
 
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 10000);
 	gogui_show_pattern(b, buf, coord, JOSEKI_PATTERN_DIST);
 	gtp_reply(gtp, buf->str, NULL);
 	return P_OK;
@@ -640,8 +624,7 @@ cmd_gogui_pattern_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 10000);
 	gogui_best_moves(buf, pattern_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
@@ -658,8 +641,7 @@ cmd_gogui_pattern_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 1000);
 	gogui_best_moves(buf, pattern_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
@@ -676,8 +658,7 @@ cmd_gogui_pattern_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
-	char buffer[5000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 5000);
 	gogui_best_moves(buf, pattern_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
@@ -708,8 +689,7 @@ cmd_gogui_pattern_features(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	bool locally = pattern_matching_locally(pc, b, color, &ownermap);
 	pattern_match(pc, &p, b, &m, &ownermap, locally);
 
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 10000);
 
 	/* Show largest spatial */
 	int dist = 0;
@@ -744,9 +724,7 @@ cmd_gogui_pattern_gammas(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	bool locally = pattern_matching_locally(pc, b, color, &ownermap);
 	pattern_match(pc, &p, b, &m, &ownermap, locally);
 
-	char buffer[1000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-
+	strbuf(buf, 1000);
 	sbprintf(buf, "TEXT ");
 	dump_gammas(buf, pc, &p);
 
@@ -766,8 +744,7 @@ cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
 	coord_t coord = str2coord(arg);
 
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
+	strbuf(buf, 10000);
 	gogui_show_pattern(b, buf, coord, spatial_dist);
 	
 	move_t m = move(coord, stone_other(last_move(b).color));

--- a/gogui.c
+++ b/gogui.c
@@ -39,7 +39,7 @@ cmd_gogui_analyze_commands(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 
 	if (e->best_moves) {
 		printf("gfx/Best Moves/gogui-best_moves\n");
-		printf("gfx/Winrates/gogui-winrates\n");
+		printf("gfx/Best Winrates/gogui-winrates\n");
 	}
 	if (e->ownermap) {
 		printf("gfx/Influence/gogui-influence\n");
@@ -321,14 +321,14 @@ cmd_gogui_color_palette(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 
-	float   best_r[GOGUI_CANDIDATES] = { 0.0, };
-	coord_t best_c[GOGUI_CANDIDATES];
-	for (int i = 0; i < GOGUI_CANDIDATES; i++)
+	float   best_r[GOGUI_MANY] = { 0.0, };
+	coord_t best_c[GOGUI_MANY];
+	for (int i = 0; i < GOGUI_MANY; i++)
 		best_c[i] = coord_xy(i%19 +1, 18 - i/19 + 1);
 
 	gtp_printf(gtp, "");  /* gtp prefix */
-	rescale_best_moves(best_c, best_r, GOGUI_CANDIDATES, GOGUI_RESCALE_LINEAR);
-	gogui_show_best_moves_colors(stdout, b, color, best_c, best_r, GOGUI_CANDIDATES);
+	rescale_best_moves(best_c, best_r, GOGUI_MANY, GOGUI_RESCALE_LINEAR);
+	gogui_show_best_moves_colors(stdout, b, color, best_c, best_r, GOGUI_MANY);
 	return P_OK;
 }
 
@@ -432,7 +432,7 @@ cmd_gogui_winrates(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 
 	gogui_reporting_t prev = gogui_livegfx;
 	gogui_set_livegfx(e, "winrates");
-	gogui_best_moves(stdout, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
+	gogui_best_moves(stdout, e, b, ti, color, GOGUI_MANY, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 	gogui_livegfx = prev;
 	
 	return P_OK;
@@ -448,7 +448,7 @@ cmd_gogui_best_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 
 	gogui_reporting_t prev = gogui_livegfx;
 	gogui_set_livegfx(e, "best_moves");
-	gogui_best_moves(stdout, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
+	gogui_best_moves(stdout, e, b, ti, color, GOGUI_NBEST, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 	gogui_livegfx = prev;
 	
 	return P_OK;
@@ -471,7 +471,7 @@ cmd_gogui_dcnn_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 
 	gtp_printf(gtp, "");   /* gtp prefix */	
-	gogui_best_moves(stdout, dcnn_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
+	gogui_best_moves(stdout, dcnn_engine, b, ti, color, GOGUI_NBEST, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 	return P_OK;
 }
 
@@ -485,7 +485,7 @@ cmd_gogui_dcnn_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 
 	gtp_printf(gtp, "");  /* gtp prefix */
-	gogui_best_moves(stdout, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
+	gogui_best_moves(stdout, dcnn_engine, b, ti, color, GOGUI_MANY, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
 	return P_OK;
 }
 
@@ -499,7 +499,7 @@ cmd_gogui_dcnn_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 
 	gtp_printf(gtp, "");   /* gtp prefix */
-	gogui_best_moves(stdout, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
+	gogui_best_moves(stdout, dcnn_engine, b, ti, color, GOGUI_MANY, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 	return P_OK;
 }
 
@@ -536,7 +536,7 @@ cmd_gogui_joseki_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 		if (p)  printf("CIRCLE %s\n", coord2sstr(c));
 	} foreach_free_point_end;
 
-	gogui_best_moves(stdout, joseki_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
+	gogui_best_moves(stdout, joseki_engine, b, ti, color, GOGUI_MANY, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
 
 	/* Show ignored moves, background color */
 	foreach_free_point(b) {
@@ -582,7 +582,7 @@ cmd_gogui_pattern_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 
 	gtp_printf(gtp, "");   /* gtp prefix */
-	gogui_best_moves(stdout, pattern_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
+	gogui_best_moves(stdout, pattern_engine, b, ti, color, GOGUI_NBEST, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
 	printf("TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
@@ -598,7 +598,7 @@ cmd_gogui_pattern_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 
 	gtp_printf(gtp, "");  /* gtp prefix */	
-	gogui_best_moves(stdout, pattern_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
+	gogui_best_moves(stdout, pattern_engine, b, ti, color, GOGUI_MANY, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
 	printf("TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
@@ -614,7 +614,7 @@ cmd_gogui_pattern_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 
 	gtp_printf(gtp, "");   /* gtp prefix */
-	gogui_best_moves(stdout, pattern_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
+	gogui_best_moves(stdout, pattern_engine, b, ti, color, GOGUI_MANY, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
 	printf("TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));

--- a/gogui.c
+++ b/gogui.c
@@ -364,7 +364,7 @@ enum parse_code
 cmd_gogui_livegfx(board_t *board, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg_optional(arg);
 	gogui_set_livegfx(e, arg);
 	return P_OK;
 }
@@ -593,8 +593,7 @@ cmd_gogui_joseki_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 enum parse_code
 cmd_gogui_joseki_show_pattern(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	char *arg;  next_tok(arg);
-	if (!arg)                          {  gtp_error(gtp, "arg missing");  return P_OK;  }
+	char *arg;  gtp_arg(arg);
 	coord_t coord = str2coord(arg);
 
 	strbuf(buf, 10000);
@@ -676,8 +675,7 @@ cmd_gogui_pattern_features(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
-	char *arg;  next_tok(arg);
-	if (!arg)                          {  gtp_error(gtp, "arg missing");  return P_OK;  }
+	char *arg;  gtp_arg(arg);
 	coord_t coord = str2coord(arg);
 	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...");  return P_OK;  }
 	
@@ -711,8 +709,7 @@ cmd_gogui_pattern_gammas(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
-	char *arg;  next_tok(arg);
-	if (!arg)                          {  gtp_error(gtp, "arg missing");  return P_OK;  }
+	char *arg;  gtp_arg(arg);
 	coord_t coord = str2coord(arg);
 	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...");  return P_OK;  }
 	
@@ -740,8 +737,7 @@ cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (!pattern_engine)   init_patternplay_engine(b);
 	pattern_config_t *pc = patternplay_get_pc(pattern_engine);
 
-	char *arg;  next_tok(arg);
-	if (!arg)                          {  gtp_error(gtp, "arg missing");  return P_OK;  }
+	char *arg;  gtp_arg(arg);
 	coord_t coord = str2coord(arg);
 
 	strbuf(buf, 10000);
@@ -764,7 +760,7 @@ cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 enum parse_code
 cmd_gogui_spatial_size(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	char *arg;  next_tok(arg);
+	char *arg;  gtp_arg_optional(arg);
 	/* Return current value */
 	if (!*arg) {  gtp_printf(gtp, "%i\n", spatial_dist);  return P_OK;  }
 

--- a/gogui.c
+++ b/gogui.c
@@ -35,55 +35,55 @@ typedef enum {
 enum parse_code
 cmd_gogui_analyze_commands(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	strbuf(buf, 2000);
+	gtp_printf(gtp, "");  /* gtp prefix */
 
 	if (e->best_moves) {
-		sbprintf(buf, "gfx/Best Moves/gogui-best_moves\n");
-		sbprintf(buf, "gfx/Winrates/gogui-winrates\n");
+		printf("gfx/Best Moves/gogui-best_moves\n");
+		printf("gfx/Winrates/gogui-winrates\n");
 	}
 	if (e->ownermap) {
-		sbprintf(buf, "gfx/Influence/gogui-influence\n");
-		sbprintf(buf, "gfx/Score Est/gogui-score_est\n");
+		printf("gfx/Influence/gogui-influence\n");
+		printf("gfx/Score Est/gogui-score_est\n");
 	}
 	if (e->dead_group_list) {
-		sbprintf(buf, "gfx/Final Score/gogui-final_score\n");
-		sbprintf(buf, "plist/Dead Groups/final_status_list dead\n");
-		//sbprintf(buf, "plist/Final Status List Dead/final_status_list dead\n");
-		//sbprintf(buf, "plist/Final Status List Alive/final_status_list alive\n");
-		//sbprintf(buf, "plist/Final Status List Seki/final_status_list seki\n");
-		//sbprintf(buf, "plist/Final Status List Black/final_status_list black_territory\n");
-		//sbprintf(buf, "plist/Final Status List White/final_status_list white_territory\n");
+		printf("gfx/Final Score/gogui-final_score\n");
+		printf("plist/Dead Groups/final_status_list dead\n");
+		//printf("plist/Final Status List Dead/final_status_list dead\n");
+		//printf("plist/Final Status List Alive/final_status_list alive\n");
+		//printf("plist/Final Status List Seki/final_status_list seki\n");
+		//printf("plist/Final Status List Black/final_status_list black_territory\n");
+		//printf("plist/Final Status List White/final_status_list white_territory\n");
 	}
-	if (!strcmp(e->name, "UCT") && using_joseki(b))
-		sbprintf(buf, "gfx/Joseki Moves/gogui-joseki_moves\n");
-		sbprintf(buf, "gfx/Joseki Range/gogui-joseki_show_pattern %%p\n");
+	if (!strcmp(e->name, "UCT") && using_joseki(b)) {
+		printf("gfx/Joseki Moves/gogui-joseki_moves\n");
+		printf("gfx/Joseki Range/gogui-joseki_show_pattern %%p\n");
+	}
 #ifdef DCNN                            /* board check fake since we're called once on startup ... */
 	if (!strcmp(e->name, "UCT") && using_dcnn(b)) {
-		sbprintf(buf, "gfx/DCNN Best Moves/gogui-dcnn_best\n");
-		sbprintf(buf, "gfx/DCNN Color Map/gogui-dcnn_colors\n");
-		sbprintf(buf, "gfx/DCNN Ratings/gogui-dcnn_rating\n");
+		printf("gfx/DCNN Best Moves/gogui-dcnn_best\n");
+		printf("gfx/DCNN Color Map/gogui-dcnn_colors\n");
+		printf("gfx/DCNN Ratings/gogui-dcnn_rating\n");
 	}
 #endif
 	if (!strcmp(e->name, "UCT") && using_patterns()) {
-		sbprintf(buf, "gfx/Pattern Best Moves/gogui-pattern_best\n");
-		sbprintf(buf, "gfx/Pattern Color Map/gogui-pattern_colors\n");
-		sbprintf(buf, "gfx/Pattern Ratings/gogui-pattern_rating\n");
-		sbprintf(buf, "gfx/Pattern Features/gogui-pattern_features %%p\n");
-		sbprintf(buf, "gfx/Pattern Gammas/gogui-pattern_gammas %%p\n");
-		sbprintf(buf, "gfx/Set Spatial Size/gogui-spatial_size %%o\n");
-		sbprintf(buf, "gfx/Show Spatial/gogui-show_spatial %%p\n");
+		printf("gfx/Pattern Best Moves/gogui-pattern_best\n");
+		printf("gfx/Pattern Color Map/gogui-pattern_colors\n");
+		printf("gfx/Pattern Ratings/gogui-pattern_rating\n");
+		printf("gfx/Pattern Features At/gogui-pattern_features %%p\n");
+		printf("gfx/Pattern Gammas At/gogui-pattern_gammas %%p\n");
+		printf("gfx/Set Spatial Size/gogui-spatial_size %%o\n");
+		printf("gfx/Show Spatial/gogui-show_spatial %%p\n");
 	}
 	if (!strcmp(e->name, "UCT")) {
-		sbprintf(buf, "gfx/Live gfx = Best Moves/gogui-livegfx best_moves\n");
-		sbprintf(buf, "gfx/Live gfx = Best Sequence/gogui-livegfx best_seq\n");
-		sbprintf(buf, "gfx/Live gfx = Winrates/gogui-livegfx winrates\n");
-		sbprintf(buf, "gfx/Live gfx = None/gogui-livegfx\n");
+		printf("gfx/Live gfx = Best Moves/gogui-livegfx best_moves\n");
+		printf("gfx/Live gfx = Best Sequence/gogui-livegfx best_seq\n");
+		printf("gfx/Live gfx = Winrates/gogui-livegfx winrates\n");
+		printf("gfx/Live gfx = None/gogui-livegfx\n");
 	}
 
 	/* Debugging */
-	//sbprintf(buf, "gfx/Color Palette/gogui-color_palette\n");
+	//printf("gfx/Color Palette/gogui-color_palette\n");
 	
-	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -181,7 +181,7 @@ gogui_paint_pattern(board_t *b, int colors[BOARD_MAX_COORDS][4],
 
 /* Display spatial pattern */
 static void
-gogui_show_pattern(board_t *b, strbuf_t *buf, coord_t coord, int maxd)
+gogui_show_pattern(board_t *b, coord_t coord, int maxd)
 {
 	assert(!is_pass(coord));
 	int colors[BOARD_MAX_COORDS][4];  memset(colors, 0, sizeof(colors));
@@ -194,7 +194,7 @@ gogui_show_pattern(board_t *b, strbuf_t *buf, coord_t coord, int maxd)
 		int rr = MIN(colors[c][0], 255);
 		int gg = MIN(colors[c][1], 255);
 		int bb = MIN(colors[c][2], 255);
-		sbprintf(buf, "COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c));
+		printf("COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c));
 	} foreach_point_end;
 }
 
@@ -213,60 +213,45 @@ gogui_set_livegfx(engine_t *e, char *arg)
 	if (e->livegfx_hook)  e->livegfx_hook(e);
 }
 
-/* GoGui reads live gfx commands on stderr */
 void
-gogui_show_livegfx(char *str)
-{
-	fprintf(stderr, "gogui-gfx:\n");
-	fprintf(stderr, "%s", str);
-	fprintf(stderr, "\n");
-}
-
-void
-gogui_show_winrates(strbuf_t *buf, board_t *b, enum stone color, coord_t *best_c, float *best_r, int nbest)
+gogui_show_winrates(FILE *f, board_t *b, enum stone color, coord_t *best_c, float *best_r, int nbest)
 {
 	/* best move */
 	if (best_c[0] != pass)
-		sbprintf(buf, "VAR %s %s\n", 
-			 (color == S_WHITE ? "w" : "b"),
-			 coord2sstr(best_c[0]) );
+		fprintf(f, "VAR %s %s\n", (color == S_WHITE ? "w" : "b"), coord2sstr(best_c[0]) );
 	
 	for (int i = 0; i < nbest; i++)
 		if (best_c[i] != pass)
-			sbprintf(buf, "LABEL %s %i\n", coord2sstr(best_c[i]),
-				 (int)(roundf(best_r[i] * 100)));
+			fprintf(f, "LABEL %s %i\n", coord2sstr(best_c[i]), (int)(roundf(best_r[i] * 100)));
 }
 
 void
-gogui_show_best_seq(strbuf_t *buf, board_t *b, enum stone color, coord_t *seq, int n)
+gogui_show_best_seq(FILE *f, board_t *b, enum stone color, coord_t *seq, int n)
 {	
-	char *col = "bw";
-	sbprintf(buf, "VAR ");
-	for (int i = 0; i < n && seq[i] != pass; i++)
-		sbprintf(buf, "%c %3s ",
-			 col[(i + (color == S_WHITE)) % 2],
-			 coord2sstr(seq[i]));
-	sbprintf(buf, "\n");
+	fprintf(f, "VAR ");
+	for (int i = 0; i < n && seq[i] != pass; i++) {
+		fprintf(f, "%.1s %3s ", stone2str(color), coord2sstr(seq[i]));
+		color = stone_other(color);
+	}
+	fprintf(f, "\n");
 }
 
 /* Display best moves graphically in GoGui. */
 void
-gogui_show_best_moves(strbuf_t *buf, board_t *b, enum stone color, coord_t *best_c, float *best_r, int n)
+gogui_show_best_moves(FILE *f, board_t *b, enum stone color, coord_t *best_c, float *best_r, int n)
 {
         /* best move */
         if (best_c[0] != pass)
-                sbprintf(buf, "VAR %s %s\n",
-                         (color == S_WHITE ? "w" : "b"),
-                         coord2sstr(best_c[0]) );
+                fprintf(f, "VAR %.1s %s\n", stone2str(color), coord2sstr(best_c[0]));
         
         for (int i = 1; i < n; i++)
                 if (best_c[i] != pass)
-                        sbprintf(buf, "LABEL %s %i\n", coord2sstr(best_c[i]), i + 1);
+                        fprintf(f, "LABEL %s %i\n", coord2sstr(best_c[i]), i + 1);
 }
 
 /* Display best moves graphically in GoGui. */
-void
-gogui_show_best_moves_colors(strbuf_t *buf, board_t *b, enum stone color,
+static void
+gogui_show_best_moves_colors(FILE *f, board_t *b, enum stone color,
 			     coord_t *best_c, float *best_r, int n)
 {
 	float vals[BOARD_MAX_COORDS];
@@ -283,8 +268,7 @@ gogui_show_best_moves_colors(strbuf_t *buf, board_t *b, enum stone color,
 		int rr, gg, bb;
 		value2color(vals[c], &rr, &gg, &bb);
 		
-		//fprintf(stderr, "COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c));
-		sbprintf(buf,   "COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c));
+		fprintf(f, "COLOR #%02x%02x%02x %s\n", rr, gg, bb, coord2sstr(c));
 	}
 }
 
@@ -314,7 +298,7 @@ rescale_best_moves(coord_t *best_c, float *best_r, int n, int rescale)
 }
 
 static void
-gogui_best_moves(strbuf_t *buf, engine_t *e, board_t *b, time_info_t *ti,
+gogui_best_moves(FILE *f, engine_t *e, board_t *b, time_info_t *ti,
 		 enum stone color, int n, gogui_gfx_t gfx_type, gogui_rescale_t rescale)
 {
 	assert(color != S_NONE);
@@ -322,23 +306,13 @@ gogui_best_moves(strbuf_t *buf, engine_t *e, board_t *b, time_info_t *ti,
 	
 	coord_t best_c[n];
 	float   best_r[n];
-	engine_best_moves(e, b, ti_genmove, color, best_c, best_r, n);
-	
-#if 0
-	fprintf(stderr, "best: [");
-	for (int i = 0; i < n; i++)
-		fprintf(stderr, "%s ", coord2sstr(best_c[i]));
-	fprintf(stderr, "]\n");
-#endif
-	
+	engine_best_moves(e, b, ti_genmove, color, best_c, best_r, n);	
 	rescale_best_moves(best_c, best_r, n, rescale);
 	
-	if (gfx_type == GOGUI_BEST_WINRATES)
-		gogui_show_winrates(buf, b, color, best_c, best_r, n);
-	if (gfx_type == GOGUI_BEST_MOVES)
-		gogui_show_best_moves(buf, b, color, best_c, best_r, n);
-	if (gfx_type == GOGUI_BEST_COLORS)
-		gogui_show_best_moves_colors(buf, b, color, best_c, best_r, n);
+	if      (gfx_type == GOGUI_BEST_WINRATES)  gogui_show_winrates(f, b, color, best_c, best_r, n);
+	else if (gfx_type == GOGUI_BEST_MOVES)     gogui_show_best_moves(f, b, color, best_c, best_r, n);
+	else if (gfx_type == GOGUI_BEST_COLORS)    gogui_show_best_moves_colors(f, b, color, best_c, best_r, n);
+	else    assert(0);
 }
 
 enum parse_code
@@ -346,16 +320,15 @@ cmd_gogui_color_palette(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	strbuf(buf, 10000);
 
 	float   best_r[GOGUI_CANDIDATES] = { 0.0, };
 	coord_t best_c[GOGUI_CANDIDATES];
 	for (int i = 0; i < GOGUI_CANDIDATES; i++)
 		best_c[i] = coord_xy(i%19 +1, 18 - i/19 + 1);
 
-	rescale_best_moves(best_c, best_r, GOGUI_CANDIDATES, GOGUI_RESCALE_LINEAR);	
-	gogui_show_best_moves_colors(buf, b, color, best_c, best_r, GOGUI_CANDIDATES);
-	gtp_reply(gtp, buf->str);
+	gtp_printf(gtp, "");  /* gtp prefix */
+	rescale_best_moves(best_c, best_r, GOGUI_CANDIDATES, GOGUI_RESCALE_LINEAR);
+	gogui_show_best_moves_colors(stdout, b, color, best_c, best_r, GOGUI_CANDIDATES);
 	return P_OK;
 }
 
@@ -375,8 +348,7 @@ cmd_gogui_influence(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	ownermap_t *ownermap = engine_ownermap(e, b);
 	if (!ownermap)  {  gtp_error(gtp, "no ownermap");  return P_OK;  }
 	
-	strbuf(buf, 5000);	
-	sbprintf(buf, "INFLUENCE");	
+	gtp_printf(gtp, "INFLUENCE");
 	foreach_point(b) {
 		if (board_at(b, c) == S_OFFBOARD)
 			continue;
@@ -390,11 +362,10 @@ cmd_gogui_influence(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 		else if (p < 0.5)  p = 0.4;
 		else if (p < 0.8)  p = 0.7;
 		else               p = 1.0;
-		sbprintf(buf, " %3s %.1lf", coord2sstr(c), p);
+		printf(" %3s %.1lf", coord2sstr(c), p);
 	} foreach_point_end;
 
-	sbprintf(buf, "\nTEXT Score Est: %s", ownermap_score_est_str(b, ownermap));
-	gtp_reply(gtp, buf->str);
+	printf("\nTEXT Score Est: %s\n", ownermap_score_est_str(b, ownermap));
 	return P_OK;
 }
 
@@ -404,19 +375,17 @@ cmd_gogui_score_est(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	ownermap_t *ownermap = engine_ownermap(e, b);
 	if (!ownermap)  {  gtp_error(gtp, "no ownermap");  return P_OK;  }
 	
-	strbuf(buf, 5000);	
-	sbprintf(buf, "INFLUENCE");
+	gtp_printf(gtp, "INFLUENCE");
 	foreach_point(b) {
 		if (board_at(b, c) == S_OFFBOARD)  continue;
 		enum point_judgement j = ownermap_score_est_coord(b, ownermap, c);
 		float p = 0;
 		if (j == PJ_BLACK)  p = 0.5;
 		if (j == PJ_WHITE)  p = -0.5;
-		sbprintf(buf, " %3s %.1lf", coord2sstr(c), p);
+		printf(" %3s %.1lf", coord2sstr(c), p);
 	} foreach_point_end;
 
-	sbprintf(buf, "\nTEXT Score Est: %s", ownermap_score_est_str(b, ownermap));
-	gtp_reply(gtp, buf->str);
+	printf("\nTEXT Score Est: %s\n", ownermap_score_est_str(b, ownermap));
 	return P_OK;
 }
 
@@ -436,23 +405,20 @@ cmd_gogui_final_score(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	int dame, seki;
 	int ownermap[board_max_coords(b)];
 	floating_t score = board_official_score_details(b, &q, &dame, &seki, ownermap, NULL);
-
-	strbuf(buf, 5000);	
-	sbprintf(buf, "INFLUENCE");
+	
+	gtp_printf(gtp, "INFLUENCE");
 	foreach_point(b) {
 		if (board_at(b, c) == S_OFFBOARD)  continue;
 		float p = 0;
 		if (ownermap[c] == S_BLACK)  p = 0.5;
 		if (ownermap[c] == S_WHITE)  p = -0.5;
-		sbprintf(buf, " %3s %.1lf", coord2sstr(c), p);
+		printf(" %3s %.1lf", coord2sstr(c), p);
 	} foreach_point_end;
-	sbprintf(buf, "\n");
+	printf("\n");
 	
-	if      (score == 0) sbprintf(buf, "TEXT 0\n");
-	else if (score > 0)  sbprintf(buf, "TEXT W+%.1f\n", score);
-	else                 sbprintf(buf, "TEXT B+%.1f\n", -score);
-
-	gtp_reply(gtp, buf->str);
+	if      (score == 0) printf("TEXT 0\n");
+	else if (score > 0)  printf("TEXT W+%.1f\n", score);
+	else                 printf("TEXT B+%.1f\n", -score);
 	return P_OK;
 }
 
@@ -462,13 +428,13 @@ cmd_gogui_winrates(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 
-	strbuf(buf, 5000);
+	gtp_printf(gtp, "");   /* gtp prefix */
+
 	gogui_reporting_t prev = gogui_livegfx;
 	gogui_set_livegfx(e, "winrates");
-	gogui_best_moves(buf, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
+	gogui_best_moves(stdout, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 	gogui_livegfx = prev;
-
-	gtp_reply(gtp, buf->str);
+	
 	return P_OK;
 }
 
@@ -478,13 +444,13 @@ cmd_gogui_best_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 
-	strbuf(buf, 10000);	
+	gtp_printf(gtp, "");   /* gtp prefix */
+
 	gogui_reporting_t prev = gogui_livegfx;
 	gogui_set_livegfx(e, "best_moves");
-	gogui_best_moves(buf, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
+	gogui_best_moves(stdout, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 	gogui_livegfx = prev;
 	
-	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -503,11 +469,9 @@ cmd_gogui_dcnn_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	
-	strbuf(buf, 10000);
-	gogui_best_moves(buf, dcnn_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 
-	gtp_reply(gtp, buf->str);
+	gtp_printf(gtp, "");   /* gtp prefix */	
+	gogui_best_moves(stdout, dcnn_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 	return P_OK;
 }
 
@@ -519,11 +483,9 @@ cmd_gogui_dcnn_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	
-	strbuf(buf, 10000);
-	gogui_best_moves(buf, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
 
-	gtp_reply(gtp, buf->str);
+	gtp_printf(gtp, "");  /* gtp prefix */
+	gogui_best_moves(stdout, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
 	return P_OK;
 }
 
@@ -535,11 +497,9 @@ cmd_gogui_dcnn_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	
-	strbuf(buf, 5000);
-	gogui_best_moves(buf, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 
-	gtp_reply(gtp, buf->str);
+	gtp_printf(gtp, "");   /* gtp prefix */
+	gogui_best_moves(stdout, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 	return P_OK;
 }
 
@@ -560,33 +520,32 @@ cmd_gogui_joseki_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
-	strbuf(buf, 10000);
-
 	float joseki_map[BOARD_MAX_COORDS];
 	joseki_rate_moves(joseki_dict, b, color, joseki_map);
+
+	gtp_printf(gtp, "");   /* gtp prefix */
 
 	/* Show relaxed / ignored moves */
 	foreach_free_point(b) {
 		josekipat_t *p = joseki_lookup_ignored(joseki_dict, b, c, color);
-		if (p)  sbprintf(buf, "MARK %s\n", coord2sstr(c));
+		if (p)  printf("MARK %s\n", coord2sstr(c));
 		if (p && (p->flags & JOSEKI_FLAGS_3X3))
-			sbprintf(buf, "CIRCLE %s\n", coord2sstr(c));
+			printf("CIRCLE %s\n", coord2sstr(c));
 		
 		p = joseki_lookup_3x3(joseki_dict, b, c, color);
-		if (p)  sbprintf(buf, "CIRCLE %s\n", coord2sstr(c));
+		if (p)  printf("CIRCLE %s\n", coord2sstr(c));
 	} foreach_free_point_end;
 
-	gogui_best_moves(buf, joseki_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
+	gogui_best_moves(stdout, joseki_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
 
 	/* Show ignored moves, background color */
 	foreach_free_point(b) {
 		if (joseki_map[c]) continue;  /* Don't clobber valid moves ! */
 		josekipat_t *p = joseki_lookup_ignored(joseki_dict, b, c, color);
 		if (!p)  continue;
-		sbprintf(buf, "COLOR #0000a0 %s\n", coord2sstr(c));
+		printf("COLOR #0000a0 %s\n", coord2sstr(c));
 	} foreach_free_point_end;
 
-	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -596,9 +555,8 @@ cmd_gogui_joseki_show_pattern(board_t *b, engine_t *e, time_info_t *ti, gtp_t *g
 	char *arg;  gtp_arg(arg);
 	coord_t coord = str2coord(arg);
 
-	strbuf(buf, 10000);
-	gogui_show_pattern(b, buf, coord, JOSEKI_PATTERN_DIST);
-	gtp_reply(gtp, buf->str);
+	gtp_printf(gtp, "");  /* gtp prefix */
+	gogui_show_pattern(b, coord, JOSEKI_PATTERN_DIST);
 	return P_OK;
 }
 
@@ -622,13 +580,12 @@ cmd_gogui_pattern_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	
-	strbuf(buf, 10000);
-	gogui_best_moves(buf, pattern_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
+
+	gtp_printf(gtp, "");   /* gtp prefix */
+	gogui_best_moves(stdout, pattern_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
-	sbprintf(buf, "TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
-	gtp_reply(gtp, buf->str);
+	printf("TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
 	return P_OK;
 }
 
@@ -639,13 +596,12 @@ cmd_gogui_pattern_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	
-	strbuf(buf, 1000);
-	gogui_best_moves(buf, pattern_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
+
+	gtp_printf(gtp, "");  /* gtp prefix */	
+	gogui_best_moves(stdout, pattern_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
-	sbprintf(buf, "TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
-	gtp_reply(gtp, buf->str);
+	printf("TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
 	return P_OK;
 }
 
@@ -656,13 +612,12 @@ cmd_gogui_pattern_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	
 	enum stone color = S_BLACK;
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	
-	strbuf(buf, 5000);
-	gogui_best_moves(buf, pattern_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
+
+	gtp_printf(gtp, "");   /* gtp prefix */
+	gogui_best_moves(stdout, pattern_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 
 	bool locally = patternplay_matched_locally(pattern_engine);
-	sbprintf(buf, "TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
-	gtp_reply(gtp, buf->str);
+	printf("TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
 	return P_OK;
 }
 
@@ -687,16 +642,15 @@ cmd_gogui_pattern_features(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	bool locally = pattern_matching_locally(pc, b, color, &ownermap);
 	pattern_match(pc, &p, b, &m, &ownermap, locally);
 
-	strbuf(buf, 10000);
-
 	/* Show largest spatial */
 	int dist = 0;
 	for (int i = 0; i < p.n; i++)
 		if (p.f[i].id >= FEAT_SPATIAL3)
 			dist = MAX(dist, p.f[i].id - FEAT_SPATIAL3 + 3);
-	if (dist)  gogui_show_pattern(b, buf, coord, dist);
-
-	gtp_printf(gtp, "%sTEXT %s\n", buf->str, pattern2sstr(&p));
+	
+	gtp_printf(gtp, "TEXT %s\n", pattern2sstr(&p));
+	if (dist)  gogui_show_pattern(b, coord, dist);
+	
 	return P_OK;
 }
 
@@ -722,10 +676,9 @@ cmd_gogui_pattern_gammas(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	pattern_match(pc, &p, b, &m, &ownermap, locally);
 
 	strbuf(buf, 1000);
-	sbprintf(buf, "TEXT ");
 	dump_gammas(buf, pc, &p);
 
-	gtp_reply(gtp, buf->str);
+	gtp_printf(gtp, "TEXT %s\n", buf->str);
 	return P_OK;
 }
 
@@ -740,20 +693,19 @@ cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	char *arg;  gtp_arg(arg);
 	coord_t coord = str2coord(arg);
 
-	strbuf(buf, 10000);
-	gogui_show_pattern(b, buf, coord, spatial_dist);
+	gtp_printf(gtp, "");   /* gtp prefix */
+	gogui_show_pattern(b, coord, spatial_dist);
 	
 	move_t m = move(coord, stone_other(last_move(b).color));
 	spatial_t s;
 	spatial_from_board(pc, &s, b, &m);
 	s.dist = spatial_dist;
 	spatial_t *s2 = spatial_dict_lookup(spat_dict, s.dist, spatial_hash(0, &s));
-	if (s2)	sbprintf(buf, "TEXT matches s%i:%i\n", spatial_dist, spatial_id(s2, spat_dict));
-	else	sbprintf(buf, "TEXT unknown s%i spatial\n", spatial_dist);
+	if (s2)	printf("TEXT matches s%i:%i\n", spatial_dist, spatial_id(s2, spat_dict));
+	else	printf("TEXT unknown s%i spatial\n", spatial_dist);
 
 	spatial_write(spat_dict, &s, 0, stderr);
 
-	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 

--- a/gogui.c
+++ b/gogui.c
@@ -83,7 +83,7 @@ cmd_gogui_analyze_commands(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	/* Debugging */
 	//sbprintf(buf, "gfx/Color Palette/gogui-color_palette\n");
 	
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -355,7 +355,7 @@ cmd_gogui_color_palette(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 
 	rescale_best_moves(best_c, best_r, GOGUI_CANDIDATES, GOGUI_RESCALE_LINEAR);	
 	gogui_show_best_moves_colors(buf, b, color, best_c, best_r, GOGUI_CANDIDATES);
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -373,7 +373,7 @@ enum parse_code
 cmd_gogui_influence(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	ownermap_t *ownermap = engine_ownermap(e, b);
-	if (!ownermap)  {  gtp_error(gtp, "no ownermap", NULL);  return P_OK;  }
+	if (!ownermap)  {  gtp_error(gtp, "no ownermap");  return P_OK;  }
 	
 	strbuf(buf, 5000);	
 	sbprintf(buf, "INFLUENCE");	
@@ -394,7 +394,7 @@ cmd_gogui_influence(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	} foreach_point_end;
 
 	sbprintf(buf, "\nTEXT Score Est: %s", ownermap_score_est_str(b, ownermap));
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -402,7 +402,7 @@ enum parse_code
 cmd_gogui_score_est(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	ownermap_t *ownermap = engine_ownermap(e, b);
-	if (!ownermap)  {  gtp_error(gtp, "no ownermap", NULL);  return P_OK;  }
+	if (!ownermap)  {  gtp_error(gtp, "no ownermap");  return P_OK;  }
 	
 	strbuf(buf, 5000);	
 	sbprintf(buf, "INFLUENCE");
@@ -416,7 +416,7 @@ cmd_gogui_score_est(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	} foreach_point_end;
 
 	sbprintf(buf, "\nTEXT Score Est: %s", ownermap_score_est_str(b, ownermap));
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -426,7 +426,7 @@ cmd_gogui_final_score(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	char *msg = NULL;
 	ownermap_t *o = engine_ownermap(e, b);
 	if (o && !board_position_final(b, o, &msg)) {
-		gtp_error(gtp, msg, NULL);
+		gtp_error(gtp, msg);
 		return P_OK;
 	}
 
@@ -452,7 +452,7 @@ cmd_gogui_final_score(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	else if (score > 0)  sbprintf(buf, "TEXT W+%.1f\n", score);
 	else                 sbprintf(buf, "TEXT B+%.1f\n", -score);
 
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -468,7 +468,7 @@ cmd_gogui_winrates(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	gogui_best_moves(buf, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 	gogui_livegfx = prev;
 
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -484,7 +484,7 @@ cmd_gogui_best_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	gogui_best_moves(buf, e, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 	gogui_livegfx = prev;
 	
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -498,7 +498,7 @@ static engine_t *dcnn_engine = NULL;
 enum parse_code
 cmd_gogui_dcnn_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn", NULL);  return P_OK;  }
+	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn");  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
 	
 	enum stone color = S_BLACK;
@@ -507,14 +507,14 @@ cmd_gogui_dcnn_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	strbuf(buf, 10000);
 	gogui_best_moves(buf, dcnn_engine, b, ti, color, 10, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
 
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
 enum parse_code
 cmd_gogui_dcnn_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn", NULL);  return P_OK;  }
+	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn");  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
 	
 	enum stone color = S_BLACK;
@@ -523,14 +523,14 @@ cmd_gogui_dcnn_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	strbuf(buf, 10000);
 	gogui_best_moves(buf, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
 
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
 enum parse_code
 cmd_gogui_dcnn_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn", NULL);  return P_OK;  }
+	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn");  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
 	
 	enum stone color = S_BLACK;
@@ -539,7 +539,7 @@ cmd_gogui_dcnn_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	strbuf(buf, 5000);
 	gogui_best_moves(buf, dcnn_engine, b, ti, color, GOGUI_CANDIDATES, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
 
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -554,7 +554,7 @@ static engine_t *joseki_engine = NULL;
 enum parse_code
 cmd_gogui_joseki_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	if (!using_joseki(b)) {  gtp_reply(gtp, "TEXT Not using joseki", NULL);  return P_OK;  }
+	if (!using_joseki(b)) {  gtp_reply(gtp, "TEXT Not using joseki");  return P_OK;  }
 	if (!joseki_engine)   joseki_engine = new_engine(E_JOSEKIPLAY, NULL, b);
 	
 	enum stone color = S_BLACK;
@@ -586,7 +586,7 @@ cmd_gogui_joseki_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 		sbprintf(buf, "COLOR #0000a0 %s\n", coord2sstr(c));
 	} foreach_free_point_end;
 
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -594,12 +594,12 @@ enum parse_code
 cmd_gogui_joseki_show_pattern(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;  next_tok(arg);
-	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
+	if (!arg)                          {  gtp_error(gtp, "arg missing");  return P_OK;  }
 	coord_t coord = str2coord(arg);
 
 	strbuf(buf, 10000);
 	gogui_show_pattern(b, buf, coord, JOSEKI_PATTERN_DIST);
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -629,7 +629,7 @@ cmd_gogui_pattern_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 
 	bool locally = patternplay_matched_locally(pattern_engine);
 	sbprintf(buf, "TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -646,7 +646,7 @@ cmd_gogui_pattern_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 
 	bool locally = patternplay_matched_locally(pattern_engine);
 	sbprintf(buf, "TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -663,7 +663,7 @@ cmd_gogui_pattern_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 
 	bool locally = patternplay_matched_locally(pattern_engine);
 	sbprintf(buf, "TEXT Matching Locally: %s\n", (locally ? "Yes" : "No"));
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -677,9 +677,9 @@ cmd_gogui_pattern_features(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
 	char *arg;  next_tok(arg);
-	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
+	if (!arg)                          {  gtp_error(gtp, "arg missing");  return P_OK;  }
 	coord_t coord = str2coord(arg);
-	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...", NULL);  return P_OK;  }
+	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...");  return P_OK;  }
 	
 	ownermap_t ownermap;
 	pattern_t p;
@@ -698,7 +698,7 @@ cmd_gogui_pattern_features(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 			dist = MAX(dist, p.f[i].id - FEAT_SPATIAL3 + 3);
 	if (dist)  gogui_show_pattern(b, buf, coord, dist);
 
-	gtp_reply(gtp, buf->str, "TEXT ", pattern2sstr(&p), NULL);
+	gtp_printf(gtp, "%sTEXT %s\n", buf->str, pattern2sstr(&p));
 	return P_OK;
 }
 
@@ -712,9 +712,9 @@ cmd_gogui_pattern_gammas(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (last_move(b).color)  color = stone_other(last_move(b).color);
 	
 	char *arg;  next_tok(arg);
-	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
+	if (!arg)                          {  gtp_error(gtp, "arg missing");  return P_OK;  }
 	coord_t coord = str2coord(arg);
-	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...", NULL);  return P_OK;  }
+	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...");  return P_OK;  }
 	
 	ownermap_t ownermap;
 	pattern_t p;
@@ -728,7 +728,7 @@ cmd_gogui_pattern_gammas(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	sbprintf(buf, "TEXT ");
 	dump_gammas(buf, pc, &p);
 
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -741,7 +741,7 @@ cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	pattern_config_t *pc = patternplay_get_pc(pattern_engine);
 
 	char *arg;  next_tok(arg);
-	if (!arg)                          {  gtp_error(gtp, "arg missing", NULL);  return P_OK;  }
+	if (!arg)                          {  gtp_error(gtp, "arg missing");  return P_OK;  }
 	coord_t coord = str2coord(arg);
 
 	strbuf(buf, 10000);
@@ -757,7 +757,7 @@ cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 
 	spatial_write(spat_dict, &s, 0, stderr);
 
-	gtp_reply(gtp, buf->str, NULL);
+	gtp_reply(gtp, buf->str);
 	return P_OK;
 }
 
@@ -766,10 +766,10 @@ cmd_gogui_spatial_size(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;  next_tok(arg);
 	/* Return current value */
-	if (!*arg) {  gtp_reply_printf(gtp, "%i", spatial_dist);  return P_OK;  }
+	if (!*arg) {  gtp_printf(gtp, "%i\n", spatial_dist);  return P_OK;  }
 
 	int d = atoi(arg);
-	if (d < 3 || d > 10) {  gtp_error(gtp, "Between 3 and 10 please", NULL);  return P_OK;  }
+	if (d < 3 || d > 10) {  gtp_error(gtp, "Between 3 and 10 please");  return P_OK;  }
 	spatial_dist = d;
 	return P_OK;
 }

--- a/gogui.h
+++ b/gogui.h
@@ -3,8 +3,9 @@
 
 #include "gtp.h"
 
-/* How many candidates to display */
-#define GOGUI_CANDIDATES 30
+/* How many moves to display ? */
+#define GOGUI_NBEST 9
+#define GOGUI_MANY 30
 
 typedef enum gogui_reporting {
 	UR_GOGUI_NONE,

--- a/gogui.h
+++ b/gogui.h
@@ -39,11 +39,9 @@ enum parse_code cmd_gogui_pattern_gammas(board_t *b, engine_t *e, time_info_t *t
 enum parse_code cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
 enum parse_code cmd_gogui_spatial_size(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp);
 
-void gogui_show_best_moves(strbuf_t *buf, board_t *b, enum stone color, coord_t *best_c, float *best_r, int n);
-void gogui_show_best_moves_colors(strbuf_t *buf, board_t *b, enum stone color, coord_t *best_c, float *best_r, int n);
-void gogui_show_winrates(strbuf_t *buf, board_t *b, enum stone color, coord_t *best_c, float *best_r, int nbest);
-void gogui_show_best_seq(strbuf_t *buf, board_t *b, enum stone color, coord_t *seq, int n);
-void gogui_show_livegfx(char *str);
+void gogui_show_best_moves(FILE *f, board_t *b, enum stone color, coord_t *best_c, float *best_r, int n);
+void gogui_show_winrates(FILE *f, board_t *b, enum stone color, coord_t *best_c, float *best_r, int nbest);
+void gogui_show_best_seq(FILE *f, board_t *b, enum stone color, coord_t *seq, int n);
 
 #endif
 

--- a/gtp.c
+++ b/gtp.c
@@ -236,7 +236,7 @@ static enum parse_code
 cmd_known_command(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	if (gtp_is_valid(engine, arg))  gtp_reply(gtp, "true");
 	else                            gtp_reply(gtp, "false");
 	return P_OK;
@@ -254,7 +254,7 @@ static enum parse_code
 cmd_boardsize(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	int size = atoi(arg);
 
 	/* Give sane error msg if pachi was compiled for a specific board size. */
@@ -311,7 +311,7 @@ static enum parse_code
 cmd_komi(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	sscanf(arg, PRIfloating, &board->komi);
 
 	if (DEBUGL(3) && debug_boardprint)
@@ -323,7 +323,7 @@ static enum parse_code
 cmd_kgs_rules(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 
 	if (DEBUGL(2))  fprintf(stderr, "%s\n", time_str());
 	
@@ -343,9 +343,9 @@ cmd_play(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	move_t m;
 
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	m.color = str2stone(arg);
-	next_tok(arg);
+	gtp_arg(arg);
 	m.coord = str2coord(arg);
 	arg = gtp->next;
 	char *enginearg = arg;
@@ -379,11 +379,10 @@ cmd_pachi_predict(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	move_t m;
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	m.color = str2stone(arg);
-	next_tok(arg);
+	gtp_arg(arg);
 	m.coord = str2coord(arg);
-	next_tok(arg);
 
 	char *str = predict_move(board, engine, ti, &m, gtp->played_games);
 
@@ -399,7 +398,7 @@ static enum parse_code
 cmd_genmove(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	enum stone color = str2stone(arg);
 
 	if (DEBUGL(2) && debug_boardprint)
@@ -451,7 +450,7 @@ static enum parse_code
 cmd_pachi_genmoves(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	enum stone color = str2stone(arg);
 	void *stats;
 	int stats_size;
@@ -488,7 +487,7 @@ static enum parse_code
 cmd_pachi_analyze(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg_optional(arg);
 
 	int start = 1;
 	if (isdigit(*arg))  start = atoi(arg);
@@ -514,7 +513,7 @@ static enum parse_code
 cmd_set_free_handicap(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	do {
 		move_t m = move(str2coord(arg), S_BLACK);
 		if (DEBUGL(4))  fprintf(stderr, "setting handicap %s\n", arg);
@@ -526,7 +525,7 @@ cmd_set_free_handicap(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 		}
 		
 		b->handicap++;
-		next_tok(arg);
+		gtp_arg_optional(arg);
 	} while (*arg);
 	
 	if (DEBUGL(1) && debug_boardprint)
@@ -541,7 +540,7 @@ static enum parse_code
 cmd_fixed_handicap(board_t *b, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	int stones = atoi(arg);
 	
 	strbuf(buf, 1024);	
@@ -688,7 +687,7 @@ cmd_final_status_list(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (gtp->quiet)  return P_OK;
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	int r = -1;
 	
 	if      (!strcasecmp(arg, "dead"))            r = cmd_final_status_list_dead(arg, b, e, gtp);
@@ -766,7 +765,7 @@ cmd_pachi_gentbook(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp
 	/* Board must be initialized properly, as if for genmove;
 	 * makes sense only as 'uct_gentbook b'. */
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	enum stone color = str2stone(arg);
 	if (!uct_gentbook(engine, board, &ti[color], color))
 		gtp_error(gtp, "error generating tbook");
@@ -777,7 +776,7 @@ static enum parse_code
 cmd_pachi_dumptbook(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	enum stone color = str2stone(arg);
 	uct_dumptbook(engine, board, color);
 	return P_OK;
@@ -787,7 +786,7 @@ static enum parse_code
 cmd_pachi_evaluate(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	enum stone color = str2stone(arg);
 
 	if (!engine->evaluate) {
@@ -833,10 +832,10 @@ static enum parse_code
 cmd_kgs_chat(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	char *loc;
-	next_tok(loc);
+	gtp_arg(loc);
 	bool opponent = !strcasecmp(loc, "game");
 	char *from;
-	next_tok(from);
+	gtp_arg(from);
 	char *msg = gtp->next;
 	msg += strspn(msg, " \n\t");
 	char *end = strchr(msg, '\n');
@@ -856,11 +855,11 @@ static enum parse_code
 cmd_time_left(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
-	next_tok(arg);
+	gtp_arg(arg);
 	enum stone color = str2stone(arg);
-	next_tok(arg);
+	gtp_arg(arg);
 	int time = atoi(arg);
-	next_tok(arg);
+	gtp_arg(arg);
 	int stones = atoi(arg);
 	if (!ti[color].ignore_gtp)
 		time_left(&ti[color], time, stones);
@@ -875,7 +874,7 @@ cmd_kgs_time_settings(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *
 	char *time_system;
 	char *arg;
 	if (!strcasecmp(gtp->cmd, "kgs-time_settings")) {
-		next_tok(time_system);
+		gtp_arg(time_system);
 	} else {
 		time_system = "canadian";
 	}
@@ -884,21 +883,21 @@ cmd_kgs_time_settings(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *
 	if (!strcasecmp(time_system, "none")) {
 		main_time = -1;
 	} else if (!strcasecmp(time_system, "absolute")) {
-		next_tok(arg);
+		gtp_arg(arg);
 		main_time = atoi(arg);
 	} else if (!strcasecmp(time_system, "byoyomi")) {
-		next_tok(arg);
+		gtp_arg(arg);
 		main_time = atoi(arg);
-		next_tok(arg);
+		gtp_arg(arg);
 		byoyomi_time = atoi(arg);
-		next_tok(arg);
+		gtp_arg(arg);
 		byoyomi_periods = atoi(arg);
 	} else if (!strcasecmp(time_system, "canadian")) {
-		next_tok(arg);
+		gtp_arg(arg);
 		main_time = atoi(arg);
-		next_tok(arg);
+		gtp_arg(arg);
 		byoyomi_time = atoi(arg);
-		next_tok(arg);
+		gtp_arg(arg);
 		byoyomi_stones = atoi(arg);
 	}
 
@@ -1010,11 +1009,11 @@ gtp_parse(gtp_t *gtp, board_t *b, engine_t *e, char *e_arg, time_info_t *ti, cha
 	gtp->next = buf;
 	gtp->replied = false;
 	gtp->flushed = false;
-	next_tok(gtp->cmd);
+	gtp_arg_optional(gtp->cmd);
 	
 	if (isdigit(*gtp->cmd)) {
 		gtp->id = atoi(gtp->cmd);
-		next_tok(gtp->cmd);
+		gtp_arg(gtp->cmd);
 	}
 
 	if (!*gtp->cmd)

--- a/gtp.c
+++ b/gtp.c
@@ -536,9 +536,7 @@ cmd_fixed_handicap(board_t *b, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 	next_tok(arg);
 	int stones = atoi(arg);
 	
-	char buffer[1024];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-	
+	strbuf(buf, 1024);	
 	move_queue_t q;  mq_init(&q);
 	board_handicap(b, stones, &q);
 	

--- a/gtp.c
+++ b/gtp.c
@@ -146,7 +146,6 @@ known_commands(engine_t *engine)
 	}
 	
 	str += sprintf(str, "gogui-analyze_commands\n");
-	str[-1] = 0;  /* remove last \n */
 	return buf;
 }
 
@@ -204,7 +203,7 @@ cmd_name(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 static enum parse_code
 cmd_echo(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
-	gtp_reply(gtp, gtp->next);
+	gtp_printf(gtp, "%s", gtp->next);
 	return P_OK;
 }
 
@@ -228,7 +227,7 @@ cmd_version(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 static enum parse_code
 cmd_list_commands(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
-	gtp_reply(gtp, known_commands(engine));
+	gtp_printf(gtp, "%s", known_commands(engine));
 	return P_OK;
 }
 
@@ -543,7 +542,6 @@ cmd_fixed_handicap(board_t *b, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 	gtp_arg(arg);
 	int stones = atoi(arg);
 	
-	strbuf(buf, 1024);	
 	move_queue_t q;  mq_init(&q);
 	board_handicap(b, stones, &q);
 	
@@ -552,13 +550,12 @@ cmd_fixed_handicap(board_t *b, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 
 	for (unsigned int i = 0; i < q.moves; i++) {
 		move_t m = move(q.move[i], S_BLACK);
-		sbprintf(buf, "%s ", coord2sstr(m.coord));
+		gtp_printf(gtp, "%s ", coord2sstr(m.coord));
 
 		/* Add to gtp move history. */
 		gtp_add_move(gtp, &m);
 	}
-	
-	gtp_reply(gtp, buf->str);
+	gtp_printf(gtp, "\n");
 	return P_OK;
 }
 
@@ -754,7 +751,9 @@ undo_reload_engine(gtp_t *gtp, board_t *b, engine_t *e, char *e_arg)
 static enum parse_code
 cmd_showboard(board_t *board, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 {
-	board_print(board, stderr);
+	gtp_printf(gtp, "");
+	board_print(board, stdout);
+	gtp->flushed = 1;  // already ends with \n\n
 	return P_OK;
 }
 

--- a/gtp.h
+++ b/gtp.h
@@ -21,7 +21,8 @@ typedef struct
 	char *next;
 	int   id;
 	bool  quiet;
-	int   replied;
+	bool  replied;
+	bool  flushed;
 
 	/* Global fields: */
 	int     played_games;
@@ -47,10 +48,17 @@ void   gtp_init(gtp_t *gtp);
 
 enum parse_code gtp_parse(gtp_t *gtp, board_t *b, struct engine *e, char *e_arg, time_info_t *ti, char *buf);
 bool gtp_is_valid(struct engine *e, const char *cmd);
-void gtp_reply(gtp_t *gtp, ...);
-void gtp_reply_printf(gtp_t *gtp, const char *format, ...);
-void gtp_error_printf(gtp_t *gtp, const char *format, ...);
-void gtp_error(gtp_t *gtp, ...);
+
+/* Output one line, end-of-line \n added automatically. */
+void gtp_reply(gtp_t *gtp, const char *str);
+void gtp_error(gtp_t *gtp, const char *str);
+
+/* Output anything (no \n added). 
+ * Can just use printf() after first gtp_printf() */
+void gtp_printf(gtp_t *gtp, const char *format, ...)
+	__attribute__ ((format (printf, 2, 3)));
+void gtp_error_printf(gtp_t *gtp, const char *format, ...)
+	__attribute__ ((format (printf, 2, 3)));
 
 #define is_gamestart(cmd) (!strcasecmp((cmd), "boardsize"))
 #define is_reset(cmd) (is_gamestart(cmd) || !strcasecmp((cmd), "clear_board") || !strcasecmp((cmd), "kgs-rules"))

--- a/gtp.h
+++ b/gtp.h
@@ -36,13 +36,27 @@ typedef struct
 	char*   custom_version;
 } gtp_t;
 
-#define next_tok(to_) \
-	to_ = gtp->next; \
+#define gtp_arg_next(gtp) \
 	gtp->next = gtp->next + strcspn(gtp->next, " \t\r\n"); \
 	if (*gtp->next) { \
 		*gtp->next = 0; gtp->next++; \
 		gtp->next += strspn(gtp->next, " \t\r\n"); \
 	}
+
+#define gtp_arg_optional(arg)  do {  \
+	(arg) = gtp->next;  \
+	gtp_arg_next(gtp);  \
+} while(0)
+
+#define gtp_arg(arg)  do { \
+	(arg) = gtp->next; \
+	if (!*(arg)) {	\
+		gtp_error(gtp, "argument missing"); \
+		return P_OK; \
+	} \
+	gtp_arg_next(gtp); \
+} while(0)
+
 
 void   gtp_init(gtp_t *gtp);
 

--- a/ownermap.c
+++ b/ownermap.c
@@ -22,7 +22,7 @@ printhook(board_t *board, coord_t c, strbuf_t *buf, void *data)
 
 	if (c == pass) { /* Stuff to display in header */
 		if (!ownermap || !ownermap->playouts) return;
-		sbprintf(buf, "Score Est: %s", ownermap_score_est_str(board, ownermap));
+		sbprintf(buf, "Score Est: %s\n", ownermap_score_est_str(board, ownermap));
 		return;
 	}
 	
@@ -201,7 +201,7 @@ ownermap_score_est_str(board_t *b, ownermap_t *ownermap)
 {
 	static char buf[32];
 	float s = ownermap_score_est(b, ownermap);
-	sprintf(buf, "%s+%.1f\n", (s > 0 ? "W" : "B"), fabs(s));
+	sprintf(buf, "%s+%.1f", (s > 0 ? "W" : "B"), fabs(s));
 	return buf;
 }
 

--- a/t-unit/Makefile
+++ b/t-unit/Makefile
@@ -15,6 +15,7 @@ test: FORCE
 		make test_board test_moggy test_spatial; \
 	fi
 
+	@make test_gtp
 	./run_tests
 
 	@echo -n "Testing uct genmove...   "
@@ -50,6 +51,19 @@ test_spatial: FORCE
 	@if bzcmp spatial.out spatial.ref.bz2  >/dev/null; then \
 	   echo "OK"; else  echo "FAILED"; exit 1;  fi
 
+test_gtp: FORCE
+	@echo "Testing gtp is sane...   "
+	@if ../pachi --compile-flags | grep -q "DCNN"; then  \
+		cp gtp_test.gtp tmp.gtp;  \
+	 else \
+		cat gtp_test.gtp | grep -v dcnn >tmp.gtp; \
+	 fi
+        # Check test suite is not missing some commands...
+	@echo list_commands | ../pachi -d0 --nodcnn --nopatterns --nojoseki | sed -e 's/^= //' | \
+           while read f; do  if ! grep -q "^\(# *\|\)$$f" tmp.gtp  ; then \
+               echo "t-unit/tmp.gtp: command $$f not tested, fixme !"; exit 1 ; fi; done
+	@if ./gtp_check ../pachi --nodcnn -t =1000 -o /dev/null < tmp.gtp;  then \
+	   echo "OK"; else  echo "FAILED"; exit 1;  fi
 
 FORCE:
 

--- a/t-unit/gtp_check
+++ b/t-unit/gtp_check
@@ -1,0 +1,52 @@
+#!/usr/bin/perl
+# check gtp answers are sane
+
+use IPC::Open2;
+
+$| = 1;
+
+$SIG{CHLD} = handler;
+sub handler {  exit 1;  }
+
+# Start Pachi instance
+my $pachi_cmd = join(" ", @ARGV);
+
+my $pachi_pid = open2(PACHI_OUT, PACHI_IN, "$pachi_cmd");
+PACHI_IN->autoflush(1);
+
+my $prev_cmd;
+
+sub check_reply
+{
+    my $reply = <PACHI_OUT>;
+    if ($reply eq "\n")       { die "malformed answer to '$prev_cmd': extra newline\n"; }
+    if ($reply =~ m/^[?] /)   { die "command failed: '$reply'\n"; }
+    if ($reply !~ m/^[=?][0-9]* /)  { die "malformed answer: '$reply'\n"; }
+
+    my $s = $reply;
+    for ($reply = "";  ($s ne "\n") && ($s ne "\r\n");  $s = <PACHI_OUT>) {
+	$reply .= $s;
+    }
+    #print "'$reply'";
+}
+
+sub pachi_command
+{
+    my ($cmd) = @_;
+    print PACHI_IN "$cmd\n";  # Forward command to pachi
+    check_reply();
+}
+
+
+# Process gtp commands
+foreach my $s (<STDIN>)
+{
+    if ($s =~ m/^ *$/) { next; }
+    if ($s =~ m/^#/)   { next; }
+    chomp($s);
+    
+    printf("  %-30s  ", $s);
+    pachi_command("$s");
+    $prev_cmd = $s;
+    print "ok\n";
+}

--- a/t-unit/gtp_test.gtp
+++ b/t-unit/gtp_test.gtp
@@ -17,7 +17,8 @@ showboard
 genmove w
 pachi-result
 undo
-kgs-genmove_cleanup w
+lz-genmove_analyze w 10
+kgs-genmove_cleanup b
 
 clear_board
 set_free_handicap d4 q16

--- a/t-unit/gtp_test.gtp
+++ b/t-unit/gtp_test.gtp
@@ -103,8 +103,6 @@ tunit sar b J8 0
 pachi-tunit sar b J8 0
 
 lz-analyze 10
-lz-analyze 0
-pachi-analyze 0
 
 gogui-analyze_commands
 gogui-livegfx best_moves

--- a/t-unit/gtp_test.gtp
+++ b/t-unit/gtp_test.gtp
@@ -1,0 +1,146 @@
+echo testing gtp
+protocol_version
+name
+version
+list_commands
+known_command version
+
+# command ids
+7 version
+
+kgs-rules chinese
+boardsize 9
+clear_board
+komi 5.5
+play b d4
+showboard
+genmove w
+pachi-result
+undo
+kgs-genmove_cleanup w
+
+clear_board
+set_free_handicap d4 q16
+
+clear_board
+place_free_handicap 2
+
+clear_board
+fixed_handicap 2
+
+time_settings 5 10 25
+
+kgs-time_settings none
+kgs-time_settings canadian 5 10 25
+kgs-time_settings absolute 600
+kgs-time_settings byoyomi 60 30 5
+
+time_left b 30 5
+
+kgs-chat game user winrate
+
+boardsize 9
+clear_board
+komi 7.5
+play b C4
+play w E5
+play b C6
+play w E6
+play b D3
+play w F4
+play b D7
+play w E7
+play b E4
+play w E3
+play b D4
+play w F3
+play b D5
+play w F5
+play b D6
+play w E8
+play b D2
+play w D8
+play b C8
+play w E2
+play b D9
+play w H5
+play b E1
+play w G2
+play b E9
+play w F8
+play b F9
+play w G9
+play b C9
+play w G8
+play b G1
+play w H2
+play b F1
+play w J2
+play b H1
+play w G3
+play b J1
+play w G6
+play b D1
+play w H4
+play b J9
+play w PASS
+play b J7
+
+score_est
+pachi-score_est
+final_score
+final_status_list dead
+final_status_list seki
+final_status_list alive
+final_status_list black_territory
+final_status_list white_territory
+
+
+predict w h9
+pachi-predict b a1
+
+tunit sar b J8 0
+pachi-tunit sar b J8 0
+
+lz-analyze 10
+lz-analyze 0
+pachi-analyze 0
+
+gogui-analyze_commands
+gogui-livegfx best_moves
+gogui-influence
+gogui-score_est
+gogui-final_score
+gogui-best_moves
+gogui-winrates
+gogui-joseki_moves
+gogui-joseki_show_pattern J9
+gogui-dcnn_best
+gogui-dcnn_colors
+gogui-dcnn_rating
+gogui-pattern_best
+gogui-pattern_colors
+gogui-pattern_rating
+gogui-pattern_features J9
+gogui-pattern_gammas J9
+gogui-show_spatial J9
+gogui-spatial_size 6
+gogui-color_palette
+gogui-analyze_commands
+
+
+
+kgs-game_over
+quit
+
+
+# TODO
+
+# pachi-gentbook
+# pachi-dumptbook
+# pachi-evaluate
+
+
+
+
+

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -44,6 +44,7 @@ typedef struct uct {
 	int debug_level;
 	enum uct_reporting reporting;
 	int reportfreq;
+	FILE *report_fh;
 
 	int games, gamelen;
 	floating_t resign_threshold, sure_win_threshold;

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -151,8 +151,8 @@ bool uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_aliv
 void uct_prepare_move(uct_t *u, board_t *b, enum stone color);
 void uct_genmove_setup(uct_t *u, board_t *b, enum stone color);
 void uct_pondering_stop(uct_t *u);
-void uct_get_best_moves(uct_t *u, coord_t *best_c, float *best_r, int nbest, bool winrates);
-void uct_get_best_moves_at(uct_t *u, tree_node_t *n, coord_t *best_c, float *best_r, int nbest, bool winrates);
+void uct_get_best_moves(uct_t *u, coord_t *best_c, float *best_r, int nbest, bool winrates, int min_playouts);
+void uct_get_best_moves_at(uct_t *u, tree_node_t *n, coord_t *best_c, float *best_r, int nbest, bool winrates, int min_playouts);
 void uct_mcowner_playouts(uct_t *u, board_t *b, enum stone color);
 
 /* This is the state used for descending the tree; we use this wrapper

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -25,7 +25,7 @@ typedef enum uct_reporting {
 	UR_TEXT,
 	UR_JSON,
 	UR_JSON_BIG,
-	UR_LEELAZ,
+	UR_LEELA_ZERO,
 } uct_reporting_t;
 
 typedef enum uct_thread_model {

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -535,7 +535,7 @@ genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_al
 
 static coord_t
 uct_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
-{	
+{
 	uct_t *u = (uct_t*)e->data;
 
 	coord_t best_coord;
@@ -583,6 +583,22 @@ uct_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pas
 		uct_pondering_start(u, b, u->t, stone_other(color), best_coord, true);
 
 	return best_coord;
+}
+
+/* lz-genmove_analyze */
+static coord_t
+uct_genmove_analyze(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
+{
+	uct_t *u = (uct_t*)e->data;
+	enum uct_reporting prev = u->reporting;
+	
+	u->reporting = UR_LEELA_ZERO;
+	u->report_fh = stdout;	
+	coord_t coord = uct_genmove(e, b, ti, color, pass_all_alive);
+	u->reporting = prev;
+	u->report_fh = stderr;
+	
+	return coord;
 }
 
 /* Start tree search in the background and output stats for the sake of
@@ -1414,6 +1430,7 @@ engine_uct_init(engine_t *e, char *arg, board_t *b)
 	e->chat = uct_chat;
 	e->result = uct_result;
 	e->genmove = uct_genmove;
+	e->genmove_analyze = uct_genmove_analyze;
 #ifdef DISTRIBUTED
 	e->genmoves = uct_genmoves;
 	if (u->slave)

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -585,7 +585,9 @@ uct_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pas
 	return best_coord;
 }
 
-/* Wild pondering for the sake of frontend running Pachi. */
+/* Start tree search in the background and output stats for the sake of
+ * frontend running Pachi: sortof like pondering without a genmove.
+ * Stop processing if @start is 0. */
 static void
 uct_analyze(engine_t *e, board_t *b, enum stone color, int start)
 {
@@ -599,9 +601,8 @@ uct_analyze(engine_t *e, board_t *b, enum stone color, int start)
 	/* Start pondering if not already. */
 	if (u->pondering)  return;
 
-	if (!u->t)
-		uct_prepare_move(u, b, color);
-
+	u->reporting = UR_LEELA_ZERO;
+	if (!u->t)  uct_prepare_move(u, b, color);
 	uct_pondering_start(u, b, u->t, color, 0, false);
 }
 
@@ -839,9 +840,11 @@ uct_state_init(char *arg, board_t *b)
 					 * Implies debug=0. */
 					u->reporting = UR_JSON_BIG;
 					u->debug_level = 0;
-				} else if (!strcasecmp(optval, "leelaz")) {
+				} else if (!strcasecmp(optval, "leela-zero") ||
+					   !strcasecmp(optval, "leelaz") ||
+					   !strcasecmp(optval, "lz")) {
 					/* Leela-Zero pondering format. */
-					u->reporting = UR_LEELAZ;
+					u->reporting = UR_LEELA_ZERO;
 				} else
 					die("UCT: Invalid reporting format %s\n", optval);
 			} else if (!strcasecmp(optname, "reportfreq") && optval) {

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -755,6 +755,7 @@ uct_state_init(char *arg, board_t *b)
 	
 	u->debug_level = debug_level;
 	u->reportfreq = 1000;
+	u->report_fh = stderr;
 	u->gamelen = MC_GAMELEN;
 	u->resign_threshold = 0.2;
 	u->sure_win_threshold = 0.95;

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -77,8 +77,10 @@ uct_progress_text(uct_t *u, tree_t *t, enum stone color, int playouts)
 	fprintf(stderr, "\n");
 }
 
+/* Leela-zero format:
+ * info move Q16 visits 1 winrate 4687 prior 2198 order 0 pv Q16 [...] */
 static void
-uct_progress_leelaz(uct_t *u, tree_t *t, enum stone color)
+uct_progress_lz(uct_t *u, tree_t *t, enum stone color)
 {
 	board_t *b = t->board;
 	tree_node_t *node = u->t->root;
@@ -88,8 +90,9 @@ uct_progress_leelaz(uct_t *u, tree_t *t, enum stone color)
 	float   best_pl[nbest];	
 	float   best_wr[nbest];
 	coord_t best_c[nbest];
-	uct_get_best_moves_at(u, node, best_c, best_pl, nbest, false, 500);
-	uct_get_best_moves_at(u, node, best_c, best_wr, nbest, true,  500);
+	uct_get_best_moves(u, best_c, best_pl, nbest, false, 500);
+	uct_get_best_moves(u, best_c, best_wr, nbest, true,  500);
+	if (is_pass(best_c[0]))  return;
 
 	/* Priors */
 	float   best_pr[19 * 19];
@@ -99,8 +102,6 @@ uct_progress_leelaz(uct_t *u, tree_t *t, enum stone color)
 	for (int i = 0; i < 19 * 19; i++)
 		priors[best_cpr[i]] = best_pr[i];
 
-	// Leela-Zero format:
-	// info move Q16 visits 1 winrate 4687 prior 2198 order 0 pv Q16 [...]
 	for (int i = 0; i < nbest && !is_pass(best_c[i]); i++) {
 		fprintf(stderr, "info move %s visits %i winrate %i prior %i order %i ",
 			coord2sstr(best_c[i]), (int)best_pl[i], (int)(best_wr[i] * 10000),
@@ -265,10 +266,10 @@ uct_progress_gogui_livegfx(uct_t *u, tree_t *t, enum stone color, int playouts, 
 void
 uct_progress_status(uct_t *u, tree_t *t, enum stone color, int playouts, coord_t *final)
 {
-	if      (u->reporting == UR_TEXT)      uct_progress_text(u, t, color, playouts);
-	else if (u->reporting == UR_JSON)      uct_progress_json(u, t, color, playouts, final, false);
-	else if (u->reporting == UR_JSON_BIG)  uct_progress_json(u, t, color, playouts, final, true);
-	else if (u->reporting == UR_LEELAZ)    uct_progress_leelaz(u, t, color);
+	if      (u->reporting == UR_TEXT)        uct_progress_text(u, t, color, playouts);
+	else if (u->reporting == UR_JSON)        uct_progress_json(u, t, color, playouts, final, false);
+	else if (u->reporting == UR_JSON_BIG)    uct_progress_json(u, t, color, playouts, final, true);
+	else if (u->reporting == UR_LEELA_ZERO)  uct_progress_lz(u, t, color);
 	else    assert(0);
 	
 	uct_progress_gogui_livegfx(u, t, color, playouts, final);

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -27,7 +27,7 @@
 
 
 void
-uct_progress_text(uct_t *u, tree_t *t, enum stone color, int playouts)
+uct_progress_text(FILE *fh, uct_t *u, tree_t *t, enum stone color, int playouts)
 {
 	board_t *b = t->board;
 	if (!UDEBUGL(0))
@@ -36,25 +36,24 @@ uct_progress_text(uct_t *u, tree_t *t, enum stone color, int playouts)
 	/* Best move */
 	tree_node_t *best = u->policy->choose(u->policy, t->root, b, color, resign);
 	if (!best) {
-		fprintf(stderr, "... No moves left\n");
+		fprintf(fh, "... No moves left\n");
 		return;
 	}
-	fprintf(stderr, "[%d] ", playouts);
-	fprintf(stderr, "best %.1f%% ", 100 * tree_node_get_value(t, 1, best->u.value));
+	fprintf(fh, "[%d] ", playouts);
+	fprintf(fh, "best %.1f%% ", 100 * tree_node_get_value(t, 1, best->u.value));
 
 	/* Dynamic komi */
 	if (t->use_extra_komi)
-		fprintf(stderr, "xkomi %.1f ", t->extra_komi);
+		fprintf(fh, "xkomi %.1f ", t->extra_komi);
 
 	/* Best sequence */
-	fprintf(stderr, "| seq ");
+	fprintf(fh, "| seq ");
 	for (int depth = 0; depth < 4; depth++) {
 		if (best && best->u.playouts >= 25) {
-			fprintf(stderr, "%3s ", coord2sstr(node_coord(best)));
+			fprintf(fh, "%3s ", coord2sstr(node_coord(best)));
 			best = u->policy->choose(u->policy, best, b, color, resign);
-		} else {
-			fprintf(stderr, "    ");
 		}
+		else    fprintf(fh, "    ");
 	}
 
 	/* Best candidates */
@@ -63,24 +62,24 @@ uct_progress_text(uct_t *u, tree_t *t, enum stone color, int playouts)
 	coord_t best_c[nbest];
 	uct_get_best_moves(u, best_c, best_r, nbest, true, 100);
 
-	fprintf(stderr, "| can %c ", color == S_BLACK ? 'b' : 'w');
+	fprintf(fh, "| can %c ", color == S_BLACK ? 'b' : 'w');
 	for (int i = 0; i < nbest; i++)
 		if (!is_pass(best_c[i]))
-			fprintf(stderr, "%3s(%.1f) ", coord2sstr(best_c[i]), 100 * best_r[i]);
+			fprintf(fh, "%3s(%.1f) ", coord2sstr(best_c[i]), 100 * best_r[i]);
 		else
-			fprintf(stderr, "          ");
+			fprintf(fh, "          ");
 
 	/* Tree memory usage */
 	if (UDEBUGL(3))
-		fprintf(stderr, " | %.1fMb", (float)t->nodes_size / 1024 / 1024);
+		fprintf(fh, " | %.1fMb", (float)t->nodes_size / 1024 / 1024);
 	
-	fprintf(stderr, "\n");
+	fprintf(fh, "\n");
 }
 
 /* Leela-zero format:
  * info move Q16 visits 1 winrate 4687 prior 2198 order 0 pv Q16 [...] */
 static void
-uct_progress_lz(uct_t *u, tree_t *t, enum stone color)
+uct_progress_lz(FILE *fh, uct_t *u, tree_t *t, enum stone color)
 {
 	board_t *b = t->board;
 	tree_node_t *node = u->t->root;
@@ -103,20 +102,20 @@ uct_progress_lz(uct_t *u, tree_t *t, enum stone color)
 		priors[best_cpr[i]] = best_pr[i];
 
 	for (int i = 0; i < nbest && !is_pass(best_c[i]); i++) {
-		fprintf(stderr, "info move %s visits %i winrate %i prior %i order %i ",
+		fprintf(fh, "info move %s visits %i winrate %i prior %i order %i ",
 			coord2sstr(best_c[i]), (int)best_pl[i], (int)(best_wr[i] * 10000),
 			(int)(priors[best_c[i]] * 10000), i);
 
 		/* Dump best variation */
-		fprintf(stderr, "pv %s ", coord2sstr(best_c[i]));
+		fprintf(fh, "pv %s ", coord2sstr(best_c[i]));
 		tree_node_t *n = tree_get_node(node, best_c[i]);
 		while (1) {
 			n = u->policy->choose(u->policy, n, b, color, resign);
 			if (!n || n->u.playouts < 100) break;
-			fprintf(stderr, "%s ", coord2sstr(node_coord(n)));
+			fprintf(fh, "%s ", coord2sstr(node_coord(n)));
 		}
 	}
-	fprintf(stderr, "\n");
+	fprintf(fh, "\n");
 }
 
 /* GoGui live gfx: show best sequence */
@@ -159,27 +158,27 @@ uct_progress_gogui_winrates(uct_t *u, tree_t *t, enum stone color, int playouts)
 }
 
 void
-uct_progress_json(uct_t *u, tree_t *t, enum stone color, int playouts, coord_t *final, bool big)
+uct_progress_json(FILE *fh, uct_t *u, tree_t *t, enum stone color, int playouts, coord_t *final, bool big)
 {
 	/* Prefix indicating JSON line. */
-	fprintf(stderr, "{\"%s\": {", final ? "move" : "frame");
+	fprintf(fh, "{\"%s\": {", final ? "move" : "frame");
 
 	/* Plaout count */
-	fprintf(stderr, "\"playouts\": %d", playouts);
+	fprintf(fh, "\"playouts\": %d", playouts);
 
 	/* Dynamic komi */
 	if (t->use_extra_komi)
-		fprintf(stderr, ", \"extrakomi\": %.1f", t->extra_komi);
+		fprintf(fh, ", \"extrakomi\": %.1f", t->extra_komi);
 
 	if (final) {
 		/* Final move choice */
-		fprintf(stderr, ", \"choice\": \"%s\"",
+		fprintf(fh, ", \"choice\": \"%s\"",
 			coord2sstr(*final));
 	} else {
 		tree_node_t *best = u->policy->choose(u->policy, t->root, t->board, color, resign);
 		if (best) {
 			/* Best move */
-			fprintf(stderr, ", \"best\": {\"%s\": %f}",
+			fprintf(fh, ", \"best\": {\"%s\": %f}",
 				coord2sstr(best->coord),
 				tree_node_get_value(t, 1, best->u.value));
 		}
@@ -190,61 +189,61 @@ uct_progress_json(uct_t *u, tree_t *t, enum stone color, int playouts, coord_t *
 	tree_node_t *can[cans];
 	memset(can, 0, sizeof(can));
 	tree_node_t *best = t->root->children;
-	while (best) {
+	while (best) {        /* XXX clean this up, use uct_get_best_moves() instead */
 		int c = 0;
 		while ((!can[c] || best->u.playouts > can[c]->u.playouts) && ++c < cans);
 		for (int d = 0; d < c; d++) can[d] = can[d + 1];
 		if (c > 0) can[c - 1] = best;
 		best = best->sibling;
 	}
-	fprintf(stderr, ", \"can\": [");
+	fprintf(fh, ", \"can\": [");
 	while (--cans >= 0) {
 		if (!can[cans]) break;
 		/* Best sequence */
-		fprintf(stderr, "[");
+		fprintf(fh, "[");
 		best = can[cans];
 		for (int depth = 0; depth < 4; depth++) {
 			if (!best || best->u.playouts < 25) break;
-			fprintf(stderr, "%s{\"%s\": [%.3f, %i]}", depth > 0 ? "," : "",
+			fprintf(fh, "%s{\"%s\": [%.3f, %i]}", depth > 0 ? "," : "",
 				coord2sstr(best->coord),
 				tree_node_get_value(t, 1, best->u.value),
 				best->u.playouts);
 			best = u->policy->choose(u->policy, best, t->board, color, resign);
 		}
-		fprintf(stderr, "]%s", cans > 0 ? ", " : "");
+		fprintf(fh, "]%s", cans > 0 ? ", " : "");
 	}
-	fprintf(stderr, "]");
+	fprintf(fh, "]");
 
 	if (big) {
 		/* Average score. */
 		if (t->avg_score.playouts > 0)
-			fprintf(stderr, ", \"avg\": {\"score\": %.3f}", t->avg_score.value);
+			fprintf(fh, ", \"avg\": {\"score\": %.3f}", t->avg_score.value);
 		/* Per-intersection information. */
-		fprintf(stderr, ", \"boards\": {");
+		fprintf(fh, ", \"boards\": {");
 		/* Position coloring information. */
-		fprintf(stderr, "\"colors\": [");
+		fprintf(fh, "\"colors\": [");
 		int f = 0;
 		foreach_point(t->board) {
 			if (board_at(t->board, c) == S_OFFBOARD) continue;
-			fprintf(stderr, "%s%d", f++ > 0 ? "," : "", board_at(t->board, c));
+			fprintf(fh, "%s%d", f++ > 0 ? "," : "", board_at(t->board, c));
 		} foreach_point_end;
-		fprintf(stderr, "]");
+		fprintf(fh, "]");
 		/* Ownership statistics. Value (0..1000) for each possible
 		 * point describes likelihood of this point becoming black.
 		 * Normally, white rate is 1000-value; exception are possible
 		 * seki points, but these should be rare. */
-		fprintf(stderr, ", \"territory\": [");
+		fprintf(fh, ", \"territory\": [");
 		f = 0;
 		foreach_point(t->board) {
 			if (board_at(t->board, c) == S_OFFBOARD) continue;
 			int rate = u->ownermap.map[c][S_BLACK] * 1000 / u->ownermap.playouts;
-			fprintf(stderr, "%s%d", f++ > 0 ? "," : "", rate);
+			fprintf(fh, "%s%d", f++ > 0 ? "," : "", rate);
 		} foreach_point_end;
-		fprintf(stderr, "]");
-		fprintf(stderr, "}");
+		fprintf(fh, "]");
+		fprintf(fh, "}");
 	}
 
-	fprintf(stderr, "}}\n");
+	fprintf(fh, "}}\n");
 }
 
 void
@@ -266,10 +265,10 @@ uct_progress_gogui_livegfx(uct_t *u, tree_t *t, enum stone color, int playouts, 
 void
 uct_progress_status(uct_t *u, tree_t *t, enum stone color, int playouts, coord_t *final)
 {
-	if      (u->reporting == UR_TEXT)        uct_progress_text(u, t, color, playouts);
-	else if (u->reporting == UR_JSON)        uct_progress_json(u, t, color, playouts, final, false);
-	else if (u->reporting == UR_JSON_BIG)    uct_progress_json(u, t, color, playouts, final, true);
-	else if (u->reporting == UR_LEELA_ZERO)  uct_progress_lz(u, t, color);
+	if      (u->reporting == UR_TEXT)        uct_progress_text(u->report_fh, u, t, color, playouts);
+	else if (u->reporting == UR_JSON)        uct_progress_json(u->report_fh, u, t, color, playouts, final, false);
+	else if (u->reporting == UR_JSON_BIG)    uct_progress_json(u->report_fh, u, t, color, playouts, final, true);
+	else if (u->reporting == UR_LEELA_ZERO)  uct_progress_lz(u->report_fh, u, t, color);
 	else    assert(0);
 	
 	uct_progress_gogui_livegfx(u, t, color, playouts, final);

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -262,13 +262,9 @@ uct_progress_status(uct_t *u, tree_t *t, enum stone color, int playouts, coord_t
 			break;
 		default: assert(0);
 	}
+	if (!gogui_livegfx)  return;
 
-	if (!gogui_livegfx)
-		return;
-
-	char buffer[10000];  strbuf_t strbuf;
-	strbuf_t *buf = strbuf_init(&strbuf, buffer, sizeof(buffer));
-
+	strbuf(buf, 10000);
 	switch(gogui_livegfx) {
 		case UR_GOGUI_BEST:
 			uct_progress_gogui_best(buf, u, t, color, playouts);

--- a/util.h
+++ b/util.h
@@ -21,13 +21,17 @@
 int str_prefix(char *prefix, char *str);
 
 /* Warn user (popup on windows) */
-void warning(const char *format, ...);
+void warning(const char *format, ...)
+	__attribute__ ((format (printf, 1, 2)));
 
 /* Warning + terminate process */
-void die(const char *format, ...)  __attribute__ ((noreturn));
+void die(const char *format, ...)
+	__attribute__ ((noreturn))
+	__attribute__ ((format (printf, 1, 2)));
 
 /* Terminate after system call failure (similar to perror()) */
-void fail(char *msg) __attribute__ ((noreturn));
+void fail(char *msg)
+	__attribute__ ((noreturn));
 
 int file_exists(const char *name);
 
@@ -163,7 +167,9 @@ strbuf_t *new_strbuf(int size);
 
 /* String buffer version of printf():
  * Use sbprintf(buf, format, ...) to accumulate output. */
-int strbuf_printf(strbuf_t *buf, const char *format, ...);
+int strbuf_printf(strbuf_t *buf, const char *format, ...)
+	__attribute__ ((format (printf, 2, 3)));
+
 #define sbprintf strbuf_printf
 
 

--- a/util.h
+++ b/util.h
@@ -139,6 +139,7 @@ typedef struct
 	char *cur;
 } strbuf_t;
 
+
 /* Initialize passed string buffer. Returns buf. */
 strbuf_t *strbuf_init(strbuf_t *buf, char *buffer, int size);
 
@@ -150,6 +151,15 @@ strbuf_t *strbuf_init_alloc(strbuf_t *buf, int size);
  * Both must be free()ed afterwards. */
 strbuf_t *new_strbuf(int size);
 
+/* Create string buffer for use within current function (stack-allocated). */
+#define strbuf(buf, size)  \
+	char buffer_[(size)];  strbuf_t strbuf_; \
+	strbuf_t *buf = strbuf_init(&strbuf_, buffer_, sizeof(buffer_));
+
+/* Create static string buffer: can return buf->str (but not buf). */
+#define static_strbuf(buf, size)  \
+	static char buffer_[(size)];  strbuf_t strbuf_; \
+	strbuf_t *buf = strbuf_init(&strbuf_, buffer_, sizeof(buffer_));
 
 /* String buffer version of printf():
  * Use sbprintf(buf, format, ...) to accumulate output. */


### PR DESCRIPTION
Revisited GTP output logic.
So nice to work with now, I wish GTP layer had been like this when i started =)

- gtp_reply()   output a line, adds end-of-line \n
- gtp_printf()  print anything (no \n added)
- autoflush: final \n added automatically
- check gtp arguments, at least that they're there.
- gtp/gogui cleanup: simpler now that we can just printf() around.
- gtp unit testing, some gtp answers were broken (extra \n)
- `lz-analyze` cleanup
- `lz-genmove_analyze` support (get winrates in Sabaki etc)
