### PR TITLE
2020 fixes

### DIFF
--- a/board.h
+++ b/board.h
@@ -237,6 +237,7 @@ FB_ONLY(int moveno)[BOARD_MAX_COORDS];     /* Move number for each coord */
 #endif
 
 #define board_stride(b)           (board_rsize(b) + 2)
+#define board_rsize2(b)		  (board_rsize(b) * board_rsize(b))
 
 
 /* This is a shortcut for taking different action on smaller and large boards 

--- a/distributed/distributed.h
+++ b/distributed/distributed.h
@@ -99,6 +99,6 @@ typedef struct {
 #define reply_disabled(id) ((id) < DIST_GAMELEN)
 
 char *path2sstr(path_t path, board_t *b);
-void engine_distributed_init(engine_t *e, char *arg, board_t *b);
+void engine_distributed_init(engine_t *e, board_t *b);
 
 #endif

--- a/gtp.c
+++ b/gtp.c
@@ -798,13 +798,17 @@ cmd_undo(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 }
 
 static void
-undo_reload_engine(gtp_t *gtp, board_t *b, engine_t *e)
+undo_reload_engine(gtp_t *gtp, board_t *b, engine_t *e, time_info_t *ti)
 {
 	if (DEBUGL(3)) fprintf(stderr, "reloading engine after undo(s).\n");
 	
 	gtp->undo_pending = false;
 
 	engine_reset(e, b);
+
+	/* Reset timer */
+	ti[S_BLACK].len.t.timer_start = 0;
+	ti[S_WHITE].len.t.timer_start = 0;
 	
 	/* Reset board */
 	int handicap = b->handicap;
@@ -1087,7 +1091,7 @@ gtp_parse(gtp_t *gtp, board_t *b, engine_t *e, time_info_t *ti, char *buf)
 	
 	/* Undo: reload engine after first non-undo command. */
 	if (gtp->undo_pending && strcasecmp(gtp->cmd, "undo"))
