### PR TITLE
Add DESTDIR to Makefile for easier packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,18 +324,18 @@ distribute: FORCE
 
 # install-recursive?
 install: distribute
-	$(INSTALL) -d $(BINDIR)
-	$(INSTALL) distribute/pachi $(BINDIR)/
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) distribute/pachi $(DESTDIR)$(BINDIR)/
 
 install-data:
-	$(INSTALL) -d $(DATADIR)
-	@for file in $(DATAFILES); do                               \
-		if [ -f $$file ]; then                              \
-                        echo $(INSTALL) $$file $(DATADIR)/;         \
-			$(INSTALL) $$file $(DATADIR)/;              \
-		else                                                \
-			echo "WARNING: $$file datafile is missing"; \
-                fi                                                  \
+	$(INSTALL) -d $(DESTDIR)$(DATADIR)
+	@for file in $(DATAFILES); do                         \
+		if [ -f $$file ]; then                            \
+			echo $(INSTALL) $$file $(DESTDIR)$(DATADIR)/; \
+			$(INSTALL) $$file $(DESTDIR)$(DATADIR)/;      \
+		else                                              \
+			echo "WARNING: $$file datafile is missing";   \
+		fi                                                \
 	done;
 
 # Generic clean rule is in Makefile.lib


### PR DESCRIPTION
Add DESTDIR as described in https://www.gnu.org/prep/standards/html_node/DESTDIR.html for easier packaging (without having to patch that into the Makefile).

It's optional and does nothing if DESTDIR is not set.

(Also fixed some spaces to tabs that seem to have slipped in)