### PR TITLE
Accurate Scoring

### DIFF
--- a/Makefile.msys2
+++ b/Makefile.msys2
@@ -9,7 +9,7 @@ WIN_HAVE_NO_REGEX_SUPPORT=1
 
 COMMON_FLAGS += $(TUNE)
 LDFLAGS      := -pthread -L$(CAFFE_PREFIX)/bin -L$(MINGW_PREFIX)/bin
-SYS_LIBS     := -lws2_32
+SYS_LIBS     := -lws2_32 -lshlwapi
 CXXFLAGS     += -I$(MINGW_PREFIX)/include/OpenBLAS
 
 # Enable mingw-w64 C99 printf() / scanf() layer ?
@@ -44,7 +44,7 @@ ifdef MSYS2_STATIC		# Static build, good luck
 
 	DCNN_LIBS := -Wl,-Bstatic $(CAFFE_STATIC_LIB)  \
 		     -lboost_system-mt -lboost_thread-mt -lopenblas $(HDF5_LIBS) -lgflags_static \
-		     -lglog -lprotobuf -lstdc++ -lwinpthread $(SYS_LIBS)   -Wl,-Bdynamic -lshlwapi
+		     -lglog -lprotobuf -lstdc++ -lwinpthread -lws2_32   -Wl,-Bdynamic -lshlwapi
 
         # glog / gflags headers really shouldn't __declspec(dllexport) symbols for us,
         # static linking will fail with undefined __imp__xxx symbols.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ will remain the same:
 * `pachi -t =5000:15000       `       kgs 2d
 * `pachi -t =5000 --nodcnn      `     kgs 3k (mcts only).
 
+**KGS**
+
+Use `pachi --kgs` when playing on KGS. See [kgsgtp.conf](kgs/kgsgtp-pachi.conf?raw=true) for example.
+
 **Other Options**
 
 * `pachi resign_threshold=0.25`     Resign when winrate < 25% (default: 20%).

--- a/board.c
+++ b/board.c
@@ -717,19 +717,26 @@ board_score(board_t *b, int scores[S_MAX])
 	return score;
 }
 
-void
-board_print_official_ownermap(board_t *b, int *final_ownermap)
+static void
+printhook(board_t *board, coord_t c, strbuf_t *buf, void *data)
 {
-	int size = board_rsize(b);
-	for (int y = size; y >= 1; y--) {
-		for (int x = 1; x <= size; x++) {
-			coord_t c = coord_xy(x, y);
-			char *chars = ".XO:";
-			fprintf(stderr, "%c ", chars[final_ownermap[c]]);
-		}
-		fprintf(stderr, "\n");
-	}
-	fprintf(stderr, "\n");
+	int *ownermap = (int*)data;
+	
+	if (c == pass)  /* Stuff to display in header */
+		return;
+	
+        const char chr[] = ".XO:";
+        sbprintf(buf, "%c ", chr[ownermap[c]]);
+}
+
+void
+board_print_official_ownermap(board_t *b, move_queue_t *dead)
+{
+	int dame, seki;
+	int ownermap[board_max_coords(b)];
+	board_official_score_details(b, dead, &dame, &seki, ownermap, NULL);
+
+        board_print_custom(b, stderr, printhook, ownermap);
 }
 
 /* Official score after removing dead groups and Tromp-Taylor counting.

--- a/board.c
+++ b/board.c
@@ -813,7 +813,7 @@ board_official_score_color(board_t *b, move_queue_t *dead, enum stone color)
 }
 
 bool
-board_set_rules(board_t *board, char *name)
+board_set_rules(board_t *board, const char *name)
 {
 	if (!strcasecmp(name, "japanese"))
 		board->rules = RULES_JAPANESE;

--- a/board.c
+++ b/board.c
@@ -805,6 +805,19 @@ board_official_score(board_t *b, move_queue_t *dead)
 	return board_official_score_details(b, dead, &dame, &seki, ownermap, NULL);
 }
 
+/* Returns static buffer */
+char *
+board_official_score_str(board_t *b, move_queue_t *dead)
+{
+	static char buf[32];
+	floating_t score = board_official_score(b, dead);
+	
+	if      (score == 0)  sprintf(buf, "0");
+	else if (score > 0)   sprintf(buf, "W+%.1f", score);
+	else                  sprintf(buf, "B+%.1f", -score);
+	return buf;
+}
+
 floating_t
 board_official_score_color(board_t *b, move_queue_t *dead, enum stone color)
 {

--- a/board.h
+++ b/board.h
@@ -364,6 +364,7 @@ floating_t board_fast_score(board_t *board);
 floating_t board_score(board_t *b, int scores[S_MAX]);
 /* Tromp-Taylor scoring, assuming given groups are actually dead. */
 floating_t board_official_score(board_t *b, move_queue_t *dead);
+char*      board_official_score_str(board_t *b, move_queue_t *dead);
 floating_t board_official_score_color(board_t *b, move_queue_t *dead, enum stone color);
 floating_t board_official_score_details(board_t *b, move_queue_t *dead, int *dame, int *seki, int *ownermap, struct ownermap *po);
 void       board_print_official_ownermap(board_t *b, move_queue_t *dead);

--- a/board.h
+++ b/board.h
@@ -370,7 +370,7 @@ void       board_print_official_ownermap(board_t *b, move_queue_t *dead);
 
 /* Set board rules according to given string. Returns false in case
  * of unknown ruleset name. */
-bool board_set_rules(board_t *b, char *name);
+bool board_set_rules(board_t *b, const char *name);
 const char *rules2str(enum rules rules);
 
 

--- a/board.h
+++ b/board.h
@@ -366,7 +366,7 @@ floating_t board_score(board_t *b, int scores[S_MAX]);
 floating_t board_official_score(board_t *b, move_queue_t *dead);
 floating_t board_official_score_color(board_t *b, move_queue_t *dead, enum stone color);
 floating_t board_official_score_details(board_t *b, move_queue_t *dead, int *dame, int *seki, int *ownermap, struct ownermap *po);
-void       board_print_official_ownermap(board_t *b, int *final_ownermap);
+void       board_print_official_ownermap(board_t *b, move_queue_t *dead);
 
 /* Set board rules according to given string. Returns false in case
  * of unknown ruleset name. */

--- a/distributed/distributed.c
+++ b/distributed/distributed.c
@@ -420,7 +420,7 @@ scmp(const void *p1, const void *p2)
 }
 
 static void
