### PR TITLE
Increasing the size of the tree displayed with reporting=json

### DIFF
--- a/uct/walk.c
+++ b/uct/walk.c
@@ -185,7 +185,7 @@ uct_progress_json(FILE *fh, uct_t *u, tree_t *t, enum stone color, int playouts,
 	}
 
 	/* Best candidates */
-	int cans = 4;
+	int cans = 20;
 	tree_node_t *can[cans];
 	memset(can, 0, sizeof(can));
 	tree_node_t *best = t->root->children;
@@ -202,8 +202,8 @@ uct_progress_json(FILE *fh, uct_t *u, tree_t *t, enum stone color, int playouts,
 		/* Best sequence */
 		fprintf(fh, "[");
 		best = can[cans];
-		for (int depth = 0; depth < 4; depth++) {
-			if (!best || best->u.playouts < 25) break;
+		for (int depth = 0; depth < 20; depth++) {
+			if (!best || best->u.playouts < 1) break;
 			fprintf(fh, "%s{\"%s\": [%.3f, %i]}", depth > 0 ? "," : "",
 				coord2sstr(best->coord),
 				tree_node_get_value(t, 1, best->u.value),


### PR DESCRIPTION
Hi!
I propose to increase the size (width and depth) of the tree displayed with **reporting=json**:

+ width from 4 to 20
+ depth from 4 to 20
+ minimum number of playout from 25 to 1

The idea is that now, since Pachi json reporting already displays the number of playout for each move of the PV, so it's up to the program reading the json output to decide what move to be conserved or not based on their own criteria. The program is free to apply a 25 playout filter, or more playout, or less. Same for the number of variations.