### PR TITLE
Memory Auto-Alloc

### DIFF
--- a/MORE.md
+++ b/MORE.md
@@ -1,3 +1,28 @@
+## Memory management
+
+By default Pachi automatically allocates memory for tree search now:
+
+```
+auto_alloc     automatically grow tree memory as needed (default)
+fixed_mem      don't grow tree memory during search (same as "auto_alloc=0")
+               search will stop if initial memory runs out.
+	       
+tree_size      initial amount of memory allocated for tree search  
+               can be useful to save memory / avoid reallocations  
+               if you know how much you need.
+max_tree_size  max amount of memory tree search can use (default: unlimited)  
+               can temporarily use more during tree reallocations.
+max_mem        max amount of memory tree search can use  
+               like "max_tree_size" but takes tree reallocations into account.
+```
+
+Compared to earlier versions of Pachi (<= 12.45):
+- Not needed to set `max_tree_size` anymore to make long thinking times work
+- If you know how much you need use `tree_size`
+- If you want to limit total memory used use `max_tree_size` or `max_mem`
+- `fixed_mem` gives old behavior (tree memory doesn't grow)
+
+
 ## Large Patterns
 
 Pachi uses MM patterns to guide tree search. The pattern matcher runs

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ Use `pachi --kgs` when playing on KGS. See [kgsgtp.conf](kgs/kgsgtp-pachi.conf?r
   Play without dcnn with time settings 20:00 S.D. on 8 threads,
   taking up to 3Gb of memory, and thinking during the opponent's turn as well.
 
+> Pachi 12.50 Note:
+> By default Pachi automatically allocates memory for tree search now so you
+> shouldn't have to set "max_tree_size" anymore unless you want to limit max
+> memory used. See [here](MORE.md) for details.
+
 For now, there is no comprehensive documentation of engine options, but
 you can get a pretty good idea by looking at the uct_state_init() function
 in uct/uct.c - you will find the list of UCT engine options there, each

--- a/pachi.c
+++ b/pachi.c
@@ -197,11 +197,8 @@ usage()
 		"      pachi threads=8 max_tree_size=3072 pondering \n"
 		"      pachi threads=8,max_tree_size=3072,pondering            (pachi < 12.50) \n"
 		"\n"
-		"  See respective engines for details. Most common options for uct: \n");
-	fprintf(stderr,
-		"      max_tree_size=100             use 100 Mb of memory for tree search (default: %i Mb) \n",
-		(int) (uct_default_max_tree_size() / 1048576));
-	fprintf(stderr,
+		"  See respective engines for details. Most common options for uct: \n"
+		"      max_tree_size=100             use max 100 Mb of memory for tree search (default: unlimited) \n"
 		"      resign_threshold=0.25         resign if winrate < 25%% (default: 20%%) \n"
 		"      reportfreq=1s                 show search progress every second (default: 1000 playouts) \n"
 		"      threads=4                     use 4 threads for tree search (default: #cores) \n"

--- a/uct/dynkomi.c
+++ b/uct/dynkomi.c
@@ -10,6 +10,7 @@
 #include "tactics/util.h"
 #include "uct/dynkomi.h"
 #include "uct/internal.h"
+#include "uct/search.h"
 #include "uct/tree.h"
 
 
@@ -75,7 +76,7 @@ static floating_t
 linear_permove(uct_dynkomi_t *d, board_t *b, tree_t *tree)
 {
 	dynkomi_linear_t *l = (dynkomi_linear_t*)d->data;
-	enum stone color = d->uct->pondering ? tree->root_color : stone_other(tree->root_color);
+	enum stone color = pondering(d->uct) ? tree->root_color : stone_other(tree->root_color);
 	int lmoves = l->moves[color];
 
 	if (b->moves < lmoves)
@@ -134,7 +135,7 @@ linear_persim(uct_dynkomi_t *d, board_t *b, tree_t *tree, tree_node_t *node)
 	 * This also means the values will stay correct after
 	 * node promotion. */
 
-	enum stone color = d->uct->pondering ? tree->root_color : stone_other(tree->root_color);
+	enum stone color = pondering(d->uct) ? tree->root_color : stone_other(tree->root_color);
 	int lmoves = l->moves[color];
 	if (b->moves < lmoves)
 		return linear_simple(l, b, color);

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -62,11 +62,14 @@ typedef struct uct {
 	double dumpthres;
 	int force_seed;
 	bool no_tbook;
+
+	/* Memory management */
 	bool fast_alloc;
 	bool auto_alloc;
-	size_t max_tree_size;
-	size_t max_pruned_size;
-	size_t pruning_threshold;
+	size_t tree_size;
+	size_t max_tree_size_opt;
+	size_t max_mem;
+	
 	int mercymin;
 	int significant_threshold;
 	bool genmove_reset_tree;
@@ -151,6 +154,11 @@ typedef struct uct {
 	bool tree_ready;
 } uct_t;
 
+/* Limit pruning temp space to 20% of memory. Beyond this we discard
+ * the nodes and recompute them at the next move if necessary. */
+#define pruned_size(tree_size)		((tree_size) / 5)
+#define pruning_threshold(tree_size)	((tree_size) / 10)
+
 #define UDEBUGL(n) DEBUGL_(u->debug_level, n)
 
 bool uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, char **msg);
@@ -160,7 +168,7 @@ void uct_pondering_stop(uct_t *u);
 void uct_get_best_moves(uct_t *u, coord_t *best_c, float *best_r, int nbest, bool winrates, int min_playouts);
 void uct_get_best_moves_at(uct_t *u, tree_node_t *n, coord_t *best_c, float *best_r, int nbest, bool winrates, int min_playouts);
 void uct_mcowner_playouts(uct_t *u, board_t *b, enum stone color);
-void uct_max_tree_size_init(uct_t *u, size_t max_tree_size);
+void uct_tree_size_init(uct_t *u, size_t tree_size);
 
 
 /* This is the state used for descending the tree; we use this wrapper

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -63,6 +63,7 @@ typedef struct uct {
 	int force_seed;
 	bool no_tbook;
 	bool fast_alloc;
+	bool auto_alloc;
 	size_t max_tree_size;
 	size_t max_pruned_size;
 	size_t pruning_threshold;

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -79,10 +79,10 @@ typedef struct uct {
 	int slave_index; /* 0..max_slaves-1, or -1 if not set */
 	enum stone my_color;
 
+	/* Current search flags */
+	int search_flags;
+	
 	bool pondering_opt;                /* User wants pondering */
-	bool pondering;                    /* Actually pondering now */
-	bool genmove_pondering;            /* Regular pondering (after a genmove) */
-	bool pondering_want_gc;		   /* Garbage collect tree before pondering */
 	int     dcnn_pondering_prior;      /* Prior next move guesses */
 	int     dcnn_pondering_mcts;       /* Genmove next move guesses */
 	coord_t dcnn_pondering_mcts_c[20];

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -144,7 +144,7 @@ typedef struct uct {
 	int pass_moveno;
 	
 	/* Timing */
-	double mcts_time_start;
+	double mcts_time;
 
 	/* Game state - maintained by setup_state(), reset_state(). */
 	tree_t *t;

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -159,6 +159,8 @@ void uct_pondering_stop(uct_t *u);
 void uct_get_best_moves(uct_t *u, coord_t *best_c, float *best_r, int nbest, bool winrates, int min_playouts);
 void uct_get_best_moves_at(uct_t *u, tree_node_t *n, coord_t *best_c, float *best_r, int nbest, bool winrates, int min_playouts);
 void uct_mcowner_playouts(uct_t *u, board_t *b, enum stone color);
+void uct_max_tree_size_init(uct_t *u, size_t max_tree_size);
+
 
 /* This is the state used for descending the tree; we use this wrapper
  * structure in order to be able to easily descend in multiple trees

--- a/uct/search.h
+++ b/uct/search.h
@@ -27,7 +27,18 @@ struct tree_node;
 #define TREE_BUSYWAIT_INTERVAL 0.1 /* 100ms */
 
 /* uct_search_start() flags */
-#define UCT_SEARCH_RESTART	(1 << 0)
+#define UCT_SEARCH_PONDERING		(1 << 0)  /* Pondering now */
+#define UCT_SEARCH_GENMOVE_PONDERING	(1 << 1)  /* Regular pondering after a genmove */
+#define UCT_SEARCH_WANT_GC		(1 << 2)  /* Garbage collect tree before pondering */
+#define UCT_SEARCH_RESTARTED		(1 << 3)  /* Resuming search */
+
+/* Search flags macros */
+#define pondering(u)		((u)->search_flags & UCT_SEARCH_PONDERING)
+#define genmove_pondering(u)	((u)->search_flags & UCT_SEARCH_GENMOVE_PONDERING)
+#define search_want_gc(u)	((u)->search_flags & UCT_SEARCH_WANT_GC)
+#define search_restarted(u)	((u)->search_flags & UCT_SEARCH_RESTARTED)
+
+#define clear_search_want_gc(u)	 do { (u)->search_flags &= ~UCT_SEARCH_WANT_GC; } while(0)
 
 /* Thread manager state */
 extern volatile sig_atomic_t uct_halt;
@@ -50,7 +61,6 @@ typedef struct uct_thread_ctx {
 /* Progress information of the on-going MCTS search - when did we
  * last adjusted dynkomi, printed out stuff, etc. */
 typedef struct uct_search_state {
-	int flags;		  /* uct_search_start() flags */
 	double mcts_time_start;
 	int base_playouts;	  /* Number of games simulated for this simulation before
 				   * we started the search. (We have simulated them earlier.) */

--- a/uct/search.h
+++ b/uct/search.h
@@ -65,6 +65,8 @@ int uct_search_games(uct_search_state_t *s);
 void uct_search_start(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti, uct_search_state_t *s);
 uct_thread_ctx_t *uct_search_stop(void);
 
+void uct_search_realloc_tree(uct_t *u, board_t *b, enum stone color, time_info_t *ti, uct_search_state_t *s);
+
 void uct_search_progress(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti, uct_search_state_t *s, int playouts);
 
 bool uct_search_check_stop(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti, uct_search_state_t *s, int i);

--- a/uct/search.h
+++ b/uct/search.h
@@ -26,6 +26,8 @@ struct tree_node;
  * stop, progress reports, etc. (in seconds) */
 #define TREE_BUSYWAIT_INTERVAL 0.1 /* 100ms */
 
+/* uct_search_start() flags */
+#define UCT_SEARCH_RESTART	(1 << 0)
 
 /* Thread manager state */
 extern volatile sig_atomic_t uct_halt;
@@ -47,7 +49,9 @@ typedef struct uct_thread_ctx {
 
 /* Progress information of the on-going MCTS search - when did we
  * last adjusted dynkomi, printed out stuff, etc. */
-typedef struct uct_search_state {	
+typedef struct uct_search_state {
+	int flags;		  /* uct_search_start() flags */
+	double mcts_time_start;
 	int base_playouts;	  /* Number of games simulated for this simulation before
 				   * we started the search. (We have simulated them earlier.) */
 	int last_dynkomi;	  /* Number of playouts for last dynkomi adjustment. */
@@ -62,7 +66,7 @@ typedef struct uct_search_state {
 
 int uct_search_games(uct_search_state_t *s);
 
-void uct_search_start(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti, uct_search_state_t *s);
+void uct_search_start(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti, uct_search_state_t *s, int flags);
 uct_thread_ctx_t *uct_search_stop(void);
 
 void uct_search_realloc_tree(uct_t *u, board_t *b, enum stone color, time_info_t *ti, uct_search_state_t *s);

--- a/uct/search.h
+++ b/uct/search.h
@@ -79,7 +79,7 @@ int uct_search_games(uct_search_state_t *s);
 void uct_search_start(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti, uct_search_state_t *s, int flags);
 uct_thread_ctx_t *uct_search_stop(void);
 
-void uct_search_realloc_tree(uct_t *u, board_t *b, enum stone color, time_info_t *ti, uct_search_state_t *s);
+int uct_search_realloc_tree(uct_t *u, board_t *b, enum stone color, time_info_t *ti, uct_search_state_t *s);
 
 void uct_search_progress(uct_t *u, board_t *b, enum stone color, tree_t *t, time_info_t *ti, uct_search_state_t *s, int playouts);
 

--- a/uct/slave.c
+++ b/uct/slave.c
@@ -514,7 +514,7 @@ uct_genmoves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
 		/* This is the first genmoves issue, start the MCTS
 		 * now and let it run while we receive stats. */
 		memset(&s, 0, sizeof(s));
-		uct_search_start(u, b, color, u->t, ti, &s);
+		uct_search_start(u, b, color, u->t, ti, &s, 0);
 	}
 
 	/* Read binary incremental stats if present, otherwise

--- a/uct/tree.c
+++ b/uct/tree.c
@@ -488,6 +488,7 @@ tree_copy(tree_t *dst, tree_t *src)
 	assert(dst->root);
 }
 
+// XXX handle failed memory alloc gracefully
 void
 tree_realloc(tree_t *t, size_t max_tree_size, size_t max_pruned_size, size_t pruning_threshold)
 {

--- a/uct/tree.h
+++ b/uct/tree.h
@@ -157,7 +157,8 @@ void tree_dump(tree_t *tree, double thres);
 void tree_save(tree_t *tree, board_t *b, int thres);
 void tree_load(tree_t *tree, board_t *b);
 void tree_copy(tree_t *dst, tree_t *src);
-void tree_realloc(tree_t *t, size_t max_tree_size, size_t max_pruned_size, size_t pruning_threshold);
+void tree_replace(tree_t *tree, tree_t *content);
+int  tree_realloc(tree_t *t, size_t max_tree_size, size_t max_pruned_size, size_t pruning_threshold);
 
 tree_node_t *tree_get_node(tree_node_t *parent, coord_t c);
 tree_node_t *tree_get_node2(tree_t *tree, tree_node_t *parent, coord_t c, bool create);

--- a/uct/tree.h
+++ b/uct/tree.h
@@ -156,6 +156,8 @@ void tree_done(tree_t *tree);
 void tree_dump(tree_t *tree, double thres);
 void tree_save(tree_t *tree, board_t *b, int thres);
 void tree_load(tree_t *tree, board_t *b);
+void tree_copy(tree_t *dst, tree_t *src);
+void tree_realloc(tree_t *t, size_t max_tree_size, size_t max_pruned_size, size_t pruning_threshold);
 
 tree_node_t *tree_get_node(tree_node_t *parent, coord_t c);
 tree_node_t *tree_get_node2(tree_t *tree, tree_node_t *parent, coord_t c, bool create);

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -761,11 +761,8 @@ uct_default_tree_size()
 	/* Double it on 64-bit, tree takes up twice as much memory ... */
 	int mult = (sizeof(void*) == 4 ? 1 : 2);
 
-	/* XXX doc
-	 * Should be enough for most scenarios (up to 240k playouts ...)
-	 * If you're using really long thinking times you definitely should
-	 * set a higher max_tree_size. */
-	return (size_t)300 * mult * 1048576;
+	/* Default tree size can be small now that it grows as needed. */
+	return (size_t)100 * mult * 1048576;
 }
 
 /* Set current tree size to use taking memory limits into account */

--- a/uct/uct.h
+++ b/uct/uct.h
@@ -7,6 +7,6 @@ void engine_uct_init(engine_t *e, board_t *b);
 
 bool   uct_gentbook(engine_t *e, board_t *b, time_info_t *ti, enum stone color);
 void   uct_dumptbook(engine_t *e, board_t *b, enum stone color);
-size_t uct_default_max_tree_size(void);
+size_t uct_default_tree_size(void);
 
 #endif

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -267,9 +267,15 @@ uct_progress_gogui_livegfx(uct_t *u, tree_t *t, enum stone color, int playouts, 
 	fprintf(stderr, "\n");
 }
 
+/* Print search progress in text / json / leela-zero format
+ * Also takes care of gogui livegfx updates if enabled.
+ * If @playouts is 0 show total playouts */
 void
 uct_progress_status(uct_t *u, tree_t *t, enum stone color, int playouts, coord_t *final)
 {
+	if (!playouts)
+		playouts = t->root->u.playouts;
+		
 	if      (u->reporting == UR_TEXT)        uct_progress_text(u->report_fh, u, t, color, playouts);
 	else if (u->reporting == UR_JSON)        uct_progress_json(u->report_fh, u, t, color, playouts, final, false);
 	else if (u->reporting == UR_JSON_BIG)    uct_progress_json(u->report_fh, u, t, color, playouts, final, true);

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -578,7 +578,7 @@ uct_playout_descent(uct_t *u, board_t *b, board_t *b2, enum stone player_color, 
 		 * The size test must be before the test&set not after, to allow
 		 * expansion of the node later if enough nodes have been freed. */
 		if (tree_leaf_node(n)
-		    && n->u.playouts - u->virtual_loss >= u->expand_p && t->nodes_size < u->max_tree_size
+		    && n->u.playouts - u->virtual_loss >= u->expand_p && t->nodes_size < t->max_tree_size
 		    && !__sync_lock_test_and_set(&n->is_expanded, 1))
 			tree_expand_node(t, n, b2, next_color, u, -parity);
 	}


### PR DESCRIPTION
Attempt to automatically grow tree memory once tree is full.
kind of `max_tree_size=auto`

Right now you have to choose `max_tree_size` in advance which sucks if you don't know how much you're going to need: Pick too large and memory is wasted, too low and search stops when limit is reached... So idea is to seamlessly allocate a bigger tree, copy current one over and resume search when memory is full. Tricky because this needs to happen within search itself...

Very much of a hack right now,
But seems to be doing ok so far, can analyze forever in Sabaki or genmove / ponder over very long thinking times without having to worry about `max_tree_size`.
