### PR TITLE
lz_analyze fixes

### DIFF
--- a/board.h
+++ b/board.h
@@ -317,6 +317,9 @@ int board_cmp(board_t *b1, board_t *b2);
 /* Place given handicap on the board; coordinates are printed to f. */
 void board_handicap(board_t *b, int stones, move_queue_t *q);
 
+/* Return color to play */
+static enum stone board_to_play(board_t *b);
+
 /* Returns group id, 0 on allowed suicide, pass or resign, -1 on error */
 int board_play(board_t *b, move_t *m);
 /* Like above, but plays random move; the move coordinate is recorded
@@ -433,6 +436,13 @@ const char *rules2str(enum rules rules);
 		} \
 	} while (0)
 
+
+/* XXX doesn't handle handicap placement phase */
+static inline enum stone
+board_to_play(board_t *b)
+{
+	return (last_move(b).color ? stone_other(last_move(b).color) : S_BLACK);
+}
 
 static inline bool
 board_is_eyelike(board_t *b, coord_t coord, enum stone eye_color)

--- a/engines/patternscan.c
+++ b/engines/patternscan.c
@@ -240,7 +240,7 @@ genspatial_process_move(patternscan_t *ps, board_t *b, move_t *m, strbuf_t *buf,
 	coord_t last_move = last_move(b).coord;
 	last_move(b).coord = m->coord;
 	board_print(b, stderr);
-	fprintf(stderr, "%s to play\n", stone2str(stone_other(last_move(b).color)));
+	fprintf(stderr, "%s to play\n", stone2str(board_to_play(b)));
 	last_move(b).coord = last_move;
 #endif
 

--- a/gogui.c
+++ b/gogui.c
@@ -326,9 +326,7 @@ gogui_best_moves(FILE *f, engine_t *e, board_t *b, time_info_t *ti,
 enum parse_code
 cmd_gogui_color_palette(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
-
+	enum stone color = board_to_play(b);
 	float   best_r[GOGUI_MANY] = { 0.0, };
 	coord_t best_c[GOGUI_MANY];
 	for (int i = 0; i < GOGUI_MANY; i++)
@@ -433,8 +431,7 @@ cmd_gogui_final_score(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 enum parse_code
 cmd_gogui_winrates(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
+	enum stone color = board_to_play(b);
 
 	gtp_printf(gtp, "");   /* gtp prefix */
 
@@ -449,8 +446,7 @@ cmd_gogui_winrates(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 enum parse_code
 cmd_gogui_best_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
+	enum stone color = board_to_play(b);
 
 	gtp_printf(gtp, "");   /* gtp prefix */
 
@@ -475,8 +471,7 @@ cmd_gogui_dcnn_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (!using_dcnn(b)) {  gtp_error(gtp, "Not using dcnn");  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
 	
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
+	enum stone color = board_to_play(b);
 
 	gtp_printf(gtp, "");   /* gtp prefix */	
 	gogui_best_moves(stdout, dcnn_engine, b, ti, color, GOGUI_NBEST, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
@@ -489,8 +484,7 @@ cmd_gogui_dcnn_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (!using_dcnn(b)) {  gtp_error(gtp, "Not using dcnn");  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
 	
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
+	enum stone color = board_to_play(b);
 
 	gtp_printf(gtp, "");  /* gtp prefix */
 	gogui_best_moves(stdout, dcnn_engine, b, ti, color, GOGUI_MANY, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
@@ -502,9 +496,8 @@ cmd_gogui_dcnn_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!using_dcnn(b)) {  gtp_error(gtp, "Not using dcnn");  return P_OK;  }
 	if (!dcnn_engine)   dcnn_engine = new_engine(E_DCNN, "", b);
-	
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
+
+	enum stone color = board_to_play(b);
 
 	gtp_printf(gtp, "");   /* gtp prefix */
 	gogui_best_moves(stdout, dcnn_engine, b, ti, color, GOGUI_MANY, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
@@ -524,10 +517,8 @@ cmd_gogui_joseki_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!using_joseki(b)) {  gtp_reply(gtp, "TEXT Not using joseki");  return P_OK;  }
 	if (!joseki_engine)   joseki_engine = new_engine(E_JOSEKIPLAY, NULL, b);
-	
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	
+
+	enum stone color = board_to_play(b);
 	float joseki_map[BOARD_MAX_COORDS];
 	joseki_rate_moves(joseki_dict, b, color, joseki_map);
 
@@ -585,9 +576,8 @@ enum parse_code
 cmd_gogui_pattern_best(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
-	
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
+
+	enum stone color = board_to_play(b);
 
 	gtp_printf(gtp, "");   /* gtp prefix */
 	gogui_best_moves(stdout, pattern_engine, b, ti, color, GOGUI_NBEST, GOGUI_BEST_MOVES, GOGUI_RESCALE_NONE);
@@ -601,9 +591,8 @@ enum parse_code
 cmd_gogui_pattern_colors(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
-	
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
+
+	enum stone color = board_to_play(b);
 
 	gtp_printf(gtp, "");  /* gtp prefix */	
 	gogui_best_moves(stdout, pattern_engine, b, ti, color, GOGUI_MANY, GOGUI_BEST_COLORS, GOGUI_RESCALE_LOG);
@@ -617,9 +606,8 @@ enum parse_code
 cmd_gogui_pattern_rating(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
-	
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
+
+	enum stone color = board_to_play(b);	
 
 	gtp_printf(gtp, "");   /* gtp prefix */
 	gogui_best_moves(stdout, pattern_engine, b, ti, color, GOGUI_MANY, GOGUI_BEST_WINRATES, GOGUI_RESCALE_NONE);
@@ -634,9 +622,8 @@ enum parse_code
 cmd_gogui_pattern_features(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
-	
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
+
+	enum stone color = board_to_play(b);
 	
 	char *arg;  gtp_arg(arg);
 	coord_t coord = str2coord(arg);
@@ -667,10 +654,8 @@ enum parse_code
 cmd_gogui_pattern_gammas(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	if (!pattern_engine)   init_patternplay_engine(b);
-	
-	enum stone color = S_BLACK;
-	if (last_move(b).color)  color = stone_other(last_move(b).color);
-	
+
+	enum stone color = board_to_play(b);	
 	char *arg;  gtp_arg(arg);
 	coord_t coord = str2coord(arg);
 	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...");  return P_OK;  }
@@ -704,7 +689,7 @@ cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	gtp_printf(gtp, "");   /* gtp prefix */
 	gogui_show_pattern(b, coord, spatial_dist);
 	
-	move_t m = move(coord, stone_other(last_move(b).color));
+	move_t m = move(coord, board_to_play(b));
 	spatial_t s;
 	spatial_from_board(pc, &s, b, &m);
 	s.dist = spatial_dist;

--- a/gtp.c
+++ b/gtp.c
@@ -524,10 +524,7 @@ stop_analyzing(gtp_t *gtp, board_t *b, engine_t *e)
 static enum parse_code
 cmd_lz_analyze(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	enum stone color = S_BLACK;
-	if (last_move(b).color != S_NONE)
-		color = stone_other(last_move(b).color);
-	
+	enum stone color = board_to_play(b);
 	char *arg;
 	gtp_arg(arg);
 	if (!isdigit(*arg)) {  gtp_error(gtp, "bad argument"); return P_OK;  }
@@ -788,8 +785,7 @@ cmd_undo(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	gtp->moves--;
 	
 	/* Send a play command to engine so it stops pondering (if it was pondering).  */
-	enum stone color = stone_other(last_move(b).color);
-	move_t m = move(pass, color);
+	move_t m = move(pass, board_to_play(b));
 	if (e->notify_play)
 		e->notify_play(e, b, &m, "");
 

--- a/gtp.c
+++ b/gtp.c
@@ -453,17 +453,18 @@ cmd_genmove(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	return P_OK;
 }
 
-/* Sabaki etc: get winrates etc during genmove.
+/* lz-genmove_analyze: get winrates etc during genmove.
  * Similar to Leela-zero lz-genmove_analyze 
- * XXX we don't honor frequency argument, set reportfreq for now. */
+ * syntax: lz-genmove_analyze <color> <freq>   */
 static enum parse_code
-cmd_genmove_analyze(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
+cmd_lz_genmove_analyze(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *arg;
 	gtp_arg(arg);
 	enum stone color = str2stone(arg);
+	if (color == S_NONE) {  gtp_error(gtp, "bad argument"); return P_OK;  }
 	gtp_arg(arg);
-	if (!isdigit(*arg)) {  gtp_error(gtp, "bad argument"); return P_OK;  }
+	if (!isdigit(*arg))  {  gtp_error(gtp, "bad argument"); return P_OK;  }
 	int freq = atoi(arg);  /* frequency (centiseconds) */
 
 	if (!e->genmove_analyze) {  gtp_error(gtp, "lz-genmove_analyze not supported for this engine"); return P_OK; }
@@ -1020,8 +1021,8 @@ static gtp_command_t gtp_commands[] =
 	{ "pachi-setoption",	    cmd_pachi_setoption },  /* Set/change engine option */
 	{ "pachi-getoption",	    cmd_pachi_getoption },  /* Get engine option(s) */
 
-	{ "lz-analyze",             cmd_lz_analyze },       /* For Lizzie */
-	{ "lz-genmove_analyze",     cmd_genmove_analyze },  /* Sabaki etc */
+	{ "lz-analyze",             cmd_lz_analyze },         /* Lizzie, Sabaki, etc */
+	{ "lz-genmove_analyze",     cmd_lz_genmove_analyze },
 
 	/* Short aliases */
 	{ "predict",                cmd_pachi_predict },

--- a/gtp.c
+++ b/gtp.c
@@ -519,15 +519,19 @@ stop_analyzing(gtp_t *gtp, board_t *b, engine_t *e)
 
 /* Start pondering and output stats for the sake of frontend running Pachi.
  * Stop processing when we receive some other command.
- * Similar to Leela-Zero's lz-analyze so we can feed data to lizzie. 
- * Usage: lz-analyze <freq>       (centiseconds)
- * XXX 'lz-analyze b 10' syntax support */
+ * Similar to Leela-Zero's lz-analyze so we can feed data to Lizzie / Sabaki.
+ * Usage: lz-analyze <freq>		(centiseconds)
+ *        lz-analyze <color> <freq>
+ * lz-analyze with allow move / avoid move syntax unsupported right now. */
 static enum parse_code
 cmd_lz_analyze(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	enum stone color = board_to_play(b);
 	char *arg;
 	gtp_arg(arg);
+	
+	/* optional color argument ? */
+	if (tolower(arg[0]) == 'w' || tolower(arg[0]) == 'b') {  color = str2stone(arg);  gtp_arg(arg);  }
 	if (!isdigit(*arg)) {  gtp_error(gtp, "bad argument"); return P_OK;  }
 	if (!e->analyze)    {  gtp_error(gtp, "lz-analyze not supported for this engine"); return P_OK;  }
 	int freq = atoi(arg);  /* frequency (centiseconds) */

--- a/gtp.c
+++ b/gtp.c
@@ -515,6 +515,8 @@ stop_analyzing(gtp_t *gtp, board_t *b, engine_t *e)
 {
 	gtp->analyze_running = false;
 	e->analyze(e, b, S_BLACK, 0);
+	printf("\n");  /* end of lz-analyze output */
+	fflush(stdout);
 }
 
 /* Start pondering and output stats for the sake of frontend running Pachi.
@@ -541,7 +543,8 @@ cmd_lz_analyze(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	strbuf(buf, 100); char *err;
 	sbprintf(buf, "reportfreq=%fs", 0.01 * freq);
 	bool r = engine_setoptions(e, b, buf->str, &err);  assert(r);
-	
+
+	gtp_printf(gtp, "");   /* just "= \n" output, last newline will be sent when we stop analyzing */
 	e->analyze(e, b, color, 1);
 	gtp->analyze_running = true;
 	

--- a/gtp.h
+++ b/gtp.h
@@ -32,6 +32,7 @@ typedef struct
 	bool    noundo;            /* undo only allowed for pass */
 	bool    kgs;
 	bool    kgs_chat;          /* enable kgs-chat command ? */
+	bool    analyze_mode;      /* analyze mode / genmove mode */
 	bool    analyze_running;
 	char*   custom_name;
 	char*   custom_version;

--- a/t-unit/gtp_check
+++ b/t-unit/gtp_check
@@ -34,6 +34,14 @@ sub pachi_command
 {
     my ($cmd) = @_;
     print PACHI_IN "$cmd\n";  # Forward command to pachi
+    
+    # lz-analyze is special, doesn't finish until next command comes in...
+    if ($cmd =~ m/lz-analyze/) {
+	sleep(1);
+	print PACHI_IN "name\n";
+	check_reply();
+    }
+    
     check_reply();
 }
 

--- a/t-unit/gtp_test.gtp
+++ b/t-unit/gtp_test.gtp
@@ -305,6 +305,8 @@ tunit sar b J8 0
 pachi-tunit sar b J8 0
 
 lz-analyze 10
+name
+lz-analyze w 10
 
 gogui-analyze_commands
 gogui-livegfx best_moves

--- a/t-unit/spatial_regtest.c
+++ b/t-unit/spatial_regtest.c
@@ -35,7 +35,7 @@ dump_spatials(board_t *b, pattern_config_t *pc)
 
 	//board_print(b, stderr);
 
-	enum stone color = (is_pass(last_move(b).coord) ? S_BLACK : stone_other(last_move(b).color));
+	enum stone color = board_to_play(b);
 	pattern_t pats[b->flen];
 	floating_t probs[b->flen];
 	ownermap_t ownermap;  fake_ownermap(b, &ownermap);  /* fake */

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -443,7 +443,7 @@ test_moggy_moves(board_t *b, char *arg)
 
 	char e_arg[128];  sprintf(e_arg, "runs=%i", runs);
 	engine_t e;  engine_init(&e, E_REPLAY, e_arg, b);
-	enum stone color = stone_other(last_move(b).color);
+	enum stone color = board_to_play(b);
 	
 	if (DEBUGL(2))
 		fprintf(stderr, "moggy moves, %s to play. Sampling moves (%i runs)...\n\n",
@@ -533,7 +533,7 @@ test_moggy_status(board_t *b, char *arg)
 	
 	if (!tunit_over_gtp) assert(last_move_set);
 	
-	enum stone color = (is_pass(last_move(b).coord) ? S_BLACK : stone_other(last_move(b).color));
+	enum stone color = board_to_play(b);
 	board_print_test(2, b);
 	if (DEBUGL(2))  fprintf(stderr, "moggy status ");
 	for (int i = 0; i < n; i++) {

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -81,6 +81,7 @@ typedef struct uct {
 	bool pondering_opt;                /* User wants pondering */
 	bool pondering;                    /* Actually pondering now */
 	bool genmove_pondering;            /* Regular pondering (after a genmove) */
+	bool pondering_want_gc;		   /* Garbage collect tree before pondering */
 	int     dcnn_pondering_prior;      /* Prior next move guesses */
 	int     dcnn_pondering_mcts;       /* Genmove next move guesses */
 	coord_t dcnn_pondering_mcts_c[20];

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -42,6 +42,7 @@ typedef enum local_tree_eval {
 /* Internal engine state. */
 typedef struct uct {
 	int debug_level;
+	enum uct_reporting reporting_opt;  /* original value */
 	enum uct_reporting reporting;
 	int    reportfreq_playouts;
 	double reportfreq_time;

--- a/uct/search.c
+++ b/uct/search.c
@@ -187,14 +187,13 @@ thread_manager(void *ctx_)
 	int joined = 0;
 
 	uct_halt = 0;
+	u->tree_ready = false;
 
 	/* Garbage collect the tree by preference when pondering. */
-	if (u->pondering && t->nodes && t->nodes_size >= t->pruning_threshold) {
+	if (u->pondering && u->pondering_want_gc && t->nodes && t->nodes_size >= t->pruning_threshold)
 		t->root = tree_garbage_collect(t, t->root);
-	}
+	u->pondering_want_gc = false;
 
-	u->tree_ready = false;
-		
 	/* Logging thread for pondering */
 	if (u->pondering)
 		pthread_create(&threads[u->threads], NULL, logger_thread, mctx);

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -443,6 +443,7 @@ uct_pondering_stop(uct_t *u)
 		free(ctx->b);
 		u->pondering = false;
 		u->genmove_pondering = false;
+		u->reporting = u->reporting_opt;
 		u->report_fh = stderr;
 	}
 }
@@ -567,14 +568,13 @@ static coord_t
 uct_genmove_analyze(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
 {
 	uct_t *u = (uct_t*)e->data;
-	enum uct_reporting prev = u->reporting;
 
 	uct_pondering_stop(u);   /* Don't clobber report_fh later on... */
 	
 	u->reporting = UR_LEELA_ZERO;
 	u->report_fh = stdout;	
 	coord_t coord = uct_genmove(e, b, ti, color, pass_all_alive);
-	u->reporting = prev;
+	u->reporting = u->reporting_opt;
 	u->report_fh = stderr;
 	
 	return coord;
@@ -795,6 +795,7 @@ uct_setoption(engine_t *e, board_t *b, const char *optname, char *optval,
 			u->reporting = UR_LEELA_ZERO;
 		} else
 			option_error("UCT: Invalid reporting format %s\n", optval);
+		u->reporting_opt = u->reporting;  /* original value */
 	}
 	else if (!strcasecmp(optname, "reportfreq") && optval) {
 		/* Set search progress info frequency:
@@ -1364,6 +1365,7 @@ uct_state_init(engine_t *e, board_t *b)
 	bool pat_setup = false;	
 
 	u->debug_level = debug_level;
+	u->reporting = u->reporting_opt = UR_TEXT;
 	u->reportfreq_playouts = 1000;
 	u->report_fh = stderr;
 	u->gamelen = MC_GAMELEN;

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -999,7 +999,7 @@ uct_setoption(engine_t *e, board_t *b, const char *optname, char *optval,
 	else if (!strcasecmp(optname, "max_tree_size") && optval) {  NEED_RESET
 		/* Maximum amount of memory [MiB] consumed by the move tree.
 		 * For fast_alloc it includes the temp tree used for pruning.
-		 * Default is 3072 (3 GiB). */
+		 * Default is 300 Mb (32 bits) / 600 Mb (64 bits) */
 		u->max_tree_size = (size_t)atoll(optval) * 1048576;  /* long is 4 bytes on windows! */
 	}
 	else if (!strcasecmp(optname, "fast_alloc")) {  NEED_RESET

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -590,7 +590,6 @@ uct_analyze(engine_t *e, board_t *b, enum stone color, int start)
 
 	if (!start) {
 		if (u->pondering) uct_pondering_stop(u);
-		if (u->t) reset_state(u);
 		return;
 	}
 

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -598,6 +598,10 @@ uct_analyze(engine_t *e, board_t *b, enum stone color, int start)
 
 	u->reporting = UR_LEELA_ZERO;
 	u->report_fh = stdout;          /* Reset in uct_pondering_stop() */
+	if (u->t) {
+		bool missing_dcnn_priors = (using_dcnn(b) && !(u->t->root->hints & TREE_HINT_DCNN));
+		if (missing_dcnn_priors) reset_state(u);
+	}
 	if (!u->t)  uct_prepare_move(u, b, color);
 	uct_pondering_start(u, b, u->t, color, 0, false);
 }

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -175,8 +175,7 @@ uct_ownermap(engine_t *e, board_t *b)
 	uct_t *u = (uct_t*)b->es;
 	
 	/* Make sure ownermap is well-seeded. */
-	enum stone color = (last_move(b).color ? stone_other(last_move(b).color) : S_BLACK);
-	uct_mcowner_playouts(u, b, color);
+	uct_mcowner_playouts(u, b, board_to_play(b));
 	
 	return &u->ownermap;
 }
@@ -418,8 +417,7 @@ uct_pondering_start(uct_t *u, board_t *b0, tree_t *t, enum stone color, coord_t 
 		int res = board_play(b, &m);
 		assert(res >= 0);
 	}
-	if (last_move(b).color != S_NONE)
-		assert(last_move(b).color == stone_other(color));
+	assert(color == board_to_play(b));
 	
 	setup_dynkomi(u, b, color);
 


### PR DESCRIPTION
Fix for issue #134 and cleanup / sanity checks:
* Handle `lz-analyze <color> <freq>` syntax for Sabaki
* uct genmove / genmove_analyze: handle non-alternating play
* lz-analyze: make sure dcnn is evaluated for root node