-distributed_dead_group_list(engine_t *e, board_t *b, move_queue_t *mq)
+distributed_dead_groups(engine_t *e, board_t *b, move_queue_t *mq)
 {
 	protocol_lock();
 
@@ -515,7 +515,7 @@ engine_distributed_init(engine_t *e, char *arg, board_t *b)
 		"Anyone can send me 'winrate' in private chat to get my assessment of the position.";
 	e->notify = distributed_notify;
 	e->genmove = distributed_genmove;
-	e->dead_group_list = distributed_dead_group_list;
+	e->dead_groups = distributed_dead_groups;
 	e->chat = distributed_chat;
 	e->data = dist;
 	// Keep the threads and the open socket connections:

--- a/engine.c
+++ b/engine.c
@@ -232,7 +232,7 @@ gnugo_dead_groups(gtp_t *gtp, board_t *b, move_queue_t *q)
 	if      (b->rules == RULES_JAPANESE)  rules = "--japanese-rules";
 	else if (b->rules == RULES_CHINESE)   rules = "--chinese-rules";
 	else die("rules must be japanese or chinese when scoring with gnugo\n");
-	snprintf(cmd, sizeof(cmd), "gnugo --mode gtp %s < %s > %s", rules, file_in, file_out);
+	snprintf(cmd, sizeof(cmd), "%s --mode gtp %s < %s > %s", gnugo_exe, rules, file_in, file_out);
 	if (DEBUGL(4))  fprintf(stderr, "cmd: '%s'\n", cmd);
 	double time_start = time_now();
 	if (system(cmd) != 0)  die("couldn't run gnugo\n");
@@ -282,6 +282,7 @@ print_dead_groups(board_t *b, move_queue_t *dead)
 	}
 }
 
+/* Ask engine for dead stones, or use gnugo if --accurate-scoring */
 void
 engine_dead_groups(engine_t *e, gtp_t *gtp, board_t *b, move_queue_t *q)
 {
@@ -290,7 +291,7 @@ engine_dead_groups(engine_t *e, gtp_t *gtp, board_t *b, move_queue_t *q)
 	/* Tell engine to stop pondering, the game is probably over. */
 	if (e->stop)  e->stop(e);
 	
-	if (true)  // XXX
+	if (gtp->accurate_scoring)
 		gnugo_dead_groups(gtp, b, q);
 	else
 		if (e->dead_groups)  e->dead_groups(e, b, q);

--- a/engine.c
+++ b/engine.c
@@ -202,10 +202,9 @@ gnugo_dead_groups(gtp_t *gtp, board_t *b, move_queue_t *q)
 		
 	/* Generate gtp commands for game */
 	
-	// XXX portable way to find temp dir ?
-	char file_in[] = "/tmp/pachi.XXXXXX";
-	int fd = mkstemp(file_in);	if (fd == -1)  fail("mkstemp");		
-	FILE *f = fdopen(fd, "w");	if (!f)        fail("fdopen");
+	char file_in[1024] = "pachi.XXXXXX";
+	int fd = pachi_mkstemp(file_in, sizeof(file_in));	if (fd == -1)  fail("mkstemp");
+	FILE *f = fdopen(fd, "w");				if (!f)        fail("fdopen");
 	fprintf(f, "boardsize %i\n", board_rsize(b));
 	fprintf(f, "clear_board\n");
 	fprintf(f, "komi %.1f\n", b->komi);
@@ -225,8 +224,8 @@ gnugo_dead_groups(gtp_t *gtp, board_t *b, move_queue_t *q)
 	
 	/* And fire up GnuGo on it */
 	
-	char file_out[] = "/tmp/pachi.XXXXXX";
-	fd = mkstemp(file_out);	    if (fd == -1)  fail("mkstemp");
+	char file_out[1024] = "pachi.XXXXXX";
+	fd = pachi_mkstemp(file_out, sizeof(file_out));		if (fd == -1)  fail("mkstemp");
 	close(fd);  fd = -1;
 	char *rules;
 	if      (b->rules == RULES_JAPANESE)  rules = "--japanese-rules";

--- a/engine.c
+++ b/engine.c
@@ -188,6 +188,16 @@ engine_ownermap(engine_t *e, board_t *b)
 	return (e->ownermap ? e->ownermap(e, b) : NULL);
 }
 
+void
+engine_dead_groups(engine_t *e, gtp_t *gtp, board_t *b, move_queue_t *q)
+{
+	mq_init(q);
+	
+	if (e->dead_groups)  e->dead_groups(e, b, q);
+	/* else we return empty list - i.e. engine not supporting
+	 * this assumes all stones alive at the game end. */
+}
+
 /* For engines internal use, ensures optval is properly strdup'ed / freed
  * since engine may change it. Must be preserved for next engine reset. */
 bool

--- a/engine.c
+++ b/engine.c
@@ -1,5 +1,8 @@
 #define DEBUG
+#include <unistd.h>
+
 #include "engine.h"
+#include "debug.h"
 #include "pachi.h"
 
 
@@ -188,14 +191,113 @@ engine_ownermap(engine_t *e, board_t *b)
 	return (e->ownermap ? e->ownermap(e, b) : NULL);
 }
 