-		undo_reload_engine(gtp, b, e);
+		undo_reload_engine(gtp, b, e, ti);
 	
 	if (e->notify && gtp_is_valid(e, gtp->cmd)) {
 		char *reply;

--- a/kgs/kgsgtp-pachi.conf
+++ b/kgs/kgsgtp-pachi.conf
@@ -12,7 +12,7 @@
 # -t =5000 for fixed number of playouts etc.
 #
 
-engine=./pachi --kgs -t =5000:15000 resign_threshold=0.25,banner=%s.+Have+a+nice+game!
+engine=./pachi --kgs -t =5000:15000 -o pachi.log resign_threshold=0.25,banner=%s.+Have+a+nice+game!
 name=KGSNAME
 password=PASSWORD
 room=Computer Go

--- a/ownermap.c
+++ b/ownermap.c
@@ -22,7 +22,7 @@ printhook(board_t *board, coord_t c, strbuf_t *buf, void *data)
 
 	if (c == pass) { /* Stuff to display in header */
 		if (!ownermap || !ownermap->playouts) return;
-		sbprintf(buf, "Score Est: %s\n", ownermap_score_est_str(board, ownermap));
+		sbprintf(buf, "Score Est: %s", ownermap_score_est_str(board, ownermap));
 		return;
 	}
 	
@@ -39,7 +39,7 @@ printhook(board_t *board, coord_t c, strbuf_t *buf, void *data)
 void
 board_print_ownermap(board_t *b, FILE *f, ownermap_t *ownermap)
 {
-        board_print_custom(b, stderr, printhook, ownermap);
+        board_print_custom(b, f, printhook, ownermap);
 }
 
 void

--- a/ownermap.h
+++ b/ownermap.h
@@ -81,7 +81,7 @@ bool board_position_final_full(board_t *b, ownermap_t *ownermap,
 
 /* Don't allow passing earlier than that:
  * 19x19: 120    15x15: 56    13x13: 33    9x9: 16 */
-#define board_earliest_pass(b)  (board_max_coords(b) / (7 - 2 * board_rsize(b) / 9))
+#define board_earliest_pass(b)  (board_rsize2(b) / (7 - 2 * board_rsize(b) / 9))
 
 
 #endif

--- a/pachi.c
+++ b/pachi.c
@@ -172,7 +172,7 @@ usage()
 		"  -t, --time TIME_SETTINGS          force basic time settings (override kgs/gtp time settings) \n"
 		"      --fuseki-time TIME_SETTINGS   specific time settings to use during fuseki \n"
 		"      --fuseki MOVES                set fuseki length for --fuseki-time \n"
-		"                                    default: 19x19: 20  15x15: 10  13x13: 7  9x9: 4 \n"
+		"                                    default: 19x19: 10  15x15: 7  9x9: 4 \n"
 		" \n"
 		"  TIME_SETTINGS: \n"
 		"  =SIMS           fixed number of Monte-Carlo simulations per move \n"

--- a/pachi.c
+++ b/pachi.c
@@ -44,9 +44,9 @@ int   debug_level = 3;
 bool  debug_boardprint = true;
 long  verbose_logs = 0;
 char *forced_ruleset = NULL;
-bool  nopassfirst = false;
 
 static char *gtp_port = NULL;
+static bool  nopassfirst = false;
 static int   accurate_scoring_wanted = 0;
 
 static void
@@ -56,6 +56,12 @@ network_init()
 	int gtp_sock = -1;
 	if (gtp_port)		open_gtp_connection(&gtp_sock, gtp_port);
 #endif
+}
+
+bool
+pachi_nopassfirst(board_t *b)
+{
+	return (nopassfirst && b->rules == RULES_CHINESE);
 }
 
 bool
@@ -141,7 +147,7 @@ usage()
 		"      --accurate-scoring            use GnuGo to compute dead stones at the end. otherwise expect \n"
 		"                                    ~5%% games to be scored incorrectly. recommended for online play \n"
 		"  -c, --chatfile FILE               set kgs chatfile \n"
-		"      --nopassfirst                 don't pass first \n"
+		"      --nopassfirst                 don't pass first when playing chinese \n"
 		"      --kgs                         use this when playing on kgs, \n"
 		"                                    enables --nopassfirst, and --accurate-scoring if gnugo is found \n"
 		"Logs / IO: \n"

--- a/pachi.h
+++ b/pachi.h
@@ -22,7 +22,8 @@ extern char *pachi_exe;
 /* Ruleset from cmdline, if present. */
 extern char *forced_ruleset;
 
-/* Don't pass first ? Needed on kgs or cleanup phase can be abused. */
-extern bool nopassfirst;
+/* Don't pass first ? Needed when playing chinese rules on kgs or cleanup phase can be abused. */
+bool pachi_nopassfirst(struct board *b);
+
 
 #endif

--- a/patternprob.c
+++ b/patternprob.c
@@ -272,7 +272,7 @@ print_pattern_best_moves(board_t *b, coord_t *best_c, float *best_r, int nbest)
 }
 
 void
