### PR TITLE
Multiple dcnn support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,12 @@ matrix:
 before_install:
   - if [ "$TRAVIS_OS_NAME" = linux ] && [ "$DCNN" = 1 ]; then sudo add-apt-repository ppa:lemonsqueeze/pachi -y ; fi
   - if [ "$TRAVIS_OS_NAME" = linux ] && [ "$DCNN" = 1 ]; then sudo apt-get update -q ; fi
-  - if [ "$TRAVIS_OS_NAME" = linux ] && [ "$DCNN" = 1 ]; then sudo apt-get install libcaffe-cpu-dev -y ; fi
+  - if [ "$TRAVIS_OS_NAME" = linux ] && [ "$DCNN" = 1 ]; then sudo apt-get install -y libcaffe-cpu-dev pachi-go-data; fi
+# XXX remove once pachi-data package is updated
+  - if [ "$TRAVIS_OS_NAME" = linux ] && [ "$DCNN" = 1 ] && ! [ -f /usr/share/pachi-go/detlef54.prototxt ]; then sudo mv /usr/share/pachi-go/golast19.prototxt /usr/share/pachi-go/detlef54.prototxt; fi
+  - if [ "$TRAVIS_OS_NAME" = linux ] && [ "$DCNN" = 1 ] && ! [ -f /usr/share/pachi-go/detlef54.trained ];  then sudo mv /usr/share/pachi-go/golast.trained    /usr/share/pachi-go/detlef54.trained; fi
 
 # https://blog.lukaspradel.com/continuous-integration-for-cmake-projects-using-travis-ci/  
 script:
-  - make -j2 DCNN=$DCNN BOARD_TESTS=1
+  - make -j2 DCNN=$DCNN BOARD_TESTS=1 DATADIR=/usr/share/pachi-go
   - make test

--- a/HACKING
+++ b/HACKING
@@ -1,5 +1,14 @@
 This is brief developer-oriented overview of Pachi structure.
 
+The aim of the software framework is to make it easy to plug your
+engine to the common infrastructure and implement your ideas while
+minimalizing the overhead of implementing the GTP, speed-optimized
+board implementation, etc.  Also, there are premade random playout
+and UCT tree engines, so that you can directly tweak only particular
+policies.  The infrastructure is pretty fast and it should be quite
+easy for you (or us) to extend it to provide more facilities for
+your engine.
+
 Pachi is completely Go-specific (c.f. Fuego; though e.g. atari go support
 should be easy to add), but fairly modular. It has been built with focus
 on MonteCarlo-based play, but it can in principle be used for other

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,38 @@
+## Compiling
+
+Currently Unix, Mac and Windows are supported.  
+To build Pachi, simply type:
+
+	make
+
+
+In case you hit compilation issues (e.g. when building on MacOS/X)
+or want to change the build configuration, check the user configurable
+section at the top of the Makefile.
+
+Here is an example for installing all dependencies and compiling Pachi
+from source under Ubuntu 18.04:
+
+	sudo apt install git make gcc g++ libcaffe-cpu-dev libboost-all-dev libgflags-dev libgoogle-glog-dev libprotobuf-dev libopenblas-dev
+	git clone https://github.com/pasky/pachi
+	cd pachi
+	make
+
+Install libcaffe-cuda-dev instead for nvidia gpu acceleration.  
+Non-dcnn build just needs git make and gcc.
+
+Otherwise:
+- Install [Caffe](http://caffe.berkeleyvision.org)  
+  CPU-only build is fine, no need for GPU, cuda or the other optional dependencies.  
+  You need openblas for good performance.
+- Edit Makefile, point it to where caffe is installed and build.
+
+After compiling and setting up data files you can install pachi with:
+
+    make install
+    make install-data
+
+Pachi will look for extra data files (such as dcnn, pattern, joseki or
+fuseki database) in pachi's system directory (`/usr/local/share/pachi`
+by default) as well as current directory. System data directory can be
+overridden at runtime by setting `DATA_DIR` environment variable.