+/* Ask GnuGo for dead groups.
+ * GnuGo is really good at scoring finished games, does better than
+ * playouts which get tripped by some sekis in certain situations.
+ * Right now Pachi gets about 95% of games right, GnuGo 99%. */
+static void
+gnugo_dead_groups(gtp_t *gtp, board_t *b, move_queue_t *q)
+{
+	if (DEBUGL(3)) fprintf(stderr, "using gnugo for dead stones\n");
+		
+	/* Generate gtp commands for game */
+	
+	// XXX portable way to find temp dir ?
+	char file_in[] = "/tmp/pachi.XXXXXX";
+	int fd = mkstemp(file_in);	if (fd == -1)  fail("mkstemp");		
+	FILE *f = fdopen(fd, "w");	if (!f)        fail("fdopen");
+	fprintf(f, "boardsize %i\n", board_rsize(b));
+	fprintf(f, "clear_board\n");
+	fprintf(f, "komi %.1f\n", b->komi);
+	/* don't bother with handicap, only care about dead stones */		
+	for (int i = 0; i < gtp->moves; i++)
+		fprintf(f, "play %c %s\n", stone2str(gtp->move[i].color)[0], coord2str(gtp->move[i].coord));
+	fprintf(f, "final_status_list dead\n");
+	fclose(f);  f = NULL;  fd = -1;
+
+	char cmd[256];
+	if (DEBUGL(4)) {
+		fprintf(stderr, "---------------- in -----------------\n");
+		snprintf(cmd, sizeof(cmd), "cat %s 1>&2", file_in);
+		if (system(cmd) != 0)		warning("system(%s) failed\n", cmd);
+		fprintf(stderr, "-------------------------------------\n");
+	}
+	
+	/* And fire up GnuGo on it */
+	
+	char file_out[] = "/tmp/pachi.XXXXXX";
+	fd = mkstemp(file_out);	    if (fd == -1)  fail("mkstemp");
+	close(fd);  fd = -1;
+	char *rules;
+	if      (b->rules == RULES_JAPANESE)  rules = "--japanese-rules";
+	else if (b->rules == RULES_CHINESE)   rules = "--chinese-rules";
+	else die("rules must be japanese or chinese when scoring with gnugo\n");
+	snprintf(cmd, sizeof(cmd), "gnugo --mode gtp %s < %s > %s", rules, file_in, file_out);
+	if (DEBUGL(4))  fprintf(stderr, "cmd: '%s'\n", cmd);
+	double time_start = time_now();
+	if (system(cmd) != 0)  die("couldn't run gnugo\n");
+	if (DEBUGL(2)) fprintf(stderr, "gnugo dead stones in %.1fs\n", time_now() - time_start);
+
+	if (DEBUGL(4)) {
+		fprintf(stderr, "---------------- out -----------------\n");
+		snprintf(cmd, sizeof(cmd), "cat %s 1>&2", file_out);
+		if (system(cmd) != 0)		warning("system(%s) failed\n", cmd);
+		fprintf(stderr, "-------------------------------------\n");
+	}
+	
+	/* Extract output */
+	
+	f = fopen(file_out, "r");      if (!f) fail("fopen");
+	char buf[256];
+	while (fgets(buf, sizeof(buf), f)) {
+		char *line = buf;
+		if (!strcmp(line, "= \n") || !strcmp(line, "\n"))  continue;
+		
+		if (line[0] == '?')          die("Eeeek, some gnugo commands failed !\n");
+		if (str_prefix("= ", line))  line += 2;  /* first line, eat up prefix */
+
+		/* One group per line, just get first coord. */
+		assert(line[0] && isalpha(line[0]));
+		coord_t c = str2coord_for(line, board_rsize(b));  assert(c != pass);
+		group_t g = group_at(b, c);   assert(g);
+		mq_add(q, g, 0);
+	}
+	fclose(f);  f = NULL;
+		
+	unlink(file_in);
+	unlink(file_out);
+}
+
+static void
+print_dead_groups(board_t *b, move_queue_t *dead)
+{
+	if (!DEBUGL(1)) return;
+
+	for (unsigned int i = 0; i < dead->moves; i++) {
+		fprintf(stderr, "  ");
+		foreach_in_group(b, dead->move[i]) {
+			fprintf(stderr, "%s ", coord2sstr(c));
+		} foreach_in_group_end;
+		fprintf(stderr, "\n");
+	}
+}
+
 void
 engine_dead_groups(engine_t *e, gtp_t *gtp, board_t *b, move_queue_t *q)
 {
 	mq_init(q);
+
+	/* Tell engine to stop pondering, the game is probably over. */
+	if (e->stop)  e->stop(e);
 	
-	if (e->dead_groups)  e->dead_groups(e, b, q);
+	if (true)  // XXX
+		gnugo_dead_groups(gtp, b, q);
+	else
+		if (e->dead_groups)  e->dead_groups(e, b, q);
 	/* else we return empty list - i.e. engine not supporting
 	 * this assumes all stones alive at the game end. */
+
+	print_dead_groups(b, q);  /* log output */
 }
 
 /* For engines internal use, ensures optval is properly strdup'ed / freed

--- a/engine.h
+++ b/engine.h
@@ -124,6 +124,7 @@ void engine_board_print(engine_t *e, board_t *b, FILE *f);
 void engine_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 		       coord_t *best_c, float *best_r, int nbest);
 struct ownermap* engine_ownermap(engine_t *e, board_t *b);
+/* Ask engine for dead stones, or use gnugo if --accurate-scoring */
 void engine_dead_groups(engine_t *e, gtp_t *gtp, board_t *b, move_queue_t *mq);
 
 /* Set/change engine option(s). May reset engine if needed.

--- a/engine.h
+++ b/engine.h
@@ -51,7 +51,7 @@ typedef void  (*engine_best_moves_t)(engine_t *e, board_t *b, time_info_t *ti, e
 				     coord_t *best_c, float *best_r, int nbest);
 typedef void (*engine_analyze_t)(engine_t *e, board_t *b, enum stone color, int start);
 typedef void (*engine_evaluate_t)(engine_t *e, board_t *b, time_info_t *ti, floating_t *vals, enum stone color);
-typedef void (*engine_dead_group_list_t)(engine_t *e, board_t *b, move_queue_t *mq);
+typedef void (*engine_dead_groups_t)(engine_t *e, board_t *b, move_queue_t *mq);
 typedef ownermap_t* (*engine_ownermap_t)(engine_t *e, board_t *b);
 typedef char *(*engine_result_t)(engine_t *e, board_t *b);
 typedef void (*engine_stop_t)(engine_t *e);
@@ -92,7 +92,7 @@ struct engine {
 						     * simulate each move from b->f[i] for time @ti, then set
 						     * 1-max(opponent_win_likelihood) in vals[i]. */
 