-get_pattern_best_moves(board_t *b, float *probs, coord_t *best_c, float *best_r, int nbest)
+get_pattern_best_moves(board_t *b, floating_t *probs, coord_t *best_c, float *best_r, int nbest)
 {
 	for (int i = 0; i < nbest; i++) {
 		best_c[i] = pass;  best_r[i] = 0;

--- a/patternprob.h
+++ b/patternprob.h
@@ -67,7 +67,7 @@ bool pattern_matching_locally(pattern_config_t *pc,
 			      ownermap_t *ownermap);
 
 void print_pattern_best_moves(board_t *b, coord_t *best_c, float *best_r, int nbest);
-void get_pattern_best_moves(board_t *b, float *probs, coord_t *best_c, float *best_r, int nbest);
+void get_pattern_best_moves(board_t *b, floating_t *probs, coord_t *best_c, float *best_r, int nbest);
 
 /* Debugging */
 void dump_gammas(strbuf_t *buf, pattern_config_t *pc, pattern_t *p);

--- a/random.c
+++ b/random.c
@@ -8,6 +8,7 @@
 
 /********************************************************************************************/
 #ifdef _WIN32
+#include <windows.h>
 
 /* Use TlsGetValue() / TlsSetValue() for thread-local storage,
  * mingw-w64's __thread is painfully slow. */

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -190,7 +190,7 @@ show_title_if_needed(int passed)
 
 
 static bool
-test_sar(board_t *b, char *arg)
+test_selfatari(board_t *b, char *arg)
 {
 	next_arg(arg);
 	enum stone color = str2stone(arg);
@@ -200,10 +200,30 @@ test_sar(board_t *b, char *arg)
 	int eres = atoi(arg);
 	args_end();
 
-	PRINT_TEST(b, "sar %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
+	PRINT_TEST(b, "selfatari %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
 
 	assert(board_at(b, c) == S_NONE);
 	int rres = is_bad_selfatari(b, color, c);
+
+	PRINT_RES(rres == eres);
+	return   (rres == eres);
+}
+
+static bool
+test_selfatari_really_bad(board_t *b, char *arg)
+{
+	next_arg(arg);
+	enum stone color = str2stone(arg);
+	next_arg(arg);
+	coord_t c = str2coord(arg);
+	next_arg(arg);
+	int eres = atoi(arg);
+	args_end();
+
+	PRINT_TEST(b, "selfatari_really_bad %s %s %d...\t", stone2str(color), coord2sstr(c), eres);
+
+	assert(board_at(b, c) == S_NONE);
+	int rres = is_really_bad_selfatari(b, color, c);
 
 	PRINT_RES(rres == eres);
 	return   (rres == eres);
@@ -570,7 +590,9 @@ typedef struct {
 } t_unit_cmd;
 
 static t_unit_cmd commands[] = {
-	{ "sar",                    test_sar,               1 },
+	{ "selfatari",              test_selfatari,         1 },
+	{ "sar",                    test_selfatari,         1 },  /* alias */
+	{ "selfatari_really_bad",   test_selfatari_really_bad,  1 },	
 	{ "ladder",                 test_ladder,            1 },
 	{ "ladder_any",             test_ladder_any,        1 },
 	{ "wouldbe_ladder",         test_wouldbe_ladder,    1 },

--- a/tactics/seki.h
+++ b/tactics/seki.h
@@ -1,8 +1,8 @@
 #ifndef PACHI_TACTICS_SEKI_H
 #define PACHI_TACTICS_SEKI_H
 
-#define MOGGY_MIDDLEGAME  (board_rsize(b) * board_rsize(b) * 10 / 25)      /*  19x19: 144 */
-#define MOGGY_ENDGAME     (board_rsize(b) * board_rsize(b) * 100 / 164)    /*  19x19: 220 */
+#define MOGGY_MIDDLEGAME  (board_rsize2(b) * 10 / 25)      /*  19x19: 144 */
+#define MOGGY_ENDGAME     (board_rsize2(b) * 100 / 164)    /*  19x19: 220 */
 
 #define check_special_sekis(b, m)  \
 	(b->moves > MOGGY_MIDDLEGAME && !immediate_liberty_count(b, m->coord))

--- a/timeinfo.c
+++ b/timeinfo.c
@@ -482,10 +482,9 @@ fuseki_moves(board_t *b)
 	if (opt_fuseki_moves)
 		return opt_fuseki_moves;
 	
-	int moves = 20;
-	if (board_rsize(b) <= 15)  moves = 10;
-	if (board_rsize(b) <= 13)  moves = 7;
-	if (board_small(b))	       moves = 4;
+	int moves = 10;
+	if (board_rsize(b) <= 15)  moves = 7;
+	if (board_small(b))	   moves = 4;
 	return moves;
 }
 

--- a/timeinfo.c
+++ b/timeinfo.c
@@ -13,6 +13,10 @@
 #include "ownermap.h"
 #include "timeinfo.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 /* Max net lag in seconds. TODO: estimate dynamically. */
 #define MAX_NET_LAG 2.0
 /* Minimal thinking time; in case reserved time gets smaller than MAX_NET_LAG,

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -126,6 +126,7 @@ typedef struct uct {
 
 	/* Used within frame of single genmove. */
 	ownermap_t ownermap;
+	bool allow_pass;    /* allow pass in uct descent */
 
 	/* Used for coordination among slaves of the distributed engine. */
 	int stats_hbits;

--- a/uct/search.c
+++ b/uct/search.c
@@ -644,8 +644,8 @@ uct_search_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_al
 static bool
 uct_pass_first(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, coord_t coord)
 {	
-	/* For kgs: must not pass first in main game phase. */
-	bool can_pass_first = (!nopassfirst || pass_all_alive);
+	/* For kgs: must not pass first in main game phase when playing chinese. */
+	bool can_pass_first = (!pachi_nopassfirst(b) || pass_all_alive);
 	if (!can_pass_first)  return false;
 
 	if (is_pass(coord) || is_pass(last_move(b).coord))  return false;

--- a/uct/search.c
+++ b/uct/search.c
@@ -651,9 +651,7 @@ uct_pass_first(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, coor
 	if (is_pass(coord) || is_pass(last_move(b).coord))  return false;
 
 	enum stone other_color = stone_other(color);
-	int capturing = board_get_atari_neighbor(b, coord, other_color);
-	int atariing = board_get_2lib_neighbor(b, coord, other_color);
-	if (capturing || atariing || board_playing_ko_threat(b))  return false;
+	if (board_playing_ko_threat(b))  return false;
 
 	/* Find dames left */
 	move_queue_t dead, unclear;

--- a/uct/search.c
+++ b/uct/search.c
@@ -705,7 +705,7 @@ uct_search_result(uct_t *u, board_t *b, enum stone color,
 
 	bool opponent_passed = is_pass(last_move(b).coord);
 	bool pass_first = uct_pass_first(u, b, color, pass_all_alive, *best_coord);
-	if (UDEBUGL(2) && pass_first)  fprintf(stderr, "<Pass first ok>\n");
+	if (UDEBUGL(2) && pass_first)  fprintf(stderr, "pass first ok\n");
 
 	/* If the opponent just passed and we win counting, always pass as well.
 	 * Pass also instead of playing in opponent territory if winning.

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -93,6 +93,7 @@ uct_prepare_move(uct_t *u, board_t *b, enum stone color)
 
 	ownermap_init(&u->ownermap);
 	u->played_own = u->played_all = 0;
+	u->allow_pass = (b->moves > board_earliest_pass(b));  /* && dames < 10  if using patterns */
 }
 
 /* Does the board look like a final position ?

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -283,11 +283,11 @@ uct_dead_groups(engine_t *e, board_t *b, move_queue_t *dead)
 		return;
 	}
 
-	fprintf(stderr, "WARNING: Recomputing dead groups\n");
+	if (UDEBUGL(1)) fprintf(stderr, "WARNING: Recomputing dead groups\n");
 
 	/* Make sure the ownermap is well-seeded. */
 	uct_mcowner_playouts(u, b, S_BLACK);
-	if (DEBUGL(2))  board_print_ownermap(b, stderr, &u->ownermap);
+	if (UDEBUGL(2))  board_print_ownermap(b, stderr, &u->ownermap);
 
 	ownermap_dead_groups(b, &u->ownermap, dead, NULL);
 }

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -488,7 +488,6 @@ uct_playout_descent(uct_t *u, board_t *b, board_t *b2, enum stone player_color, 
 		significant[node_color - 1] = n;
 
 	int result;
-	int pass_limit = board_rsize2(b2) / 2;
 	int passes = is_pass(last_move(b).coord) && b->moves > 0;
 
 	/* debug */
@@ -518,9 +517,9 @@ uct_playout_descent(uct_t *u, board_t *b, board_t *b2, enum stone player_color, 
 		}
 
 		if (!u->random_policy_chance || fast_random(u->random_policy_chance))
-			u->policy->descend(u->policy, t, &descent[dlen], parity, (b2->moves > pass_limit));
+			u->policy->descend(u->policy, t, &descent[dlen], parity, u->allow_pass);
 		else
-			u->random_policy->descend(u->random_policy, t, &descent[dlen], parity, (b2->moves > pass_limit));
+			u->random_policy->descend(u->random_policy, t, &descent[dlen], parity, u->allow_pass);
 
 
 		/*** Perform the descent: */

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -488,7 +488,7 @@ uct_playout_descent(uct_t *u, board_t *b, board_t *b2, enum stone player_color, 
 		significant[node_color - 1] = n;
 
 	int result;
-	int pass_limit = board_rsize(b2) * board_rsize(b2) / 2;
+	int pass_limit = board_rsize2(b2) / 2;
 	int passes = is_pass(last_move(b).coord) && b->moves > 0;
 
 	/* debug */

--- a/util.c
+++ b/util.c
@@ -15,7 +15,8 @@
 #include "util.h"
 
 #ifdef _WIN32
-#include <shlwapi.h>
+#include <shlwapi.h>   /* PathFindOnPathA() */
+#include <windows.h>
 #endif
 
 void
@@ -100,27 +101,6 @@ fopen_data_file(const char *filename, const char *mode)
 	get_data_file(buf, filename);
 	return fopen(buf, mode);
 }
-
-#ifdef _WIN32
-
-const char *
-strcasestr(const char *haystack, const char *needle)
-{
-	for (const char *p = haystack; *p; p++) {
-		for (int ni = 0; needle[ni]; ni++) {
-			if (!p[ni])
-				return NULL;
-			if (toupper(p[ni]) != toupper(needle[ni]))
-				goto more_hay;
-		}
-		return p;
-more_hay:;
-	}
-	return NULL;
-}
-
-#endif /* _WIN32 */
-
 
 int
 str_prefix(char *prefix, char *str)
@@ -272,3 +252,41 @@ strbuf_printf(strbuf_t *buf, const char *format, ...)
 	va_end(ap);
 	return n;
 }
+
+
+/**************************************************************************************************/
+/* Windows */
+
+#ifdef _WIN32
+
+
+void pachi_sleep(int seconds)
+{
+	Sleep((seconds) * 1000);
+}
+
+/* Windows MessageBox() */
+void
+pachi_popup(const char *msg)
+{
+	MessageBox(0, msg, "Pachi", MB_OK);
+}
+
+const char *
+strcasestr(const char *haystack, const char *needle)
+{
+	for (const char *p = haystack; *p; p++) {
+		for (int ni = 0; needle[ni]; ni++) {
+			if (!p[ni])
+				return NULL;
+			if (toupper(p[ni]) != toupper(needle[ni]))
+				goto more_hay;
+		}
+		return p;
+more_hay:;
+	}
+	return NULL;
+}
+
+
+#endif /* _WIN32 */

--- a/util.h
+++ b/util.h
@@ -63,26 +63,21 @@ FILE *fopen_data_file(const char *filename, const char *mode);
 
 #ifdef _WIN32
 
-/*
- * sometimes we use winsock and like to avoid a warning to include
- * windows.h only after winsock2.h
- */
-#include <winsock2.h>
-#include <windows.h>
-#include <ctype.h>
-
-#define sleep(seconds) Sleep((seconds) * 1000)
+#define sleep(seconds)  pachi_sleep(seconds)
+void pachi_sleep(int seconds);
 
 /* No line buffering on windows, set to unbuffered. */
 #define setlinebuf(file)   setvbuf(file, NULL, _IONBF, 0)
 
 /* Windows MessageBox() */
-#define popup(msg)	MessageBox(0, msg, "Pachi", MB_OK);
+#define popup(msg)	pachi_popup(msg)
+void pachi_popup(const char *msg);
 
 /* MinGW gcc, no function prototype for built-in function stpcpy() */ 
 char *stpcpy (char *dest, const char *src);
 
 const char *strcasestr(const char *haystack, const char *needle);
+
 
 #endif /* _WIN32 */
 


### PR DESCRIPTION
Good thing with lockdown, I have some time to take care of Pachi =)

Mostly fixes a few bugs in previous PRs, and makes windows build almost 3x faster.

- Fixed DOUBLE_FLOATING issue
- Distributed engine works again, forgot to convert it in gtp_setoption PR (#111)
- Fixed undo timer issue. With things like 'pachi -t 10', Pachi would stop thinking if you undo + genmove immediately in gogui / sabaki etc.
- UCT: Lowered uct pass_limit, helps with early pass for short games (esp. japanese rules)
- KGS: `--nopassfirst` only applies to chinese rules games
- Fixed `board_earliest_pass()` bug, values were wrong !
- `--fuseki-time` stops after move 10 instead of 20, helps with trick plays