--- a/MORE.md
+++ b/MORE.md
@@ -1,0 +1,139 @@
+## Large Patterns
+
+Pachi uses MM patterns to guide tree search. The pattern matcher runs
+on the cpu each time a new node is explored (see pattern/README for details).
+Right now prediction rate is about 37%.
+
+One benefit of MM is that the weights are very small. If you used previous
+Pachi versions, it's no longer necessary to install extra files to
+get patterns working. Patterns should load instantly now and take up
+very little memory.
+
+
+## Joseki engine
+
+When playing without dcnn Pachi uses a joseki engine to improve play during
+the opening. The "Joseki Moves" gogui analyze command can be used to display
+what moves Pachi would consider in a given position. Just keep in mind these
+are "Pachi joseki moves": moves Pachi might want to play at around 3k level.
+For a full joseki reference from a player's point of view see Kogo joseki
+dictionary for example.
+
+To run Pachi without joseki engine:
+   `pachi --nodcnn --nojoseki -t =5000`
+
+
+## Opening book
+
+> Mostly useful when running without dcnn (dcnn can deal with fuseki).
+
+Pachi can use an opening book in a Fuego-compatible format - you can
+obtain one at http://gnugo.baduk.org/fuegoob.htm and use it in Pachi
+with the -f parameter:
+
+	pachi -f book.dat ...
+
+You may wish to append some custom Pachi opening book lines to book.dat;
+take them from the book.dat.extra file. If using the default Fuego book,
+you may want to remove the lines listed in book.dat.bad.
+
+
+## Greedy Pachi
+
+> Mostly useful when running without dcnn
+
+Normally, Pachi cares only for win or loss and does not take into
+account the point amount. This means that it will play slack endgame
+when winning and crazy moves followed with a resign when losing.
+
+It may give you a more pleasurable playing experience if Pachi
+_does_ take into account the point size, strives for a maximum
+(reasonable) win margin when winning and minimal point loss when
+losing. This is possible by using the maximize_score parameter, e.g.:
+
+	pachi -t _1200 threads=8,maximize_score
+
+This enables an aggressive dynamic komi usage and end result margin
+is included in node values aside of winrate. Pachi will also enter
+scoring even when losing (normally, Pachi will never pass in that case).
+Note that if you pass any 'dynkomi' parameter to Pachi, you will reset
+the values set by 'maximize_score'.
+
+Note that Pachi in this mode may be slightly weaker, and result margin
+should not be taken into account when judging either player's strength.
+During the game, the winning/losing margin can be approximated from
+Pachi's "extra komi" or "xkomi" reporting in the progress messages.
+
+
+## Game Analysis
+
+Pachi can help you analyze your games by being able to provide its
+opinion on various positions. The user interface is very rudimentary,
+but the ability is certainly there.
+
+There are currently several Pachi interfaces provided for this purpose:
+
+* Winrate Development
+
+  Pachi can evaluate all moves within a given game and show how
+  the winrates for both players evolved - i.e. who was winning at which
+  game stage. This is implemented using the `tools/sgf-analyse.pl` script.
+  See the comment on top of the script about its usage.
+
+* Move Ranking
+
+  Pachi can evaluate all available moves in a given situation
+  and for each give a value between 0 and 1 representing perceived
+  likelihood of winning the game if one would play that move. I.e. it can
+  suggest which moves would be good and bad in a single given situation.
+
+  To achieve the latter, note the number of move at the situation you
+  want to evaluate and run the `tools/sgf-ratemove.sh` script.
+  See the comment on top of the script about its usage.
+
+* Move Hinting
+
+  Pachi can show instantenous dcnn or pattern-based move suggestions either
+  graphically in GoGui or through the above method (pass an extra parameter
+  like '-e patternplay' to tools/sgf-ratemove.sh).
+
+
+## Experiments and Testing
+
+Except UCT, Pachi supports a simple `random` idiotbot-like engine and an
+example `montecarlo` treeless MonteCarlo-player. The MonteCarlo simulation ("playout")
+policies are also pluggable, by default we use the one that makes use of
+heavy domain knowledge.
+
+Other special engines are also provided:
+* `distributed` engine for cluster play; the description at the top of
+  distributed/distributed.c should provide all the guidance
+* `dcnn` engine plays moves according to dcnn policy.
+* `replay` engine simply plays moves according to the playout policy suggestions
+* `patternplay` engine plays moves according to the learned patterns
+* few other purely for development usage
+
+Pachi can be used as a test opponent for development of other go-playing
+programs. For example, to get the "plainest UCT" player, use:
+
+	pachi -t =5000 --nodcnn policy=ucb1,playout=light,prior=eqex=0,dynkomi=none,pondering=0,pass_all_alive
+
+This will fix the number of playouts per move to 5000, switch the node
+selection policy from ucb1amaf to ucb1 (i.e. disable RAVE), switch the
+playouts from heuristic-heavy moggy to uniformly random light, stop
+prioring the node values heuristically, turn off dynamic komi, disable
+thinking on the opponent's time and make sure Pachi passes only when
+just 10% alive stones remain on the board (to avoid disputes during
+counting).
+
+You can of course selectively re-enable various features or tweak this
+further. But please note that using Pachi in this mode is not tested
+extensively, so check its performance in whatever version you test
+before you use it as a reference.
+
+Note that even in this "basic UCT" mode, Pachi optimizes tree search
+by considering board symmetries at the beginning. Currently, there's no
+easy option to turn that off. The easiest way is to tweak board.c so
+that board_symmetry_update() has goto break_symmetry at the beginning
+and board_clear has board->symmetry.type = SYM_NONE.
+

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 #### CONFIGURATION
 
-# Uncomment one of the options below to change the way Pachi is built.
+# Tweak options below to change the way Pachi is built.
 # Alternatively, you can pass the option to make itself, like:
 # 	make MAC=1 DOUBLE_FLOATING=1
-# or use the short aliases (make quick, make generic ...)
+# or use the short aliases (make fast, make generic ...)
+
+######################### Build #########################
 
 # Generic build ?
 # If binary will be distributed you need this !
@@ -24,12 +26,21 @@
 
 # MAC=1
 
+#################### Deep Learning ######################
+
 # Compile Pachi with dcnn support ?
 # You'll need to install Boost and Caffe libraries.
 # If Caffe is in a custom directory you can set it here.
 
 DCNN=1
 # CAFFE_PREFIX=/usr/local/caffe
+
+# Supported networks:
+# Comment out those you don't need for speed.
+
+DCNN_DETLEF=1
+
+######################## Extras #########################
 
 # Fixed board size. Set this to enable more aggressive optimizations
 # if you only play on 19x19. Pachi won't be able to play on other
@@ -63,6 +74,8 @@ DCNN=1
 # Compile extra tests ? Enable this to test board implementation.
 # BOARD_TESTS=1
 
+###################### Profiling ########################
+
 # Enable performance profiling using gprof. Note that this also disables
 # inlining, which allows more fine-grained profile, but may also distort
 # it somewhat.
@@ -75,6 +88,7 @@ DCNN=1
 
 # PROFILING=perftools
 
+######################## Install #########################
 
 # Target directories when running 'make install' / 'make install-data'.
 # Pachi will look for extra data files (such as dcnn, pattern, joseki or
@@ -94,7 +108,7 @@ CFLAGS       := -std=gnu99 -pthread -Wsign-compare -Wno-format-zero-length
 CXXFLAGS     := -std=c++11
 
 
-###################################################################################################################
+##############################################################################
 ### CONFIGURATION END
 
 # Main rule + aliases
@@ -175,6 +189,12 @@ ifeq ($(DCNN), 1)
 	COMMON_FLAGS   += -DDCNN
 	EXTRA_OBJS     += $(EXTRA_DCNN_OBJS) caffe.o dcnn.o
 	SYS_LIBS := $(DCNN_LIBS)
+else
+	DCNN_DETLEF = 0
+endif
+
+ifeq ($(DCNN_DETLEF), 1)
+	COMMON_FLAGS += -DDCNN_DETLEF
 endif
 
 ifeq ($(FIFO), 1)

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ DCNN=1
 # Comment out those you don't need for speed.
 
 DCNN_DETLEF=1
+DCNN_DARKFOREST=1
 
 ######################## Extras #########################
 
@@ -191,10 +192,15 @@ ifeq ($(DCNN), 1)
 	SYS_LIBS := $(DCNN_LIBS)
 else
 	DCNN_DETLEF = 0
+	DCNN_DARKFOREST = 0
 endif
 
 ifeq ($(DCNN_DETLEF), 1)
 	COMMON_FLAGS += -DDCNN_DETLEF
+endif
+
+ifeq ($(DCNN_DARKFOREST), 1)
+	COMMON_FLAGS += -DDCNN_DARKFOREST
 endif
 
 ifeq ($(FIFO), 1)

--- a/README.md
+++ b/README.md
@@ -39,17 +39,14 @@ and follow instructions inside.
 
 > Performance might be better if you recompile for your own system though.
 