-	engine_dead_group_list_t dead_group_list;   /* One dead group per queued move (coord_t is (ab)used as group_t). */
+	engine_dead_groups_t     dead_groups;       /* One dead group per queued move (coord_t is (ab)used as group_t). */
 	engine_ownermap_t        ownermap;	    /* Return current ownermap, if engine supports it. */
 	engine_result_t          result;
 
@@ -124,6 +124,7 @@ void engine_board_print(engine_t *e, board_t *b, FILE *f);
 void engine_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 		       coord_t *best_c, float *best_r, int nbest);
 struct ownermap* engine_ownermap(engine_t *e, board_t *b);
+void engine_dead_groups(engine_t *e, gtp_t *gtp, board_t *b, move_queue_t *mq);
 
 /* Set/change engine option(s). May reset engine if needed.
  * New options are saved, so persist across engine resets.

--- a/gogui.c
+++ b/gogui.c
@@ -46,7 +46,7 @@ cmd_gogui_analyze_commands(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 		printf("gfx/Influence/gogui-influence\n");
 		printf("gfx/Score Est/gogui-score_est\n");
 	}
-	if (e->dead_group_list) {
+	if (e->dead_groups) {
 		printf("gfx/Final Score/gogui-final_score\n");
 		printf("plist/Dead Groups/final_status_list dead\n");
 		//printf("plist/Final Status List Dead/final_status_list dead\n");
@@ -407,8 +407,8 @@ cmd_gogui_final_score(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 		return P_OK;
 	}
 
-	move_queue_t q;  mq_init(&q);
-	if (e->dead_group_list)  e->dead_group_list(e, b, &q);
+	move_queue_t q;
+	engine_dead_groups(e, gtp, b, &q);
 	
 	int dame, seki;
 	int ownermap[board_max_coords(b)];

--- a/gtp.c
+++ b/gtp.c
@@ -330,9 +330,10 @@ cmd_kgs_rules(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 		if (DEBUGL(2))  fprintf(stderr, "ignored kgs-rules, using %s.\n", forced_ruleset);
 		return P_OK;
 	}
-
-	if (!board_set_rules(b, arg))
+	
+	if (!pachi_set_rules(gtp, b, arg))
 		gtp_error(gtp, "unknown rules");
+
 	return P_OK;
 }
 

--- a/gtp.c
+++ b/gtp.c
@@ -604,8 +604,8 @@ cmd_final_score(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 		return P_OK;
 	}
 
-	move_queue_t q;  mq_init(&q);
-	if (e->dead_group_list)  e->dead_group_list(e, b, &q);	
+	move_queue_t q;
+	engine_dead_groups(e, gtp, b, &q);
 	floating_t score = board_official_score(b, &q);
 
 	if (DEBUGL(1))  fprintf(stderr, "counted score %.1f\n", score);
@@ -663,10 +663,8 @@ cmd_pachi_getoption(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 static int
 cmd_final_status_list_dead(char *arg, board_t *b, engine_t *e, gtp_t *gtp)
 {
-	move_queue_t q;  mq_init(&q);
-	if (e->dead_group_list)  e->dead_group_list(e, b, &q);
-	/* else we return empty list - i.e. engine not supporting
-	 * this assumes all stones alive at the game end. */
+	move_queue_t q;
+	engine_dead_groups(e, gtp, b, &q);
 
 	for (unsigned int i = 0; i < q.moves; i++) {
 		foreach_in_group(b, q.move[i]) {
@@ -680,8 +678,8 @@ cmd_final_status_list_dead(char *arg, board_t *b, engine_t *e, gtp_t *gtp)
 static int
 cmd_final_status_list_alive(char *arg, board_t *b, engine_t *e, gtp_t *gtp)
 {
-	move_queue_t q;  mq_init(&q);
-	if (e->dead_group_list)  e->dead_group_list(e, b, &q);
+	move_queue_t q;
+	engine_dead_groups(e, gtp, b, &q);
 	int printed = 0;
 	
 	foreach_point(b) { // foreach_group, effectively

--- a/gtp.c
+++ b/gtp.c
@@ -607,13 +607,11 @@ cmd_final_score(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 
 	move_queue_t q;
 	engine_dead_groups(e, gtp, b, &q);
-	floating_t score = board_official_score(b, &q);
+	char *score_str = board_official_score_str(b, &q);
 
-	if (DEBUGL(1))  fprintf(stderr, "counted score %.1f\n", score);
-	
-	if      (score == 0) gtp_printf(gtp, "0\n");
-	else if (score > 0)  gtp_printf(gtp, "W+%.1f\n", score);
-	else                 gtp_printf(gtp, "B+%.1f\n", -score);
+	if (DEBUGL(1))  fprintf(stderr, "official score: %s\n", score_str);
+	gtp_printf(gtp, "%s\n", score_str);
+
 	return P_OK;
 }
 
@@ -673,6 +671,12 @@ cmd_final_status_list_dead(char *arg, board_t *b, engine_t *e, gtp_t *gtp)
 		} foreach_in_group_end;
 		gtp_printf(gtp, "\n");
 	}
+
+	if (DEBUGL(1)) {   /* show final score and board */
+		fprintf(stderr, "\nfinal score: %s\n", board_official_score_str(b, &q));
+		board_print_official_ownermap(b, &q);
+	}
+
 	return q.moves;
 }
 

--- a/gtp.h
+++ b/gtp.h
@@ -26,14 +26,15 @@ typedef struct
 
 	/* Global fields: */
 	int     played_games;
-	move_t  move[1500];     /* move history, for undo */
+	move_t  move[1500];        /* move history, for undo */
 	int     moves;
 	bool    undo_pending;
-	bool    noundo;           /* undo only allowed for pass */
+	bool    noundo;            /* undo only allowed for pass */
 	bool    kgs;
 	bool    analyze_running;
 	char*   custom_name;
 	char*   custom_version;
+	bool    accurate_scoring;  /* use gnugo to get dead stones */
 } gtp_t;
 
 #define gtp_arg_next(gtp) \

