### PR TITLE
Tree garbage collect fix

### DIFF
--- a/uct/internal.h
+++ b/uct/internal.h
@@ -143,6 +143,13 @@ typedef struct uct {
 } uct_t;
 
 
+/* Whether search tree carries over for next move under current uct settings.
+ * Only case where tree can't be reused is the default case: dcnn without pondering. */
+#define reusing_tree(u, b)	(! ((using_dcnn(b) && !u->pondering_opt) ||			\
+				    (u->t && u->t->untrustworthy_tree)   ||			\
+				    u->genmove_reset_tree))
+
+
 #ifdef DISTRIBUTED
 #define stats_hbits(u)			((u)->stats_hbits)
 #define played_all(u)			((u)->played_all)

--- a/uct/tree.c
+++ b/uct/tree.c
@@ -490,11 +490,12 @@ log_temp_tree_overflow(tree_t *t, tree_t *t2, int threshold, int max_depth)
 #define SMALL_TREE_PLAYOUTS 5000
 
 /* Tree garbage collection
- * Right now this does 3 things:
+ * Main job:
  * - reclaim space used by unreachable nodes after move promotion
- * - prune tree down to max 20% capacity
- * - prune large trees (>40k playouts) keeping only nodes with enough playouts.
- * See also LARGE_TREE_PLAYOUTS, DEEP_PLAYOUTS_THRESHOLD above.
+ * For large trees also:
+ * - prune tree down to max 20% capacity      (>300Mb)
+ * - keep only nodes with enough playouts.    (>40k playouts)
+ * See also LARGE_TREE_PLAYOUTS, DEEP_PLAYOUTS_THRESHOLD above, tree_max_pruned_size()
  * Expensive, especially for huge trees, needs to copy the whole tree twice. */
 void
 tree_garbage_collect(tree_t *t)
@@ -505,6 +506,9 @@ tree_garbage_collect(tree_t *t)
 	size_t orig_size = t->nodes_size;
 	size_t orig_content_size = (DEBUGL(3) ? tree_actual_size(t) : 0);
 	size_t max_pruned_size = tree_max_pruned_size(t);
+
+	if (DEBUGL(3)) fprintf(stderr, "tree gc     tree: %0.1f Mb -> %0.1f Mb temp space\n",
+			       (float)t->max_tree_size / (1024*1024), (float)max_pruned_size / (1024*1024));
 	
 	/* Temp tree for pruning. */
 	tree_t *t2 = tree_init(t->root_color, max_pruned_size, 0);

--- a/uct/tree.c
+++ b/uct/tree.c
@@ -161,6 +161,28 @@ tree_dump(tree_t *tree, double thres)
 	tree_node_dump(tree, tree->root, 1, 0, thres_abs);
 }
 
+static void
+tree_actual_size_node(tree_t *t, tree_node_t *node, size_t *size)
+{
+	*size += sizeof(*node);
+
+	for (tree_node_t *ni = node->children;  ni;  ni = ni->sibling)
+		tree_actual_size_node(t, ni, size);
+}
+
+/* Walk whole tree and find actual size.
+ * Useful for debugging as t->nodes_size may not reflect actual content:
+ * For example after move promotion or failed tree_alloc_node()'s
+ * (nodes_size is still bumped). */
+size_t
+tree_actual_size(tree_t *t)
+{
+	size_t size = 0;
+	if (t->root)
+		tree_actual_size_node(t, t->root, &size);
+	return size;
+}
+
 
 static char *
 tree_book_name(board_t *b)

