### PR TITLE
kgsgtp >= 3.5.20 crash fix

### DIFF
--- a/gtp.h
+++ b/gtp.h
@@ -31,6 +31,7 @@ typedef struct
 	bool    undo_pending;
 	bool    noundo;            /* undo only allowed for pass */
 	bool    kgs;
+	bool    kgs_chat;          /* enable kgs-chat command ? */
 	bool    analyze_running;
 	char*   custom_name;
 	char*   custom_version;
@@ -61,6 +62,7 @@ typedef struct
 
 void   gtp_init(gtp_t *gtp);
 
+void gtp_internal_init(gtp_t *gtp);
 enum parse_code gtp_parse(gtp_t *gtp, board_t *b, struct engine *e, time_info_t *ti, char *buf);
 bool gtp_is_valid(struct engine *e, const char *cmd);
 

--- a/kgs/kgsgtp-pachi.conf
+++ b/kgs/kgsgtp-pachi.conf
@@ -1,6 +1,5 @@
 # Run kgsGTP in the directory where Pachi lives.
 # On Windows, maybe you will need to replace ./pachi with pachi.exe.
-# If latest kgsGtp doesn't work for you try kgsGtp-3.5.11 instead.
 #
 # Recommended: Install GnuGo also, Pachi will use it to compute dead
 # stones at the end. Otherwise mcts does a good job but expect ~5% of
@@ -10,6 +9,9 @@
 # For time settings you can either let Pachi play by kgs time settings
 # or pass -t option to override it: for example -t 5 for max 5s per move,
 # -t =5000 for fixed number of playouts etc.
+#
+# If you want kgs-chat command support you need kgsGtp-3.5.11 and pass
+# --kgs-chat option to pachi. Later kgsGtp versions don't handle it.
 #
 
 engine=./pachi --kgs -t =5000:15000 -o pachi.log resign_threshold=0.25,banner=%s.+Have+a+nice+game!

--- a/pachi.c
+++ b/pachi.c
@@ -147,6 +147,7 @@ usage()
 		"      --accurate-scoring            use GnuGo to compute dead stones at the end. otherwise expect \n"
 		"                                    ~5%% games to be scored incorrectly. recommended for online play \n"
 		"  -c, --chatfile FILE               set kgs chatfile \n"
+		"      --kgs-chat                    enable kgs-chat cmd (kgsGtp 3.5.11 only, crashes 3.5.20+) \n"
 		"      --nopassfirst                 don't pass first when playing chinese \n"
 		"      --kgs                         use this when playing on kgs, \n"
 		"                                    enables --nopassfirst, and --accurate-scoring if gnugo is found \n"
@@ -237,6 +238,7 @@ show_version(FILE *s)
 #define OPT_NAME              269
 #define OPT_LIST_DCNNS	      270
 #define OPT_ACCURATE_SCORING  271
+#define OPT_KGS_CHAT	      272
 
 static struct option longopts[] = {
 	{ "accurate-scoring",   no_argument,       0, OPT_ACCURATE_SCORING },	
@@ -255,6 +257,7 @@ static struct option longopts[] = {
 	{ "help",               no_argument,       0, 'h' },
 	{ "joseki",             no_argument,       0, OPT_JOSEKI },	
 	{ "kgs",                no_argument,       0, OPT_KGS },
+	{ "kgs-chat",           no_argument,       0, OPT_KGS_CHAT },
 #ifdef DCNN
 	{ "list-dcnns",         no_argument,       0, OPT_LIST_DCNNS },
 #endif
@@ -358,6 +361,9 @@ int main(int argc, char *argv[])
 				nopassfirst = true;             /* --nopassfirst */
 				accurate_scoring_wanted = 1;    /* use gnugo to get dead stones, if possible */
 				break;
+			case OPT_KGS_CHAT:
+				gtp->kgs_chat = true;
+				break;
 #ifdef NETWORK
 			case 'l':
 				log_port = strdup(optarg);
@@ -459,6 +465,7 @@ int main(int argc, char *argv[])
 		if (!pachi_set_rules(gtp, b, forced_ruleset))  die("Unknown ruleset: %s\n", forced_ruleset);
 		if (DEBUGL(1))  fprintf(stderr, "Rules: %s\n", forced_ruleset);
 	}
+	gtp_internal_init(gtp);
 	accurate_scoring_init(gtp, b);
 
 	time_info_t ti[S_MAX];


### PR DESCRIPTION
kgs-chat command crashes kgsGtp >= 3.5.20, so disabling by default.

If you want kgs-chat support, use kgsGtp-3.5.11 with `pachi --kgs-chat`