--- a/kgs/kgsgtp-pachi.conf
+++ b/kgs/kgsgtp-pachi.conf
@@ -2,10 +2,16 @@
 # On Windows, maybe you will need to replace ./pachi with pachi.exe.
 # If latest kgsGtp doesn't work for you try kgsGtp-3.5.11 instead.
 #
+# Recommended: Install GnuGo also, Pachi will use it to compute dead
+# stones at the end. Otherwise mcts does a good job but expect ~5% of
+# finished games to be scored incorrectly.
+# Either current directory or somewhere in your PATH should be fine.
+# 
 # For time settings you can either let Pachi play by kgs time settings
 # or pass -t option to override it: for example -t 5 for max 5s per move,
 # -t =5000 for fixed number of playouts etc.
 #
+
 engine=./pachi --kgs -t =5000:15000 resign_threshold=0.25,banner=%s.+Have+a+nice+game!
 name=KGSNAME
 password=PASSWORD

--- a/ownermap.c
+++ b/ownermap.c
@@ -135,7 +135,7 @@ groups_of_status(board_t *b, group_judgement_t *judge, enum gj_state s, move_que
 }
 
 void
-get_dead_groups(board_t *b, ownermap_t *ownermap, move_queue_t *dead, move_queue_t *unclear)
+ownermap_dead_groups(board_t *b, ownermap_t *ownermap, move_queue_t *dead, move_queue_t *unclear)
 {
 	enum gj_state gs_array[board_max_coords(b)];
 	group_judgement_t gj = { 0.67, gs_array };
@@ -225,7 +225,7 @@ board_position_final(board_t *b, ownermap_t *ownermap, char **msg)
 		return false;
 	
 	move_queue_t dead, unclear;
-	get_dead_groups(b, ownermap, &dead, &unclear);
+	ownermap_dead_groups(b, ownermap, &dead, &unclear);
 	
 	floating_t score_est = ownermap_score_est(b, ownermap);
 

--- a/ownermap.h
+++ b/ownermap.h
@@ -56,7 +56,7 @@ enum stone ownermap_color(ownermap_t *ownermap, coord_t c, floating_t thres);
 float ownermap_estimate_point(ownermap_t *ownermap, coord_t c);
 
 /* Find dead / unclear groups. */
-void get_dead_groups(board_t *b, ownermap_t *ownermap, move_queue_t *dead, move_queue_t *unclear);
+void ownermap_dead_groups(board_t *b, ownermap_t *ownermap, move_queue_t *dead, move_queue_t *unclear);
 /* Estimate status of stones on board based on ownermap stats. */
 void ownermap_judge_groups(board_t *b, ownermap_t *ownermap, group_judgement_t *judge);
 /* Add groups of given status to mq. */

--- a/pachi.c
+++ b/pachi.c
@@ -47,6 +47,7 @@ char *forced_ruleset = NULL;
 bool  nopassfirst = false;
 
 static char *gtp_port = NULL;
+static bool  accurate_scoring_wanted = false;
 
 static void
 network_init()
@@ -55,6 +56,33 @@ network_init()
 	int gtp_sock = -1;
 	if (gtp_port)		open_gtp_connection(&gtp_sock, gtp_port);
 #endif
+}
+
+bool
+pachi_set_rules(gtp_t *gtp, board_t *b, const char *name)
+{
+	if (gtp->accurate_scoring &&   /* GnuGo handles japaneses or chinese */
+	    b->rules != RULES_JAPANESE && b->rules != RULES_CHINESE)
+		die("--accurate-scoring: rules must be japanese or chinese\n");
+
+	return board_set_rules(b, name);
+}
+
+static void
+accurate_scoring_init(gtp_t *gtp, board_t *b) {
+	if (!accurate_scoring_wanted) {
+		if (DEBUGL(1)) fprintf(stderr, "Scoring: using mcts (possibly inaccurate)\n");
+		return;
+	}
+	
+	if (check_gnugo()) {
+		gtp->accurate_scoring = true;
+		pachi_set_rules(gtp, b, rules2str(b->rules));  /* recheck rules */
+		if (DEBUGL(1)) fprintf(stderr, "Scoring: using gnugo (accurate)\n");
+		return;
+	}
+	
+	die("Couldn't find gnugo, needed for --accurate-scoring. Aborting.\n");
 }
 
 static engine_init_t engine_inits[E_MAX] = { NULL };
@@ -103,13 +131,15 @@ usage()
 		" \n"
 		"Gameplay: \n"
 		"  -f, --fbook FBOOKFILE             use opening book \n"
-		"      --nopassfirst                 don't pass first (needed for kgs) \n"
+		"      --nopassfirst                 don't pass first (kgs) \n"
 		"      --noundo                      undo only allowed for pass \n"
 		"  -r, --rules RULESET               rules to use: (default chinese) \n"
 		"                                    japanese|chinese|aga|new_zealand|simplified_ing \n"
 		"KGS: \n"