--- a/uct/tree.h
+++ b/uct/tree.h
@@ -134,6 +134,7 @@ typedef struct {
 tree_t *tree_init(enum stone color, size_t max_tree_size, int hbits);
 void tree_done(tree_t *tree);
 void tree_dump(tree_t *tree, double thres);
+size_t tree_actual_size(tree_t *t);
 void tree_save(tree_t *tree, board_t *b, int thres);
 void tree_load(tree_t *tree, board_t *b);
 void tree_copy(tree_t *dst, tree_t *src);

--- a/uct/tree.h
+++ b/uct/tree.h
@@ -124,9 +124,11 @@ typedef struct {
 } tree_t;
 
 /* Tree garbage collection:
- * Limit pruning temp space to 20% of memory. Beyond this we discard
- * the nodes and recompute them at the next move if necessary. */
-#define tree_max_pruned_size(t)		((t)->max_tree_size * 20 / 100)
+ * For large trees (>300Mb) limit pruning temp space to 20% of memory. Beyond
+ * this we discard the nodes and recompute them at the next move if necessary. */
+#define tree_max_pruned_size(t)		((t)->max_tree_size <= 300 * 1024 * 1024  ?	\
+					 (t)->max_tree_size :				\
+					 (t)->max_tree_size * 20 / 100)
 #define tree_gc_threshold(t)		((t)->max_tree_size * 10 / 100)
 #define tree_gc_needed(t)		((t)->nodes_size >= tree_gc_threshold((t)))
 

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -547,7 +547,8 @@ genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_al
 	if (u->t) {
 		bool unexpected_color = (color != board_to_play(b));  /* playing twice in a row ?? */
 		bool missing_dcnn_priors = (using_dcnn(b) && !(u->t->root->hints & TREE_HINT_DCNN));
-		if (u->genmove_reset_tree || unexpected_color || missing_dcnn_priors) {
+		if (u->genmove_reset_tree || u->t->untrustworthy_tree ||
+		    unexpected_color || missing_dcnn_priors) {
 			u->initial_extra_komi = u->t->extra_komi;
 			reset_state(u);
 		}

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -599,8 +599,10 @@ uct_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pas
 	if (u->pondering_opt)
 		uct_genmove_pondering_save_replies(u, b, color, best);
 	
-	/* Promote node or throw away tree as needed. */
-	if (!tree_promote_node(u->t, best_node, b, NULL)) {
+	/* Promote node or throw away tree as needed.
+	 * Reset now if we don't reuse tree, avoids unnecessary tree gc. */
+	if (!reusing_tree(u, b) ||
+	    !tree_promote_node(u->t, best_node, b, NULL)) {
 		/* Preserve dynamic komi information though, that is important. */
 		u->initial_extra_komi = u->t->extra_komi;
 		reset_state(u);

--- a/util.h
+++ b/util.h
@@ -12,6 +12,8 @@
 #define MIN(a, b) ((a) < (b) ? (a) : (b));
 #define MAX(a, b) ((a) > (b) ? (a) : (b));
 
+#define swap(x, y)  do { typeof(x) __tmp;  __tmp = (x);  (x) = (y);  (y) = __tmp;  } while(0)
+
 #ifdef __cplusplus
 #define typeof decltype
 #define restrict __restrict__
@@ -131,11 +133,22 @@ checked_calloc(size_t nmemb, size_t size, const char *filename, unsigned int lin
 	return p;
 }
 
+static inline void *
+checked_realloc(void *ptr, size_t size, char *filename, unsigned int line, const char *func)
+{
+	void *p = realloc(ptr, size);
+	if (!p)
+		die("%s:%u: %s: OUT OF MEMORY realloc(%u)\n",
+		    filename, line, func, (unsigned) size);
+	return p;
+}
+
 /* casts: make c++ happy */
 #define cmalloc(size)        checked_malloc((size), __FILE__, __LINE__, __func__)
 #define ccalloc(nmemb, size) checked_calloc((nmemb), (size), __FILE__, __LINE__, __func__)
 #define malloc2(type)        ((type*)cmalloc(sizeof(type)))
 #define calloc2(nmemb, type) ((type*)ccalloc(nmemb, sizeof(type)))
+#define crealloc(ptr, size)  checked_realloc((ptr), (size), __FILE__, __LINE__, __func__)
 
 #define checked_write(fd, pt, size)	(assert(write((fd), (pt), (size)) == (size)))
 #define checked_fread(pt, size, n, f)   (assert(fread((pt), (size), (n), (f)) == (n)))


### PR DESCRIPTION
Fixes issues where most of the tree gets thrown away in case of temp tree overflow during tree gc. Happened with Lizzie when analyzing sometimes for example.

Until now `tree_prune()` was processing the tree depth-first, but this creates issues in case of overflow: If we run out of nodes deep in the tree we don't have enough for toplevel nodes and most of the tree gets discarded.

-> Prune the tree breadth-first instead so only deep nodes get discarded.

`tree_copy()` stays depth-first, it can't overflow (simpler/faster).
(the old `tree_prune()` basically)

Other changes:
- Don't limit pruned size for small trees, keep everything useful.
- Don't bother garbage collecting tree if we don't reuse it anyway (dcnn and no pondering)