-## Installation
-
-Currently Unix, Mac and Windows are supported.  
-To build Pachi, simply type:
-
-	make
+For build instructions see [INSTALL](INSTALL.md).
 
 <img align="right" src="media/screenshot_sabaki.jpg" title="playing through sabaki">
 
-The resulting binary program `pachi` is a GTP client. Connect to it
-with your favorite Go program interface (e.g. [gogui][1], [sabaki][2], [lizzie](#Lizzie)),
+## Setup
+
+The `pachi` binary program is a GTP client. Use it with your favorite
+Go program interface (e.g. [gogui][1], [sabaki][2], [lizzie](#Lizzie)),
 or use [kgsGtp][3] to connect it to KGS.
 
 > DO NOT make the GTP interface accessible directly to untrusted users
@@ -61,60 +58,25 @@ or use [kgsGtp][3] to connect it to KGS.
 [3]: http://www.michna.com/kgsbot.htm
 
 The pachi program can take many parameters. The defaults should be fine
-for initial usage, see below for some more tips.
-
-In case you hit compilation issues (e.g. when building on MacOS/X)
-or want to change the build configuration, check the user configurable
-section at the top of the Makefile.
-
-Here is an example for installing all dependencies and compiling Pachi
-from sources under Ubuntu 18.04:
-
-	sudo apt install git make gcc g++ libcaffe-cpu-dev libboost-all-dev libgflags-dev libgoogle-glog-dev libprotobuf-dev libopenblas-dev
-	git clone https://github.com/pasky/pachi.git
-	cd pachi
-	make
-
-Install libcaffe-cuda-dev instead for nvidia gpu acceleration.  
-Non-dcnn build just needs git make and gcc.
-
-After compiling and setting up data files you can install pachi with:
-
-    make install
-    make install-data
-
-Pachi will look for extra data files (such as dcnn, pattern, joseki or
-fuseki database) in pachi's system directory (`/usr/local/share/pachi`
-by default) as well as current directory. System data directory can be
-overridden at runtime by setting `DATA_DIR` environment variable.
+for initial usage, see below for more tips.
 
 
-## DCNN support
+## Deep Learning
 
-Pachi can use a neural network as source of good moves to consider.
-With dcnn support Pachi can play at dan level strength on modest hardware.
-For large number of playouts this makes it about 1 stone stronger, and
-tends to make the games more pretty. A raw dcnn engine is available for
-pure dcnn play (not recommended for actual games, pachi won't know when to
-pass or resign !).
+Pachi uses a neural network as source of good moves to consider (policy network).
+With dcnn support Pachi can play at dan level on modest hardware.
+For large number of playouts this makes it about 1 stone stronger and
+makes the games more pretty. A raw dcnn engine is available for
+pure dcnn play (not recommended for actual games, pachi won't know
+when to pass or resign !).
 
-To build Pachi with DCNN support:
-- Install [Caffe](http://caffe.berkeleyvision.org)  
-  CPU-only build is fine, no need for GPU, cuda or the other optional dependencies.  
-  You need openblas for good performance.
-- Edit Makefile, set DCNN=1, point it to where caffe is installed and build.
+`pachi --list-dcnn`    List supported networks.  
+`pachi --dcnn=name`    Choose network to use (Detlef's 54% dcnn by default).
 
-Install dcnn files in current directory.
-Detlef Schmicker's 54% dcnn can be found at:  
-  http://physik.de/CNNlast.tar.gz
+Releases come with Detlef's 54% dcnn by default.
+For other networks see [Pachi Networks](https://github.com/pasky/pachi/releases/tag/pachi_networks).
 
-More information about this dcnn [here](http://computer-go.org/pipermail/computer-go/2015-December/008324.html).
-
-Pachi will look for `golast19.prototxt` and `golast.trained` files on startup.
-
-This network is fully convolutional, so can work with boards other than 19x19.
-right now it's used for boards 13x13 and up.
-Currently dcnn is used for root node only, dcnn + pondering working now.
+Currently dcnn is used for root node only.
 
 
 ## How to run
@@ -148,8 +110,9 @@ It's also possible to force time settings via the command line
 Pachi will play fast on a fast computer, slow on a slow computer, but strength
 will remain the same:
 
-* `pachi -t =5000:15000    `    kgs 2d with dcnn support.
-* `pachi --nodcnn -t =5000   `   kgs 3k (mcts only).
+* `pachi -t =5000:15000 --dcnn=df `   kgs 3d
+* `pachi -t =5000:15000       `       kgs 2d
+* `pachi -t =5000 --nodcnn      `     kgs 3k (mcts only).
 
 **Other Options**
 
@@ -187,7 +150,8 @@ via the live gfx commands.
 ![score estimate](media/screenshot_score_est.png?raw=true "score estimate")
 ![dcnn colormap](media/screenshot_dcnn_colors.png?raw=true "dcnn colormap")
 
-There are some non-gui tools for game analysis as well, see below.
+For game analysis try [GoReviewPartner](https://github.com/pnprog/goreviewpartner),
+or see [here](MORE.md) for some tools that come with Pachi.
 
 
 ## Lizzie
@@ -222,159 +186,10 @@ unexpected happens.
 `-o log_file` logs to a file instead. gogui live-gfx commands won't work though.
 
 
-## Large Patterns
+## More
 
-Pachi uses MM patterns to guide tree search. The pattern matcher runs
-on the cpu each time a new node is explored (see pattern/README for details).
-Right now prediction rate is about 37%.
-
-One benefit of MM is that the weights are very small. If you used previous
-Pachi versions, it's no longer necessary to install extra files to
-get patterns working. Patterns should load instantly now and take up
-very little memory.
-
-
-## Joseki engine
-
-When playing without dcnn Pachi uses a joseki engine to improve play during
-the opening. The "Joseki Moves" gogui analyze command can be used to display
-what moves Pachi would consider in a given position. Just keep in mind these
-are "Pachi joseki moves": moves Pachi might want to play at around 3k level.
-For a full joseki reference from a player's point of view see Kogo joseki
-dictionary for example.
-
-To run Pachi without joseki engine:
-   `pachi --nodcnn --nojoseki -t =5000`
-
-
-## Opening book
-
-> Mostly useful when running without dcnn (dcnn can deal with fuseki).
-
-Pachi can use an opening book in a Fuego-compatible format - you can
-obtain one at http://gnugo.baduk.org/fuegoob.htm and use it in Pachi
-with the -f parameter:
-
-	pachi -f book.dat ...
-
-You may wish to append some custom Pachi opening book lines to book.dat;
-take them from the book.dat.extra file. If using the default Fuego book,
-you may want to remove the lines listed in book.dat.bad.
-
-
-## Greedy Pachi
-
-> Mostly useful when running without dcnn
-
-Normally, Pachi cares only for win or loss and does not take into
-account the point amount. This means that it will play slack endgame
-when winning and crazy moves followed with a resign when losing.
-
-It may give you a more pleasurable playing experience if Pachi
-_does_ take into account the point size, strives for a maximum
-(reasonable) win margin when winning and minimal point loss when
-losing. This is possible by using the maximize_score parameter, e.g.:
-
-	pachi -t _1200 threads=8,maximize_score
-
-This enables an aggressive dynamic komi usage and end result margin
-is included in node values aside of winrate. Pachi will also enter
-scoring even when losing (normally, Pachi will never pass in that case).
-Note that if you pass any 'dynkomi' parameter to Pachi, you will reset
-the values set by 'maximize_score'.
-
-Note that Pachi in this mode may be slightly weaker, and result margin
-should not be taken into account when judging either player's strength.
-During the game, the winning/losing margin can be approximated from
-Pachi's "extra komi" or "xkomi" reporting in the progress messages.
-
-
-## Experiments and Testing
-
-Except UCT, Pachi supports a simple `random` idiotbot-like engine and an
-example `montecarlo` treeless MonteCarlo-player. The MonteCarlo simulation ("playout")
-policies are also pluggable, by default we use the one that makes use of
-heavy domain knowledge.
-
-Other special engines are also provided:
-* `distributed` engine for cluster play; the description at the top of
-  distributed/distributed.c should provide all the guidance
-* `dcnn` engine plays moves according to dcnn policy.
-* `replay` engine simply plays moves according to the playout policy suggestions
-* `patternplay` engine plays moves according to the learned patterns
-* few other purely for development usage
-
-Pachi can be used as a test opponent for development of other go-playing
-programs. For example, to get the "plainest UCT" player, use:
-
-	pachi -t =5000 --nodcnn policy=ucb1,playout=light,prior=eqex=0,dynkomi=none,pondering=0,pass_all_alive
-
-This will fix the number of playouts per move to 5000, switch the node
-selection policy from ucb1amaf to ucb1 (i.e. disable RAVE), switch the
-playouts from heuristic-heavy moggy to uniformly random light, stop
-prioring the node values heuristically, turn off dynamic komi, disable
-thinking on the opponent's time and make sure Pachi passes only when
-just 10% alive stones remain on the board (to avoid disputes during
-counting).
-
-You can of course selectively re-enable various features or tweak this
-further. But please note that using Pachi in this mode is not tested
-extensively, so check its performance in whatever version you test
-before you use it as a reference.
-
-Note that even in this "basic UCT" mode, Pachi optimizes tree search
-by considering board symmetries at the beginning. Currently, there's no
-easy option to turn that off. The easiest way is to tweak board.c so
-that board_symmetry_update() has goto break_symmetry at the beginning
-and board_clear has board->symmetry.type = SYM_NONE.
-
-
-## Game Analysis
-
-Pachi can also help you analyze your games by being able to provide
-its opinion on various positions. The user interface is very rudimentary,
-but the ability is certainly there.
-
-There are currently several Pachi interfaces provided for this purpose.
-
-**Winrate Development**
-
-Pachi can evaluate all moves within a given game and show how
-the winrates for both players evolved - i.e. who was winning at which
-game stage. This is implemented using the `tools/sgf-analyse.pl` script.
-See the comment on top of the script about its usage.
-
-**Move Ranking**
-
-Pachi can evaluate all available moves in a given situation
-and for each give a value between 0 and 1 representing perceived
-likelihood of winning the game if one would play that move. I.e. it can
-suggest which moves would be good and bad in a single given situation.
-
-To achieve the latter, note the number of move at the situation you
-want to evaluate and run the `tools/sgf-ratemove.sh` script.
-See the comment on top of the script about its usage.
-
-**Pattern Move Hinting**
-
-Pachi can show instantenous pattern-based move suggestions very much
-like for example Moyo Go Studio (though of course without a GUI).
-You can use the Move Ranking method above (tools/sgf-ratemove.sh),
-but pass it an extra parameter '-e patternplay'.
-
-
-## Framework
-
-The aim of the software framework is to make it easy to plug your
-engine to the common infrastructure and implement your ideas while
-minimalizing the overhead of implementing the GTP, speed-optimized
-board implementation, etc.  Also, there are premade random playout
-and UCT tree engines, so that you can directly tweak only particular
-policies.  The infrastructure is pretty fast and it should be quite
-easy for you (or us) to extend it to provide more facilities for
-your engine.
-
-See the [HACKING](HACKING?raw=true) file for a more detailed developer's view of Pachi.
+See [HACKING](HACKING?raw=true) for a more detailed developer's view of Pachi,  
+[MORE](MORE.md) for more details, other engines and game analysis tools.
 
 Also, if you are interested about Pachi's architecture, algorithms
 etc., consider taking a look at Petr Baudis' Master's Thesis:

--- a/board.c
+++ b/board.c
@@ -11,6 +11,7 @@
 #include "mq.h"
 #include "random.h"
 #include "ownermap.h"
+#include "dcnn.h"
 
 #ifdef BOARD_PAT3
 #include "pattern3.h"
@@ -860,6 +861,13 @@ board_rmf(board_t *b, int f)
 static void
 board_commit_move(board_t *b, move_t *m)
 {
+	if (!playout_board(b)) {
+#ifdef DCNN_DARKFOREST
+		if (darkforest_dcnn && !is_pass(m->coord))
+			b->moveno[m->coord] = b->moves;
+#endif
+	}
+
 	b->last_move_i = last_move_nexti(b);
 	last_move(b) = *m;
 

--- a/board.h
+++ b/board.h
@@ -203,6 +203,10 @@ FB_ONLY(hash_t hash_history)[BOARD_HASH_HISTORY]; /* Last hashes encountered, fo
 
 /*************************************************************************************************************/
 
+#ifdef DCNN_DARKFOREST
+FB_ONLY(int moveno)[BOARD_MAX_COORDS];     /* Move number for each coord */
+#endif
+
 #ifdef BOARD_UNDO_CHECKS	
 	int quicked;                       /* Guard against invalid quick_play() / quick_undo() uses */
 #endif

--- a/caffe.cpp
+++ b/caffe.cpp
@@ -37,14 +37,14 @@ caffe_ready()
 static int
 caffe_load()
 {
-	char model_file[256];    get_data_file(model_file, "golast19.prototxt");
-	char trained_file[256];  get_data_file(trained_file, "golast.trained");
+	char model_file[256];    get_data_file(model_file, "detlef54.prototxt");
+	char trained_file[256];  get_data_file(trained_file, "detlef54.trained");
 	if (!file_exists(model_file) || !file_exists(trained_file)) {
-		if (DEBUGL(1))  fprintf(stderr, "No dcnn files found, will not use dcnn code.\n");
-#ifdef _WIN32
-		popup("WARNING: Couldn't find Pachi data files, running without dcnn support !\n");
-#endif
-		return 0;
+ 		if (DEBUGL(1))  fprintf(stderr, "Couldn't find dcnn files, aborting.\n");
+ #ifdef _WIN32
+		popup("ERROR: Couldn't find Pachi data files.\n");
+ #endif
+		exit(1);
 	}
 	
 	Caffe::set_mode(Caffe::CPU);       

--- a/caffe.cpp
+++ b/caffe.cpp
@@ -19,6 +19,15 @@ extern "C" {
 static shared_ptr<Net<float> > net;
 static int net_size = 0;		/* board size */
 
+static int
+shape_size(const vector<int>& shape)
+{
+       int size = 1;
+       for (unsigned int i = 0; i < shape.size(); i++)
+               size *= shape[i];
+       return size;
+}
+	
 /* Make caffe quiet */
 void
 quiet_caffe(int argc, char *argv[])
@@ -35,15 +44,16 @@ caffe_ready()
 }
 
 static int
-caffe_load()
+caffe_load(char *model, char *weights, int default_size)
 {
-	char model_file[256];    get_data_file(model_file, "detlef54.prototxt");
-	char trained_file[256];  get_data_file(trained_file, "detlef54.trained");
-	if (!file_exists(model_file) || !file_exists(trained_file)) {
- 		if (DEBUGL(1))  fprintf(stderr, "Couldn't find dcnn files, aborting.\n");
- #ifdef _WIN32
+	char model_file[256];    get_data_file(model_file, model);
+	char weights_file[256];  get_data_file(weights_file, weights);
+	if (!file_exists(model_file) || !file_exists(weights_file)) {
+		if (DEBUGL(1))  fprintf(stderr, "Loading dcnn files: %s, %s\n"
+					        "Couldn't find dcnn files, aborting.\n", model, weights);
+#ifdef _WIN32
 		popup("ERROR: Couldn't find Pachi data files.\n");
- #endif
+#endif
 		exit(1);
 	}
 	
@@ -51,24 +61,19 @@ caffe_load()
 	
 	/* Load the network. */
 	net.reset(new Net<float>(model_file, TEST));
-	net->CopyTrainedLayersFrom(trained_file);
-	
-	/* Get board size. */
-	static const vector<int>& shape = net->input_blobs()[0]->shape();
-	assert(shape.size() == 4);
-	assert(shape[0] == 1 && shape[2] == shape[3]);
-	net_size = shape[3];
+	net->CopyTrainedLayersFrom(weights_file);
+	net_size = default_size;
 
 	return 1;
 }
 
 void
-caffe_init(int size)
+caffe_init(int size, char *model, char *weights, char *name, int default_size)
 {
 	if (net && net_size == size)  return;   /* Nothing to do. */
-	if (!net && !caffe_load())    return;
+	if (!net && !caffe_load(model, weights, default_size))    return;
 	
-	/* Network is fully convolutional so can handle any boardsize,
+	/* If network is fully convolutional it can handle any boardsize,
 	 * just need to resize the input layer. */
 	if (net_size != size) {
 		static const vector<int>& shape = net->input_blobs()[0]->shape();
@@ -78,19 +83,26 @@ caffe_init(int size)
 	}
 	
 	if (DEBUGL(1))
-		fprintf(stderr, "Loaded Detlef's 54%% dcnn for %ix%i\n", size, size);
+		fprintf(stderr, "Loaded %s dcnn for %ix%i\n", name, size, size);
 }
 
-
 void
-caffe_get_data(float *data, float *result, int planes, int size)
+caffe_done()
 {
-	assert(net && net_size == size);	
-	Blob<float> *blob = new Blob<float>(1, planes, size, size);
+	net.reset();
+	net_size = 0;
+}
+	
+void
+caffe_get_data(float *data, float *result, int size, int planes, int psize)
+{
+	assert(net && net_size == size);
+	Blob<float> *blob = new Blob<float>(1, planes, psize, psize);
 	blob->set_cpu_data(data);
 	vector<Blob<float>*> bottom;
 	bottom.push_back(blob);
 	const vector<Blob<float>*>& rr = net->Forward(bottom);
+	assert(shape_size(rr[0]->shape()) >= size * size);
 	
 	for (int i = 0; i < size * size; i++) {
 		result[i] = rr[0]->cpu_data()[i];
@@ -98,7 +110,7 @@ caffe_get_data(float *data, float *result, int planes, int size)
 			result[i] = 0.00001;
 	}
 	
-	delete blob;	
+	delete blob;
 }
 
 	

--- a/caffe.h
+++ b/caffe.h
@@ -8,8 +8,9 @@ extern "C" {
 
 
 bool caffe_ready(void);
-void caffe_init(int size);
-void caffe_get_data(float *data, float *result, int planes, int size);
+void caffe_init(int size, char *model, char *weights, char *name, int default_size);
+void caffe_done(void);
+void caffe_get_data(float *data, float *result, int size, int planes, int psize);
 
 #ifdef DCNN
 void quiet_caffe(int argc, char *argv[]);

--- a/dcnn.c
+++ b/dcnn.c
@@ -10,16 +10,6 @@
 #include "dcnn.h"
 #include "timeinfo.h"
 
-static bool board_19x19(board_t *b)        {  return (board_rsize(b) == 19);  }
-static bool board_15x15(board_t *b)        {  return (board_rsize(b) == 15);  }
-//static bool board_13x13(board_t *b)      {  return (board_rsize(b) == 13);  }
-static bool board_13x13_and_up(board_t *b) {  return (board_rsize(b) >= 13);  }
-
-#ifdef DCNN_DETLEF
-static void detlef54_dcnn_eval(board_t *b, enum stone color, float result[]);
-static void detlef44_dcnn_eval(board_t *b, enum stone color, float result[]);
-#endif
-
 typedef void (*dcnn_evaluate_t)(board_t *b, enum stone color, float result[]);
 typedef bool (*dcnn_supported_board_size_t)(board_t *b);
 
@@ -31,13 +21,36 @@ typedef struct {
 	int  default_size;
 	dcnn_supported_board_size_t supported_board_size;
 	dcnn_evaluate_t             eval;
+	int  *global_var;
 } dcnn_t;
+
+
+static bool board_19x19(board_t *b)        {  return (board_rsize(b) == 19);  }
+static bool board_15x15(board_t *b)        {  return (board_rsize(b) == 15);  }
+//static bool board_13x13(board_t *b)      {  return (board_rsize(b) == 13);  }
+static bool board_13x13_and_up(board_t *b) {  return (board_rsize(b) >= 13);  }
+
+#ifdef DCNN_DETLEF
+static void detlef54_dcnn_eval(board_t *b, enum stone color, float result[]);
+static void detlef44_dcnn_eval(board_t *b, enum stone color, float result[]);
+#endif
+#ifdef DCNN_DARKFOREST
+static void darkforest_dcnn_eval(board_t *b, enum stone color, float result[]);
+#endif
+
+int darkforest_dcnn = 0;
 
 static dcnn_t dcnns[] = {
 #ifdef DCNN_DETLEF
 {  "detlef",     "Detlef's 54%", "detlef54.prototxt",  "detlef54.trained", 19, board_13x13_and_up,   detlef54_dcnn_eval },
 {  "detlef54",   "Detlef's 54%", "detlef54.prototxt",  "detlef54.trained", 19, board_13x13_and_up,   detlef54_dcnn_eval },
 {  "detlef44",   "Detlef's 44%", "detlef44.prototxt",  "detlef44.trained", 19, board_19x19,          detlef44_dcnn_eval },
+#endif
+#ifdef DCNN_DARKFOREST
+{  "df",         "Darkforest",   "df2.prototxt",       "df2.trained",      19, board_19x19,          darkforest_dcnn_eval,  &darkforest_dcnn },
+{  "darkforest", "Darkforest",   "df2.prototxt",       "df2.trained",      19, board_19x19,          darkforest_dcnn_eval,  &darkforest_dcnn },
+{  "df",         "Darkforest",   "df2_15x15.prototxt", "df2.trained",      15, board_15x15,          darkforest_dcnn_eval,  &darkforest_dcnn },
+{  "darkforest", "Darkforest",   "df2_15x15.prototxt", "df2.trained",      15, board_15x15,          darkforest_dcnn_eval,  &darkforest_dcnn },
 #endif
 {  0, }
 };
@@ -55,6 +68,8 @@ set_dcnn(char *name)
 		    !strcmp(name, dcnns[i].model_filename) ||
 		    !strcmp(name, dcnns[i].weights_filename)) {
 			dcnn = &dcnns[i];
+			if (dcnn->global_var)
+				*dcnn->global_var = 1;
 			return;
 		}
 	
@@ -188,10 +203,135 @@ detlef44_dcnn_eval(board_t *b, enum stone color, float result[])
 
 	caffe_get_data((float*)data, result, size, 2, size);
 }
-
-/********************************************************************************************************/
 #endif /* DCNN_DETLEF */
 
+
+#ifdef DCNN_DARKFOREST
+/********************************************************************************************************/
+/* Darkforest dcnn */
+
+/* 12 layers, 25 input planes, trained to predict next 3 moves:
+ * https://github.com/facebookresearch/darkforestGo
+ * https://arxiv.org/abs/1511.06410 */
+
+static void
+df_distance_transform(float *arr, int size)
+{
+	// First dimension.
+	for (int j = 0; j < size; j++) {
+		for (int i = 1; i < size; i++) 
+			arr[i*size + j] = MIN(arr[i*size + j], arr[(i-1)*size + j] + 1);
+		for (int i = size - 2; i >= 0; i--) 
+			arr[i*size + j] = MIN(arr[i*size + j], arr[(i+1)*size + j] + 1);
+	}
+	// Second dimension
+	for (int i = 0; i < size; i++) {
+		for (int j = 1; j < size; j++)
+			arr[i*size + j] = MIN(arr[i*size + j], arr[i*size + (j-1)] + 1);
+		for (int j = size - 2; j >= 0; j--) 
+			arr[i*size + j] = MIN(arr[i*size+j], arr[i * size + (j+1)] + 1);
+	}
+}
+
+static void
+df_get_distance_map(board_t *b, enum stone color, float *data) 
+{
+	int size = board_rsize(b);
+	for (int i = 0; i < size; i++) {
+		for (int j = 0; j < size; j++) {
+			coord_t c = coord_xy(i+1, j+1);
+			if (board_at(b, c) == color)
+				data[i*size + j] = 0;
+			else
+				data[i*size + j] = 10000;
+		}
+	}
+	df_distance_transform(data, size);
+}
+
+static float
+df_board_history_decay(board_t *b, coord_t coord, enum stone color)
+{
+	int v = 0;
+	if (board_at(b, coord) == color || board_at(b, coord) == S_NONE)
+		v = b->moveno[coord];
+	return exp(0.1 * (v - (b->moves+1)));
+}
+
+static void
+darkforest_dcnn_eval(board_t *b, enum stone color, float result[])
+{
+	enum stone other_color = stone_other(color);
+	int size = board_rsize(b);
+	float data[25][size][size];
+	memset(data, 0, sizeof(data));
+	
+	float our_dist[size * size];
+	float opponent_dist[size * size];
+	df_get_distance_map(b, color, our_dist);
+	df_get_distance_map(b, other_color, opponent_dist);
+	
+	for (int y = 0; y < size; y++)
+	for (int x = 0; x < size; x++) {
+		int p = size * y + x;
+		coord_t c = coord_xy(x+1, y+1);
+		group_t g = group_at(b, c);
+		enum stone bc = board_at(b, c);
+		int libs = board_group_info(b, g).libs;
+		if (libs > 3) libs = 3;
+			
+		/* plane 0: our stones with 1 liberty */
+		/* plane 1: our stones with 2 liberties */
+		/* plane 2: our stones with 3+ liberties */
+		if (bc == color)              data[libs-1][y][x] = 1;
+
+		/* planes 3, 4, 5: opponent liberties */
+		if (bc == other_color)        data[3+libs-1][y][x] = 1;
+
+		/* plane 6: our simple ko  (but actually, our stones. typo ?) */
+		if (bc == color)              data[6][y][x] = 1;
+
+		/* plane 7: our stones. */
+		if (bc == color)              data[7][y][x] = 1;
+
+		/* plane 8: opponent stones. */
+		if (bc == other_color)        data[8][y][x] = 1;
+
+		/* plane 9: empty spots. */
+		if (bc == S_NONE)             data[9][y][x] = 1;
+
+		/* plane 10: our history */
+		/* FIXME -1 for komi */
+		data[10][y][x] = df_board_history_decay(b, c, color);
+			
+		/* plane 11: opponent history */
+		/* FIXME -1 for komi */
+		data[11][y][x] = df_board_history_decay(b, c, other_color);
+
+		/* plane 12: border */
+		if (!x || !y || x == size-1 || y == size-1)
+			data[12][y][x] = 1.0;
+		
+		/* plane 13: position mask - distance from corner */
+		float m = (float)(size+1) / 2;
+		data[13][y][x] = expf(-0.5 * ((x-m)*(x-m) + (y-m)*(y-m)));
+
+		/* plane 14: closest color is ours */
+		data[14][y][x] = (our_dist[p] < opponent_dist[p]);
+
+		/* plane 15: closest color is opponent */
+		data[15][y][x] = (opponent_dist[p] < our_dist[p]);
+
+		/* planes 16-24: encode rank - set 9th plane for 9d */
+		data[24][y][x] = 1.0;
+	}
+
+	caffe_get_data((float*)data, result, size, 25, size);
+}
+#endif /* DCNN_DARKFOREST */
+
+
+/********************************************************************************************************/
 
 void
 get_dcnn_best_moves(board_t *b, float *r, coord_t *best_c, float *best_r, int nbest)

--- a/dcnn.c
+++ b/dcnn.c
@@ -59,39 +59,29 @@ detlef54_dcnn_eval(board_t *b, enum stone color, float result[])
 	assert(dcnn_supported_board_size(b));
 
 	int size = board_rsize(b);
-	int dsize = 13 * size * size;
-	float *data = calloc2(dsize, float);
+	float data[13][size][size];
+	memset(data, 0, sizeof(data));
 
 	for (int x = 0; x < size; x++)
 	for (int y = 0; y < size; y++) {
-		int p = y * size + x;
-
 		coord_t c = coord_xy(x+1, y+1);
 		group_t g = group_at(b, c);
 		enum stone bc = board_at(b, c);
 		int libs = board_group_info(b, g).libs - 1;
 		if (libs > 3) libs = 3;
-		if (bc == S_NONE)
-			data[       8*size*size + p] = 1.0;
-		else if (bc == color)
-			data[(0+libs)*size*size + p] = 1.0;
-		else if (bc == stone_other(color))
-			data[(4+libs)*size*size + p] = 1.0;
 		
-		if (c == last_move(b).coord)
-			data[9*size*size + p] = 1.0;
-		else if (c == last_move2(b).coord)
-			data[10*size*size + p] = 1.0;
-		else if (c == last_move3(b).coord)
-			data[11*size*size + p] = 1.0;
-		else if (c == last_move4(b).coord)
-			data[12*size*size + p] = 1.0;
+		if (bc == S_NONE)                    data[8][y][x] = 1.0;
+		else if (bc == color)                data[0+libs][y][x] = 1.0;
+		else if (bc == stone_other(color))   data[4+libs][y][x] = 1.0;
+		
+		if (c == last_move(b).coord)	     data[9][y][x] = 1.0;
+		else if (c == last_move2(b).coord)   data[10][y][x] = 1.0;
+		else if (c == last_move3(b).coord)   data[11][y][x] = 1.0;
+		else if (c == last_move4(b).coord)   data[12][y][x] = 1.0;
 	}
 
-	caffe_get_data(data, result, 13, size);
-	free(data);
+	caffe_get_data((float*)data, result, 13, size);
 }
-
 
 void
 get_dcnn_best_moves(board_t *b, float *r, coord_t *best_c, float *best_r, int nbest)

--- a/dcnn.h
+++ b/dcnn.h
@@ -6,6 +6,11 @@
 
 #define DCNN_BEST_N 20
 
+/* Choose which dcnn to load */
+void set_dcnn(char *name);
+void list_dcnns(void);
+int dcnn_default_board_size(void);
+
 /* Ensure / disable dcnn */
 void require_dcnn(void);
 void disable_dcnn(void);
@@ -34,6 +39,8 @@ coord2dcnn_idx(coord_t c)
 #else
 
 
+#define set_dcnn(n)     die("dcnn required but not compiled in, aborting.\n")
+#define dcnn_default_board_size()  19
 #define disable_dcnn()  ((void)0)
 #define require_dcnn()  die("dcnn required but not compiled in, aborting.\n")
 #define using_dcnn(b)   0

--- a/dcnn.h
+++ b/dcnn.h
@@ -25,6 +25,8 @@ void print_dcnn_best_moves(board_t *b, coord_t *best_c, float *best_r, int nbest
 /* Convert board coord to dcnn data index */
 static inline int coord2dcnn_idx(coord_t c);
 
+extern int darkforest_dcnn;
+
 
 static inline int
 coord2dcnn_idx(coord_t c)

--- a/gogui.c
+++ b/gogui.c
@@ -464,7 +464,7 @@ static engine_t *dcnn_engine = NULL;
 enum parse_code
 cmd_gogui_dcnn_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn");  return P_OK;  }
+	if (!using_dcnn(b)) {  gtp_error(gtp, "Not using dcnn");  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
 	
 	enum stone color = S_BLACK;
@@ -478,7 +478,7 @@ cmd_gogui_dcnn_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 enum parse_code
 cmd_gogui_dcnn_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn");  return P_OK;  }
+	if (!using_dcnn(b)) {  gtp_error(gtp, "Not using dcnn");  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
 	
 	enum stone color = S_BLACK;
@@ -492,7 +492,7 @@ cmd_gogui_dcnn_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 enum parse_code
 cmd_gogui_dcnn_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	if (!using_dcnn(b)) {  gtp_reply(gtp, "TEXT Not using dcnn");  return P_OK;  }
+	if (!using_dcnn(b)) {  gtp_error(gtp, "Not using dcnn");  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
 	
 	enum stone color = S_BLACK;

--- a/t-unit/Makefile
+++ b/t-unit/Makefile
@@ -59,10 +59,10 @@ test_gtp: FORCE
 		cat gtp_test.gtp | grep -v dcnn >tmp.gtp; \
 	 fi
         # Check test suite is not missing some commands...
-	@echo list_commands | ../pachi -d0 --nodcnn --nopatterns --nojoseki | sed -e 's/^= //' | \
+	@echo list_commands | ../pachi -d0 | sed -e 's/^= //' | \
            while read f; do  if ! grep -q "^\(# *\|\)$$f" tmp.gtp  ; then \
-               echo "t-unit/tmp.gtp: command $$f not tested, fixme !"; exit 1 ; fi; done
-	@if ./gtp_check ../pachi --nodcnn -t =1000 -o /dev/null < tmp.gtp;  then \
+               echo "t-unit/gtp_test.gtp: command $$f not tested, fixme !"; exit 1 ; fi; done
+	@if ./gtp_check ../pachi -t =1000 -o /dev/null < tmp.gtp;  then \
 	   echo "OK"; else  echo "FAILED"; exit 1;  fi
 
 FORCE:

--- a/t-unit/gtp_test.gtp
+++ b/t-unit/gtp_test.gtp
@@ -21,6 +21,11 @@ lz-genmove_analyze w 10
 kgs-genmove_cleanup b
 
 clear_board
+predict b a1
+clear_board
+pachi-predict b a1
+
+clear_board
 set_free_handicap d4 q16
 
 clear_board
@@ -40,52 +45,249 @@ time_left b 30 5
 
 kgs-chat game user winrate
 
-boardsize 9
+kgs-rules japanese
+boardsize 19
 clear_board
-komi 7.5
-play b C4
-play w E5
-play b C6
-play w E6
-play b D3
-play w F4
-play b D7
-play w E7
-play b E4
-play w E3
-play b D4
-play w F3
-play b D5
-play w F5
-play b D6
-play w E8
-play b D2
-play w D8
-play b C8
-play w E2
-play b D9
-play w H5
-play b E1
-play w G2
-play b E9
-play w F8
-play b F9
-play w G9
-play b C9
-play w G8
-play b G1
-play w H2
-play b F1
-play w J2
-play b H1
-play w G3
-play b J1
-play w G6
-play b D1
-play w H4
-play b J9
-play w PASS
-play b J7
+komi 0.5
+set_free_handicap q16 d4 q4
+play W d16
+play B k4
+play W c6
+play B g4
+play W o17
+play B r13
+play W q17
+play B r16
+play W r6
+play B n4
+play W r4
+play B q5
+play W r5
+play B q6
+play W q7
+play B p7
+play W q8
+play B o8
+play W o9
+play B n8
+play W p8
+play B r10
+play W n9
+play B m8
+play W q3
+play B p3
+play W p6
+play B p4
+play W o7
+play B n7
+play W n6
+play B m6
+play W m5
+play B n5
+play W o6
+play B l5
+play W e13
+play B m4
+play W p16
+play B p15
+play W o15
+play B p14
+play W c9
+play B p10
+play W p9
+play B q10
+play W o14
+play B o13
+play W n13
+play B o12
+play W r17
+play B s16
+play W s2
+play B q2
+play W r3
+play B p2
+play W s17
+play B e6
+play W c4
+play B d3
+play W c3
+play B d5
+play W c5
+play B s7
+play W s8
+play B r8
+play W r7
+play B r9
+play W s6
+play B s9
+play W t7
+play B f17
+play W h17
+play B g18
+play W d2
+play B e2
+play W j18
+play B d18
+play W c2
+play B f3
+play W c17
+play B c18
+play W b18
+play B d17
+play W c16
+play B e16
+play W e15
+play B f15
+play W f14
+play B g15
+play W h15
+play B g14
+play W h14
+play B f13
+play W e14
+play B h13
+play W j13
+play B f12
+play W h12
+play B g13
+play W e12
+play B h16
+play W j16
+play B g16
+play W m9
+play B l8
+play W j11
+play B e11
+play W d11
+play B e10
+play W b15
+play B d10
+play W c10
+play B e8
+play W g11
+play B f11
+play W k11
+play B g10
+play W h10
+play B g9
+play W k17
+play B h9
+play W t16
+play B t15
+play W t17
+play B s15
+play W k9
+play B k8
+play W c8
+play B l9
+play W l10
+play B j9
+play W n12
+play B n11
+play W m11
+play B n10
+play W o10
+play B o11
+play W m12
+play B m10
+play W j15
+play B k10
+play W l11
+play B j10
+play W h18
+play B g17
+play W b19
+play B c19
+play W b17
+play B h11
+play W p13
+play B p11
+play W r14
+play B q15
+play W s14
+play B q13
+play W g19
+play B f19
+play W e1
+play B f1
+play W r2
+play B g12
+play W j12
+play B s13
+play W h19
+play B e18
+play W d1
+play B d6
+play W f2
+play B g2
+play W p18
+play B o5
+play W c7
+play B d8
+play W t9
+play B t10
+play W t8
+play B s10
+play W d7
+play B e7
+play W r1
+play B q1
+play W d9
+play B e9
+play W q9
+play B p5
+play W p7
+play B p12
+play W c12
+play B n16
+play W o16
+play B n17
+play W k12
+play B n18
+play W o18
+play B n15
+play W l18
+play B n14
+play W m14
+play B m15
+play W r18
+play B l14
+play W k15
+play B m13
+play W l15
+play B k14
+play W j14
+play B l16
+play W k16
+play B l17
+play W l19
+play B m18
+play W b2
+play B l13
+play W k19
+play B b11
+play W c11
+play B b12
+play W b10
+play B b13
+play W c13
+play B b14
+play W c14
+play B a15
+play W a16
+play B a14
+play W n19
+play B m19
+play W o19
+play B q19
+play W r19
+play B t5
+play W t4
+play B s4
+play W t6
+play B t3
+play W t2
+play B pass
 
 score_est
 pachi-score_est
@@ -95,10 +297,6 @@ final_status_list seki
 final_status_list alive
 final_status_list black_territory
 final_status_list white_territory
-
-
-predict w h9
-pachi-predict b a1
 
 tunit sar b J8 0
 pachi-tunit sar b J8 0


### PR DESCRIPTION
Support multiple dcnns:

`pachi --list-dcnn`    List supported networks.
`pachi --dcnn=name`    Choose network to use (Detlef's 54% dcnn by default).

Merged Detlef 44% and Darkforest branches.

See [Pachi Networks](https://github.com/pasky/pachi/releases/tag/pachi_networks) to download extra networks.