+		"      --accurate-scoring            use GnuGo to compute dead stones at the end. otherwise expect \n"
+		"                                    ~5%% games to be scored incorrectly. recommended for online play \n"
 		"  -c, --chatfile FILE               set kgs chatfile \n"
-		"      --kgs                         use this when playing on kgs \n"
+		"      --kgs                         use this when playing on kgs, \n"
 		" \n"
 		"Logs / IO: \n"
 		"  -d, --debug-level LEVEL           set debug level \n"
@@ -182,54 +212,57 @@ show_version(FILE *s)
 }
 
 
-#define OPT_FUSEKI_TIME   256
-#define OPT_NODCNN        257
-#define OPT_DCNN          258
-#define OPT_VERBOSE_CAFFE 259
-#define OPT_COMPILE_FLAGS 260
-#define OPT_NOPASSFIRST   261
-#define OPT_PATTERNS      262
-#define OPT_NOPATTERNS    263
-#define OPT_JOSEKI        264
-#define OPT_NOJOSEKI      265
-#define OPT_FUSEKI        266
-#define OPT_NOUNDO        267
-#define OPT_KGS           268
-#define OPT_NAME          269
-#define OPT_LIST_DCNNS    270
+#define OPT_FUSEKI_TIME       256
+#define OPT_NODCNN            257
+#define OPT_DCNN              258
+#define OPT_VERBOSE_CAFFE     259
+#define OPT_COMPILE_FLAGS     260
+#define OPT_NOPASSFIRST       261
+#define OPT_PATTERNS          262
+#define OPT_NOPATTERNS        263
+#define OPT_JOSEKI            264
+#define OPT_NOJOSEKI          265
+#define OPT_FUSEKI            266
+#define OPT_NOUNDO            267
+#define OPT_KGS               268
+#define OPT_NAME              269
+#define OPT_LIST_DCNNS	      270
+#define OPT_ACCURATE_SCORING  271
+
 static struct option longopts[] = {
-	{ "fuseki-time", required_argument, 0, OPT_FUSEKI_TIME },
-	{ "fuseki",      required_argument, 0, OPT_FUSEKI },
-	{ "chatfile",    required_argument, 0, 'c' },
-	{ "compile-flags", no_argument,     0, OPT_COMPILE_FLAGS },
-	{ "debug-level", required_argument, 0, 'd' },
-	{ "dcnn",        optional_argument, 0, OPT_DCNN },
-	{ "engine",      required_argument, 0, 'e' },
-	{ "fbook",       required_argument, 0, 'f' },
-	{ "joseki",      no_argument,       0, OPT_JOSEKI },
+	{ "accurate-scoring",   no_argument,       0, OPT_ACCURATE_SCORING },	
+	{ "chatfile",           required_argument, 0, 'c' },
+	{ "compile-flags",      no_argument,       0, OPT_COMPILE_FLAGS },
+	{ "debug-level",        required_argument, 0, 'd' },
+	{ "dcnn",               optional_argument, 0, OPT_DCNN },
+	{ "engine",             required_argument, 0, 'e' },
+	{ "fbook",              required_argument, 0, 'f' },
+	{ "fuseki-time",        required_argument, 0, OPT_FUSEKI_TIME },
+	{ "fuseki",             required_argument, 0, OPT_FUSEKI },
 #ifdef NETWORK
-	{ "gtp-port",    required_argument, 0, 'g' },
-	{ "log-port",    required_argument, 0, 'l' },
+	{ "gtp-port",           required_argument, 0, 'g' },
+	{ "log-port",           required_argument, 0, 'l' },
 #endif
-	{ "help",        no_argument,       0, 'h' },
-	{ "kgs",         no_argument,       0, OPT_KGS },
+	{ "help",               no_argument,       0, 'h' },
+	{ "joseki",             no_argument,       0, OPT_JOSEKI },	
+	{ "kgs",                no_argument,       0, OPT_KGS },
 #ifdef DCNN
-	{ "list-dcnns",  no_argument,       0, OPT_LIST_DCNNS },
+	{ "list-dcnns",         no_argument,       0, OPT_LIST_DCNNS },
 #endif
-	{ "log-file",    required_argument, 0, 'o' },
-	{ "name",        required_argument, 0, OPT_NAME },
-	{ "nodcnn",      no_argument,       0, OPT_NODCNN },
-	{ "noundo",      no_argument,       0, OPT_NOUNDO },
-	{ "nojoseki",    no_argument,       0, OPT_NOJOSEKI },
-	{ "nopassfirst", no_argument,       0, OPT_NOPASSFIRST },
-	{ "nopatterns",  no_argument,       0, OPT_NOPATTERNS },
-	{ "patterns",    no_argument,       0, OPT_PATTERNS },
-	{ "rules",       required_argument, 0, 'r' },
-	{ "seed",        required_argument, 0, 's' },
-	{ "time",        required_argument, 0, 't' },
-	{ "unit-test",   required_argument, 0, 'u' },
-	{ "verbose-caffe", no_argument,     0, OPT_VERBOSE_CAFFE },
-	{ "version",     optional_argument, 0, 'v' },
+	{ "log-file",           required_argument, 0, 'o' },
+	{ "name",               required_argument, 0, OPT_NAME },
+	{ "nodcnn",             no_argument,       0, OPT_NODCNN },
+	{ "noundo",             no_argument,       0, OPT_NOUNDO },
+	{ "nojoseki",           no_argument,       0, OPT_NOJOSEKI },
+	{ "nopassfirst",        no_argument,       0, OPT_NOPASSFIRST },
+	{ "nopatterns",         no_argument,       0, OPT_NOPATTERNS },
+	{ "patterns",           no_argument,       0, OPT_PATTERNS },
+	{ "rules",              required_argument, 0, 'r' },
+	{ "seed",               required_argument, 0, 's' },
+	{ "time",               required_argument, 0, 't' },
+	{ "unit-test",          required_argument, 0, 'u' },
+	{ "verbose-caffe",      no_argument,       0, OPT_VERBOSE_CAFFE },
+	{ "version",            optional_argument, 0, 'v' },
 	{ 0, 0, 0, 0 }
 };
 
@@ -261,6 +294,9 @@ int main(int argc, char *argv[])
 	/* Leading ':' -> we handle error messages. */
 	while ((opt = getopt_long(argc, argv, ":c:e:d:Df:g:hl:o:r:s:t:u:v::", longopts, &option_index)) != -1) {
 		switch (opt) {
+			case OPT_ACCURATE_SCORING:
+				accurate_scoring_wanted = true;
+				break;
 			case 'c':
 				chatfile = strdup(optarg);
 				break;
@@ -309,8 +345,8 @@ int main(int argc, char *argv[])
 				require_joseki();
 				break;
 			case OPT_KGS:
-				gtp->kgs = true;       /* Show engine comment in version. */
-				nopassfirst = true;    /* --nopassfirst */
+				gtp->kgs = true;                /* Show engine comment in version. */
+				nopassfirst = true;             /* --nopassfirst */
 				break;
 #ifdef NETWORK
 			case 'l':
@@ -410,9 +446,10 @@ int main(int argc, char *argv[])
 
 	board_t *b = board_new(dcnn_default_board_size(), fbookfile);
 	if (forced_ruleset) {
-		if (!board_set_rules(b, forced_ruleset))  die("Unknown ruleset: %s\n", forced_ruleset);
+		if (!pachi_set_rules(gtp, b, forced_ruleset))  die("Unknown ruleset: %s\n", forced_ruleset);
 		if (DEBUGL(1))  fprintf(stderr, "Rules: %s\n", forced_ruleset);
 	}
+	accurate_scoring_init(gtp, b);
 
 	time_info_t ti[S_MAX];
 	ti[S_BLACK] = ti_default;

--- a/pachi.h
+++ b/pachi.h
@@ -2,6 +2,7 @@
 #define PACHI_PACHI_H
 
 #include <stdbool.h>
+#include "gtp.h"
 
 struct board;
 struct engine;
@@ -12,6 +13,8 @@ void pachi_done();
 /* Init engines */
 void pachi_engine_init(struct engine *e, int id, struct board *b);
 
+/* Set board rules */
+bool pachi_set_rules(gtp_t *gtp, board_t *b, const char *name);
 
 /* Pachi binary */
 extern char *pachi_exe;

--- a/uct/search.c
+++ b/uct/search.c
@@ -636,7 +636,7 @@ uct_search_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_al
 		move_queue_t unclear;
 		move_queue_t *dead = &u->dead_groups;
 		u->pass_moveno = b->moves + 1;
-		get_dead_groups(b, &u->ownermap, dead, &unclear);
+		ownermap_dead_groups(b, &u->ownermap, dead, &unclear);
 	}
 	return res;
 }
@@ -658,7 +658,7 @@ uct_pass_first(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, coor
 	/* Find dames left */
 	move_queue_t dead, unclear;
 	uct_mcowner_playouts(u, b, color);
-	get_dead_groups(b, &u->ownermap, &dead, &unclear);
+	ownermap_dead_groups(b, &u->ownermap, &dead, &unclear);
 	if (unclear.moves)  return false;
 	int final_ownermap[board_max_coords(b)];
 	int dame, seki;

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -109,7 +109,7 @@ uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, ch
 	/* Make sure enough playouts are simulated to get a reasonable dead group list. */
 	move_queue_t dead, unclear;	
 	uct_mcowner_playouts(u, b, color);
-	get_dead_groups(b, &u->ownermap, &dead, &unclear);
+	ownermap_dead_groups(b, &u->ownermap, &dead, &unclear);
 
 	bool check_score = !u->allow_losing_pass;
 
@@ -281,7 +281,7 @@ print_dead_groups(uct_t *u, board_t *b, move_queue_t *dead)
 
 
 static void
-uct_dead_group_list(engine_t *e, board_t *b, move_queue_t *dead)
+uct_dead_groups(engine_t *e, board_t *b, move_queue_t *dead)
 {
 	uct_t *u = (uct_t*)e->data;
 	
@@ -306,7 +306,7 @@ uct_dead_group_list(engine_t *e, board_t *b, move_queue_t *dead)
 	uct_mcowner_playouts(u, b, S_BLACK);
 	if (DEBUGL(2))  board_print_ownermap(b, stderr, &u->ownermap);
 
-	get_dead_groups(b, &u->ownermap, dead, NULL);
+	ownermap_dead_groups(b, &u->ownermap, dead, NULL);
 	print_dead_groups(u, b, dead);
 }
 
@@ -1494,7 +1494,7 @@ engine_uct_init(engine_t *e, board_t *b)
 	e->best_moves = uct_best_moves;
 	e->evaluate = uct_evaluate;
 	e->analyze = uct_analyze;
-	e->dead_group_list = uct_dead_group_list;
+	e->dead_groups = uct_dead_groups;
 	e->stop = uct_stop;
 	e->done = uct_done;
 	e->ownermap = uct_ownermap;

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -265,22 +265,6 @@ uct_chat(engine_t *e, board_t *b, bool opponent, char *from, char *cmd)
 }
 
 static void
-print_dead_groups(uct_t *u, board_t *b, move_queue_t *dead)
-{
-	fprintf(stderr, "dead groups (playing %s)\n", (u->my_color ? stone2str(u->my_color) : "???"));
-	if (!dead->moves)
-		fprintf(stderr, "  none\n");
-	for (unsigned int i = 0; i < dead->moves; i++) {
-		fprintf(stderr, "  ");
-		foreach_in_group(b, dead->move[i]) {
-			fprintf(stderr, "%s ", coord2sstr(c));
-		} foreach_in_group_end;
-		fprintf(stderr, "\n");
-	}
-}
-
-
-static void
 uct_dead_groups(engine_t *e, board_t *b, move_queue_t *dead)
 {
 	uct_t *u = (uct_t*)e->data;
@@ -296,7 +280,6 @@ uct_dead_groups(engine_t *e, board_t *b, move_queue_t *dead)
 	 * lead to wrong list. */
 	if (u->pass_moveno == b->moves || u->pass_moveno == b->moves - 1) {
 		memcpy(dead, &u->dead_groups, sizeof(*dead));
-		print_dead_groups(u, b, dead);
 		return;
 	}
 
@@ -307,7 +290,6 @@ uct_dead_groups(engine_t *e, board_t *b, move_queue_t *dead)
 	if (DEBUGL(2))  board_print_ownermap(b, stderr, &u->ownermap);
 
 	ownermap_dead_groups(b, &u->ownermap, dead, NULL);
-	print_dead_groups(u, b, dead);
 }
 
 static void

--- a/util.c
+++ b/util.c
@@ -1,3 +1,4 @@
+#define DEBUG 1
 
 #include <unistd.h>
 #include <stdlib.h>
@@ -8,7 +9,9 @@
 #include <libgen.h>
 #include <sys/stat.h>
 #include <stdbool.h>
+
 #include "pachi.h"
+#include "debug.h"
 #include "util.h"
 
 void
@@ -159,6 +162,29 @@ fail(char *msg)
 	warning("%s: %s\n", msg, strerror(errno));
 	exit(42);
 }
+
+
+char *gnugo_exe = NULL;
+
+bool
+check_gnugo()
+{
+	// XXX windows support
+
+	char *cmds[] = { "./gnugo", "gnugo", "/usr/games/gnugo", NULL };
+	char cmd[256];
+
+	for (int i = 0; cmds[i]; i++) {
+		snprintf(cmd, sizeof(cmd), "%s -h >/dev/null 2>&1", cmds[i]);
+		if (system(cmd) == 0) {
+			gnugo_exe = cmds[i];
+			return true;
+		}
+	}
+	
+	return false;
+}
+
 
 /**************************************************************************************************/
 /* String buffer */

--- a/util.c
+++ b/util.c
@@ -14,6 +14,10 @@
 #include "debug.h"
 #include "util.h"
 
+#ifdef _WIN32
+#include <shlwapi.h>
+#endif
+
 void
 win_set_pachi_cwd(char *pachi)
 {
@@ -163,14 +167,46 @@ fail(char *msg)
 	exit(42);
 }
 
+/* like mkstemp() but takes care of creating file in system's temp directory.
+ * on return @pattern contains the full path to the file. */
+int
+pachi_mkstemp(char *pattern, size_t max_size)
+{
+#ifdef _WIN32
+	char *    dir = getenv("TEMP");
+	if (!dir) dir = getenv("TMP");
+	if (!dir) die("couldn't find temp directory\n");
+#else
+	char *dir = "/tmp";
+#endif
+
+	size_t res_len = strlen(dir) + strlen(pattern) + 1;
+	assert(max_size >= res_len + 1);
+	assert(max_size >  res_len + 1 + strlen(pattern) + 1);  /* copy */
+
+	char *tmp = pattern + res_len + 1;
+	strcpy(tmp, pattern);
+	
+	size_t r = snprintf(pattern, max_size, "%s/%s", dir, tmp);	assert(r == res_len);
+	return mkstemp(pattern);
+}
+
 
 char *gnugo_exe = NULL;
 
 bool
 check_gnugo()
 {
-	// XXX windows support
+#ifdef _WIN32
+  
+	static char path[MAX_PATH] = "gnugo.exe";
+	
+	if (file_exists("gnugo.exe"))     {  gnugo_exe = "gnugo";  return true;  }
+	if (file_exists("gnugo.bat"))     {  gnugo_exe = "gnugo";  return true;  }
+	if (PathFindOnPathA(path, NULL))  {  gnugo_exe = "gnugo";  return true;  }
 
+#else
+  
 	char *cmds[] = { "./gnugo", "gnugo", "/usr/games/gnugo", NULL };
 	char cmd[256];
 
@@ -182,7 +218,8 @@ check_gnugo()
 		}
 	}
 	
-	return false;
+#endif
+	return false;	
 }
 
 

--- a/util.h
+++ b/util.h
@@ -190,6 +190,10 @@ int strbuf_printf(strbuf_t *buf, const char *format, ...)
 
 /**************************************************************************************************/
 
+/* like mkstemp() but takes care of creating file in system's temp directory 
+ * on return @pattern contains the full path to the file. */
+int pachi_mkstemp(char *pattern, size_t max_size);
+
 extern char *gnugo_exe;
 bool check_gnugo();
 

--- a/util.h
+++ b/util.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 #undef MIN
 #undef MAX
@@ -185,6 +186,12 @@ int strbuf_printf(strbuf_t *buf, const char *format, ...)
 	__attribute__ ((format (printf, 2, 3)));
 
 #define sbprintf strbuf_printf
+
+
+/**************************************************************************************************/
+
+extern char *gnugo_exe;
+bool check_gnugo();
 
 
 #endif


### PR DESCRIPTION
Adds option to use GnuGo to compute dead stones at the end to ensure games are scored properly on KGS (no more seki screwups !).

GnuGo is really good at scoring finished games, does better than playouts which get tripped by sekis in certain situations. It's slower however, takes a few seconds on average. With mcts, can expect about 5% of finished games to be scored incorrectly [(1)](https://github.com/online-go/score-estimator/pull/9) .
    
* Mostly this only matters for online play so mcts is used by default.
    
* `--accurate-scoring` ensures GnuGo is used instead. Pachi won't start if it's missing.
    
* `--kgs` will use GnuGo if available, otherwise mcts and issue a warning.

For now only japanese and chinese rules are supported.
Should work on windows also.