### PR TITLE
Smart Pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # 	make MAC=1 DOUBLE_FLOATING=1
 # or use the short aliases (make fast, make generic ...)
 
-######################### Build #########################
+################################ Build ################################
 
 # Generic build ?
 # If binary will be distributed you need this !
@@ -26,7 +26,7 @@
 
 # MAC=1
 
-#################### Deep Learning ######################
+############################ Deep Learning ############################
 
 # Compile Pachi with dcnn support ?
 # You'll need to install Boost and Caffe libraries.
@@ -41,7 +41,7 @@ DCNN=1
 DCNN_DETLEF=1
 DCNN_DARKFOREST=1
 
-######################## Extras #########################
+############################ Special Builds ###########################
 
 # Fixed board size. Set this to enable more aggressive optimizations
 # if you only play on 19x19. Pachi won't be able to play on other
@@ -75,7 +75,7 @@ DCNN_DARKFOREST=1
 # Compile extra tests ? Enable this to test board implementation.
 # BOARD_TESTS=1
 
-###################### Profiling ########################
+############################## Profiling ##############################
 
 # Enable performance profiling using gprof. Note that this also disables
 # inlining, which allows more fine-grained profile, but may also distort
@@ -89,7 +89,7 @@ DCNN_DARKFOREST=1
 
 # PROFILING=perftools
 
-######################## Install #########################
+############################### Install ###############################
 
 # Target directories when running 'make install' / 'make install-data'.
 # Pachi will look for extra data files (such as dcnn, pattern, joseki or
@@ -109,7 +109,7 @@ CFLAGS       := -std=gnu99 -pthread -Wsign-compare -Wno-format-zero-length
 CXXFLAGS     := -std=c++11
 
 
-##############################################################################
+#########################################################################
 ### CONFIGURATION END
 
 # Main rule + aliases
@@ -141,7 +141,7 @@ double:
 	+@make DOUBLE_FLOATING=1
 
 
-###############################################################################################################
+#######################################################################
 
 MAKEFLAGS += --no-print-directory
 ARCH = $(shell uname -m)
@@ -267,7 +267,7 @@ SUBDIRS   = $(EXTRA_SUBDIRS) uct uct/policy t-unit t-predict engines playout tac
 DATAFILES = patterns_mm.gamma patterns_mm.spat book.dat golast19.prototxt golast.trained joseki19.gtp
 
 
-###############################################################################################################
+############################################################################################################
 
 LOCALLIBS=$(SUBDIRS:%=%/lib.a)
 $(LOCALLIBS): all-recursive

--- a/board.c
+++ b/board.c
@@ -712,19 +712,23 @@ board_official_score_color(board_t *b, move_queue_t *dead, enum stone color)
 bool
 board_set_rules(board_t *board, const char *name)
 {
-	if (!strcasecmp(name, "japanese"))
-		board->rules = RULES_JAPANESE;
-	else if (!strcasecmp(name, "chinese"))
-		board->rules = RULES_CHINESE;
-	else if (!strcasecmp(name, "aga"))
-		board->rules = RULES_AGA;
-	else if (!strcasecmp(name, "new_zealand"))
-		board->rules = RULES_NEW_ZEALAND;
-	else if (!strcasecmp(name, "siming") || !strcasecmp(name, "simplified_ing"))
-		board->rules = RULES_SIMING;
-	else
+	enum rules rules = board_parse_rules(name);
+	if (rules == RULES_INVALID)
 		return false;
+	board->rules = rules;
 	return true;
+}
+
+enum rules
+board_parse_rules(const char *name)
+{
+	if (!strcasecmp(name, "japanese"))       return RULES_JAPANESE;
+	if (!strcasecmp(name, "chinese"))        return RULES_CHINESE;
+	if (!strcasecmp(name, "aga"))            return RULES_AGA;
+	if (!strcasecmp(name, "new_zealand"))    return RULES_NEW_ZEALAND;
+	if (!strcasecmp(name, "siming") ||
+	    !strcasecmp(name, "simplified_ing")) return RULES_SIMING;
+	return RULES_INVALID;
 }
 
 const char*

--- a/board.h
+++ b/board.h
@@ -344,9 +344,10 @@ floating_t board_official_score_color(board_t *b, move_queue_t *dead, enum stone
 floating_t board_official_score_details(board_t *b, move_queue_t *dead, int *dame, int *seki, int *ownermap, struct ownermap *po);
 void       board_print_official_ownermap(board_t *b, move_queue_t *dead);
 
-/* Set board rules according to given string. Returns false in case
- * of unknown ruleset name. */
+/* Set board rules according to given string.
+ * Returns false in case of unknown ruleset. */
 bool board_set_rules(board_t *b, const char *name);
+enum rules board_parse_rules(const char *name);
 const char *rules2str(enum rules rules);
 
 

--- a/gtp.c
+++ b/gtp.c
@@ -335,8 +335,8 @@ cmd_kgs_rules(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	/* Print timestamp at game start, makes logs more useful */
 	if (DEBUGL(2))  fprintf(stderr, "%s\n", time_str());
 	
-	if (forced_ruleset) {
-		if (DEBUGL(2))  fprintf(stderr, "ignored kgs-rules, using %s.\n", forced_ruleset);
+	if (pachi_options()->forced_rules) {
+		if (DEBUGL(2))  fprintf(stderr, "ignored kgs-rules, using %s.\n", rules2str(b->rules));
 		return P_OK;
 	}
 	

--- a/gtp.h
+++ b/gtp.h
@@ -19,26 +19,29 @@ enum parse_code {
 
 typedef struct
 {
+	/* Gtp Options */
+	bool    noundo;               /* undo only allowed for pass */
+	bool    kgs;		      /* show engine comment in version */
+	bool    kgs_chat;             /* enable kgs-chat command ? */
+	char*   custom_name;
+	char*   custom_version;
+	
+	/* Private fields (global) */
+	int     played_games;
+	move_t  move[1500];           /* move history, for undo */
+	int     moves;
+	bool    undo_pending;
+	bool    analyze_mode;         /* analyze mode / genmove mode */
+	bool    analyze_running;
+
+	/* Single cmd scope: */
 	char *cmd;
 	char *next;
 	int   id;
 	bool  quiet;		  /* mute all gtp output */
 	bool  replied;		  /* gtp reply sent */
 	bool  flushed;		  /* gtp_flush() called */
-	bool  error;		  /* gtp_error() / gtp_error_printf() called */
-
-	/* Global fields: */
-	int     played_games;
-	move_t  move[1500];        /* move history, for undo */
-	int     moves;
-	bool    undo_pending;
-	bool    noundo;            /* undo only allowed for pass */
-	bool    kgs;
-	bool    kgs_chat;          /* enable kgs-chat command ? */
-	bool    analyze_mode;      /* analyze mode / genmove mode */
-	bool    analyze_running;
-	char*   custom_name;
-	char*   custom_version;
+	bool  error;		  /* gtp_error() / gtp_error_printf() called */	
 } gtp_t;
 
 #define gtp_arg_next(gtp) \

--- a/network.c
+++ b/network.c
@@ -21,6 +21,7 @@
 #endif
 
 #include "debug.h"
+#include "network.h"
 #include "util.h"
 
 #define STDIN  0
@@ -228,4 +229,12 @@ open_gtp_connection(int *socket, char *port)
 	}
 	if (DEBUGL(0))
 		fprintf(stderr, "gtp connection opened\n");
+}
+
+void
+network_init(char *gtp_port)
+{
+	if (!gtp_port)  return;
+	int gtp_sock = -1;
+	open_gtp_connection(&gtp_sock, gtp_port);
 }

--- a/network.h
+++ b/network.h
@@ -9,6 +9,7 @@
 #include <netinet/in.h>
 #endif
 
+void network_init(char* gtp_port);
 int port_listen(char *port, int max_connections);
 int open_server_connection(int socket, struct in_addr *client);
 void open_log_port(char *port);
@@ -16,6 +17,7 @@ void open_gtp_connection(int *socket, char *port);
 
 #else
 
+#define network_init(gtp_port)
 #define port_listen(port, max_conn)        die("network code not compiled in, enable NETWORK in Makefile\n");
 #define open_server_connection(s, c)       die("network code not compiled in, enable NETWORK in Makefile\n");
 #define open_log_port(port)                die("network code not compiled in, enable NETWORK in Makefile\n");

--- a/ownermap.c
+++ b/ownermap.c
@@ -266,6 +266,8 @@ board_position_final(board_t *b, ownermap_t *ownermap, char **msg)
 					 final_ownermap, dame, final_score, msg);
 }
 
+/* Not thread-safe if called on the main board !  (can call with_move()...)
+ * Must call on board copy in this case. */
 bool
 board_position_final_full(board_t *b, ownermap_t *ownermap,
 			  move_queue_t *dead, move_queue_t *unclear, float score_est,

--- a/ownermap.c
+++ b/ownermap.c
@@ -278,8 +278,8 @@ board_position_final_full(board_t *b, ownermap_t *ownermap,
 		foreach_neighbor(b, dame, {
 			ne[final_ownermap[c]]++;
 		});		
-		if (ne[S_BLACK] + ne[FO_DAME] == 4 ||
-		    ne[S_WHITE] + ne[FO_DAME] == 4) {
+		if (ne[S_BLACK] + ne[FO_DAME] + ne[S_OFFBOARD] == 4 ||
+		    ne[S_WHITE] + ne[FO_DAME] + ne[S_OFFBOARD] == 4) {
 			static char buf[100];
 			sprintf(buf, "non-final position at %s", coord2sstr(dame));
 			*msg = buf;

--- a/ownermap.c
+++ b/ownermap.c
@@ -266,6 +266,23 @@ board_position_final_full(board_t *b, ownermap_t *ownermap,
 		});
 	} foreach_point_end;
 
+	/* Can't have b&w dead groups next to each other */
+	if (dead->moves < 2)  goto skip;
+	foreach_point(b) {
+		group_t g = group_at(b, c);
+		if (!g || !mq_has(dead, g))  continue;
+		enum stone other_color = stone_other(board_at(b, c));
+
+		foreach_neighbor(b, c, {
+			group_t g2 = group_at(b, c);
+			if (!g2 || g2 == g || board_at(b, c) != other_color || !mq_has(dead, g2))
+				continue;
+			*msg = "b&w dead groups next to each other";
+			return false;
+		});
+	} foreach_point_end;
+	
+ skip:
 	/* Non-seki dames surrounded by only dames / border / one color are no dame to me,
 	 * most likely some territories are still open ... */
 	foreach_point(b) {

--- a/ownermap.c
+++ b/ownermap.c
@@ -7,6 +7,7 @@
 #include "debug.h"
 #include "move.h"
 #include "mq.h"
+#include "tactics/1lib.h"
 #include "ownermap.h"
 
 void
@@ -255,6 +256,7 @@ board_position_final_full(board_t *b, ownermap_t *ownermap,
 		group_t g = group_at(b, c);
 		if (!g || board_group_info(b, g).libs > 1)  continue;
 		if (!border_stone(b, c, final_ownermap))  continue;
+		if (capturing_group_is_snapback(b, g))  continue;
 
 		enum stone color = board_at(b, c);
 		foreach_neighbor(b, board_group_info(b, g).lib[0], {

--- a/ownermap.h
+++ b/ownermap.h
@@ -80,8 +80,8 @@ bool board_position_final_full(board_t *b, ownermap_t *ownermap,
 			       int *final_ownermap, int final_dames, float final_score, char **msg);
 
 /* Don't allow passing earlier than that:
- * 19x19: 120    15x15: 56    13x13: 33    9x9: 16 */
-#define board_earliest_pass(b)  (board_rsize2(b) / (7 - 2 * board_rsize(b) / 9))
+ * 19x19: 90    15x15: 56    13x13: 33    9x9: 13 */
+#define board_earliest_pass(b)  (board_rsize2(b) / (7 - board_rsize(b) / 5))
 
 
 #endif

--- a/pachi.h
+++ b/pachi.h
@@ -7,20 +7,25 @@
 struct board;
 struct engine;
 
+/* Global options */
+typedef struct {
+	bool    kgs;
+	bool    nopassfirst;		/* don't pass first when playing chinese */
+	enum rules forced_rules;
+} pachi_options_t;
+
+
 /* Free globals */
 void pachi_done();
 
 /* Init engines */
 void pachi_engine_init(struct engine *e, int id, struct board *b);
 
+/* Get global options */
+const pachi_options_t *pachi_options();
+
 /* Pachi binary */
 extern char *pachi_exe;
-
-/* Ruleset from cmdline, if present. */
-extern char *forced_ruleset;
-
-/* Don't pass first ? Needed when playing chinese rules on kgs or cleanup phase can be abused. */
-bool pachi_nopassfirst(struct board *b);
 
 
 #endif

--- a/pachi.h
+++ b/pachi.h
@@ -11,6 +11,7 @@ struct engine;
 typedef struct {
 	bool    kgs;
 	bool    nopassfirst;		/* don't pass first when playing chinese */
+	bool    guess_unclear_groups;   /* ok to guess unclear dead groups ? (smart pass) */
 	enum rules forced_rules;
 } pachi_options_t;
 

--- a/t-unit/pass_is_safe.t
+++ b/t-unit/pass_is_safe.t
@@ -1,0 +1,28 @@
+
+
+boardsize 19
+komi 0.5
+handicap 6
+. . X O O . . . . . . . . . O O X . .
+. . X X O O . . . . . . . O O X . . .
+. . . X X O O O O . O . . O X X X . .
+. . . X . X O X O O . O O O X X . X X
+X X . . . . X X X O . X . O X . . X X
+O X . X . . . X O . . X X O O X X O X
+O X . . . . . X O O . O O X X X O O O
+O O X X X . X X X O O O X . X O . O .
+. . O O X X X X O X . O X X X O . O .
+. O O X O O X O O O . O O O X X O . O
+. . . . O X X O X X O . . . O X O O X
+. . O . O O O O O X X O . O O O O X X
+. O . O O X X X X X X X O O X X X X .
+. O O X X . . X O X X X X X . X . . .
+O O X . . . X X O X O X X X X . . . .
+O X X X . . . X O O O O O O O X X . .
+X X . . . . X X O . O . . O . O X X .
+. . . . . X X O O . . O . . . O O X X
+. . . . . X O O . . . . . . . . O O X
+
+pass_is_safe w 1    # W+7.5
+rules japanese
+pass_is_safe w 1

--- a/t-unit/pass_is_safe.t
+++ b/t-unit/pass_is_safe.t
@@ -1,5 +1,190 @@
+# pass_is_safe() tests
+# needs --kgs option (smart pass enabled for japanese rules)
+
+% too early to pass
+boardsize 9
+komi 0.5
+. . . . . . . . .
+. . . . X . . . .
+. . O . . . . O .
+. . . . . . . . .
+. . . . . . . . .
+. X . . . . . X .
+. . . . . . . . .
+. . . . X . X . .
+. . . . . . . . .
+
+pass_is_safe b 0
+pass_is_safe w 0
 
 
+% dames left but ok
+boardsize 9
+komi 0.5
+. X . O X . X . .
+. . . O . O . X .
+. . O O O O O O .
+. . O . . . X O .
+. . O X X X X O .
+. . O X O . X O O
+O O O X . . X . O
+X X O X . O . X .
+. X X X X X X X X
+
+pass_is_safe w 1
+pass_is_safe b 0   # losing game
+
+
+% unfinished game, open territories
+boardsize 9
+komi 0.5
+. X . O X . X . .
+. . . O . O . X .
+. . O O O O O . .
+. . O . . . O . .
+. . O X X X O . .
+. . O X O X O . .
+O O O X . X O . .
+X X O X . O X X X
+. X X X X X X . .
+
+pass_is_safe w 0
+
+
+% open territories at the edge
+boardsize 9
+komi 0.5
+. X . O X . X . .
+. . . O . O . X .
+. . O O O O O O .
+. . O . . . X O . 
+. . O X X X X O .
+. . O X O . X O .
+O O O X . . X O .
+X X O X . O . X X
+. X X X X X X X .
+
+pass_is_safe w 0
+
+
+% non-final position at F3
+boardsize 9
+komi 0.5
+. X . O X . X . .
+. . . O X O . X .
+X X . X . X O X X
+O O X . X . X O O)
+. O O X X X X O .
+O . O X O O O O O
+O O O X . . O . O
+X X O X X O O O O
+. X X X X X X X X
+
+pass_is_safe b 0
+
+
+% border stones in atari
+boardsize 9
+komi 0.5
+. X . O X . X . .
+. . . O . O O X .
+. . O O O X O O .
+. . O . X . X O . 
+. . O X X . X O .
+. . O X O . X O .
+O O O X . . X O O
+X X O X . O X X X
+. X X X . X . . .
+
+pass_is_safe w 0
+
+
+% smart pass: unclear groups, must guess
+boardsize 9
+komi 0.5
+. . . . . X X . .
+. O . . O X . X .
+X X X X X X X X X
+O O O X X O X O X
+. . O X X O O O O
+. . O O O O X X O
+. . . . O X . X O
+. O O O X X . X O
+. O X X X . . X O)
+
+rules chinese
+pass_is_safe b 0    # smart pass disabled in chinese
+pass_is_safe w 0
+
+rules japanese
+pass_is_safe b 1    # guesses alive
+pass_is_safe w 1    # guesses wrong ! but intended behavior right now
+
+
+% smart pass: unclear groups, ok in worst-case scenario
+boardsize 9
+komi 0.5
+O O O O O X X . .
+X O . O O X . X .
+. X O O X X X X X
+. . O X X O X O X
+. . O X X O O O O
+. . O O O O X X O
+. . . . O X . X O
+. O O O X X . X O
+. O X X X . . X)O
+
+rules chinese
+pass_is_safe w 0     # smart pass disabled in chinese
+pass_is_safe b 0
+
+rules japanese
+pass_is_safe w 1
+pass_is_safe b 0
+
+
+% dead group not captured yet !
+boardsize 9
+komi 0.5
+. X X X O O O . O
+X . X O O O . O O
+X X O X X O O O .
+X O O X X O . O O
+O O X . X O O O O
+O O X . . X O . O
+. O O X X X O O O
+O . O X X X X X O
+O O O X . X). X O
+
+pass_is_safe w 0         # actual test
+# XXX w can capture b 2 stones at C4 because of damezumari, however
+#     hasn't been played out so can't consider it as dead group yet !
+#     actually works because of non-final position at E4...
+#     add test for these kind of situations ?
+
+!pass_is_safe b 1         # make it fail on purpose
+
+
+% double ko !
+boardsize 9
+komi 0.5
+. X . O X . X . .
+. . . O X O . X .
+X X . X . X O X X
+O O X . X . X O O)
+. O O X X X X O .
+O . O X O O O O O
+O O O X O . O X O
+X X O O X O X . X
+. X X X X X X X X
+
+rules chinese
+!pass_is_safe b 1         # XXX fixme !
+rules japanese
+!pass_is_safe b 1         # XXX fixme !
+
+
+% nothing special, W+7.5
 boardsize 19
 komi 0.5
 handicap 6
@@ -23,6 +208,153 @@ X X . . . . X X O . O . . O . O X X .
 . . . . . X X O O . . O . . . O O X X
 . . . . . X O O . . . . . . . . O O X
 
-pass_is_safe w 1    # W+7.5
+rules chinese
+pass_is_safe w 1
 rules japanese
 pass_is_safe w 1
+
+
+% no time to clarify unclear group at B4 (japanese rules, B+0.5)
+boardsize 19
+rules japanese
+komi 0.5
+passes b 2
+handicap 3
+. . O O O . . O . . O . . . . O O O X
+O X O X O O O . . O . O . O O . O X X
+. O X X X O O . O O O . O O X O O O X
+. O O X X O O O X O X O . O X X X X X
+. O . O X . X X X X X . X X O O X . .
+. . O X X X X X . . . . X . O . O X .
+. O O O O O O X O . O O X O . O O X .
+. . O X X O X O O . O X O O O O X X .
+. . O X X O X X X . O X O X X O X . .
+O O O O X X O O O . O X O O X X X X .
+O X X X . X X O . O O X O O X O X . .
+X X X . . X O X O O O X O O O O X X X
+. O . . . . . X X O X X X O O O X O X
+. . O . . . . X X X . X X X X O O O O
+. . . . . . . X . . . . . . . X O . O
+. O . X . . O O X X X . . X X X O O)X
+. O X . . X X X X X X . X . X . X X X
+. X . . . . . . X . X . X . X . . . .
+. . . . . . . . X . . . X X . . . . .
+
+pass_is_safe b 1
+
+
+% snapback ok for border stone in atari (H4)
+boardsize 19
+rules japanese
+passes b 1
+komi 0.5
+handicap 2
+X . X X . . X O O . . O O X . . . X .
+X . . X X X X X O O . O X X . . X X O
+X X X O O X O O O . O X . . X X X O O
+O X O . O O O . . O . X . X O X O O .
+O O . O O X X O O X X . . X O X X O .
+. . O O O O X X X X O X X O O O O O O
+. O X X O O X . X O O X X X O . . O O
+. O X X X X X . X . O . O O . . . . O
+O O O O O O X X O O O O O . . . O O O
+. O X X X X . X X O . . . . . O X X X
+. O O O O X X O X O O O O O O O X . .
+. . X O X X . O O . . O X . O X . . .
+. . . O O X X O . O O O X . O X . . .
+. . O . X X X O O O X O X X X . X . .
+. O O X . X O O X X X O X O X . . X X
+. O X X . X O X . X . X O O X X X O O
+. . O O X . X O O O X X O O O O O O X
+. O O O O X X X O X . X O . . . O O X
+. . . O X X . . X . X X X)O . O . O .
+
+pass_is_safe w 1
+
+
+% unfinished game, lots of unclear groups !
+boardsize 19
+rules japanese
+komi 0.5
+. X . X X . O . O . X . . . . . . . .
+O O X O O O O . O O X . . . . . . . .
+X . X X X X O O X X . . X . O O O O .
+. X O O . X X X O X . X . X X X X O .
+O X X O X X O O O O O . . . . . X X .
+. O O O . O . . . . . . . . . . O X .
+. . . . . O . . . . . O . . X . O . .
+. . . . . . . . X . O . O O O O . . .
+. . . . . . . O X . O . . . . . O . .
+. . . . . . . O O X . O . . O . O . .
+. . . . . O O X X . X X O . . O . . .
+. . . . . O X . X X O O . O O . X . .
+. . . O O X X X O X X O . . . . . . .
+. . O . X X . X O . O . . . . . . . .
+. . . . . O O O O O . . O . . . . . .
+. . . O . O X X O X O O X X . . X . .
+. . . . O X O X X X X X . . X . . . .
+. . . X X X . . . . . . . . . . . . .
+. . . . . . . . . . . . . . . . . . .
+
+
+pass_is_safe w 0
+
+
+% non-final position check too strict...
+boardsize 19
+komi 0.5
+handicap 5
+. . X O O . . . . . O X X X X . X . .
+. X . X O O . . . O O X O O O X . X .
+. . . X X O . . . O X . X O X X X . .
+. . . X O O . O O O X X X O O X X . .
+X X . X O O O O X X X X O . O X . . .
+O X X X X X O X X . X O O . O X X . .
+O O O O X X O O X . . X O . . O X . .
+. . O X X O O X . X . X O O . O X . .
+O . O O O X O X X . . X O . . O X . .
+. O . O X X O O O X . X O O O X . X X
+. O O X X O O . O X X X O X X X . . .
+O O X X X X X O O O O O X O . X . X X
+. X . X O O X X X X . O X X X X . . X
+X X X X O . O O O X X O O O O O X X X
+O O O X O X . O O O O O . O X X O X .
+. . O X O O O X)X O X X O O O X . . .
+O O O X X O . . X X X . X O O X . . .
+. O O X O O O X X . X X X X O X X . .
+O O X X O O O O X . . . . X O O X . .
+
+# XXX getting non-final position at G3, silly
+#     check eye shape ?
+!pass_is_safe w 1
+
+
+% smart pass: can't pick b&w dead groups next to each other!
+boardsize 19
+komi 6.5
+. . . . . . O . O O O X X X X X . X .
+. O X X X X O . O X X X X O X X X . .
+. O O X O X X O O O O X O O O O X X .
+. O X O O X O O . O X O O . O . O X .
+. . . . . O X . O O X . . X . O O X .
+. . O . . O X . O X X X . X O O . O X
+. . . . . O X . X O X X X X X X O O .
+. . . . . O X . X O O O O O . X X O X
+. . . O O X X . . . . O X X X X X X X
+. . . O X O . . X O O . O X O O O O O
+O O . . X X O O O X O O O O O . O X X
+X O O O O O O O X X X X X O . O O X .
+X X X X X X O X X O X . X O O O X X .
+X . X O O O X X O O X X . X O O X . .
+X O X X O X O O O . O O X X O O X . .
+X X O O O X X O . O O X X X O X . . .
+O O O X X X X O . O X X X O O X . . .
+. O X X . . X X O . O O X O X X . . .
+. X . . . . X O O O . O X X). . . . .
+
+# (artificial example)
+# unclear groups at bottom left, only thing
+# that works is if he picks both groups as
+# dead, which should not be allowed.
+rules japanese
+pass_is_safe w 0

--- a/t-unit/pass_is_safe.t
+++ b/t-unit/pass_is_safe.t
@@ -179,9 +179,9 @@ X X O O X O X . X
 . X X X X X X X X
 
 rules chinese
-!pass_is_safe b 1         # XXX fixme !
+!pass_is_safe b 1	# XXX possibly we never pass under chinese !
 rules japanese
-!pass_is_safe b 1         # XXX fixme !
+pass_is_safe b 1
 
 
 % nothing special, W+7.5

--- a/t-unit/run_tests
+++ b/t-unit/run_tests
@@ -9,7 +9,7 @@ cd $dir
 for f in `git ls-files *.t | tac`; do
     grep -q 'auto-run off' $f  &&  continue
     
-    cmd="./pachi -d2 -u t-unit/$f"
+    cmd="./pachi --kgs -d2 -u t-unit/$f"	# --kgs: needed by pass_is_safe.t
     echo ""; echo "*******************************************************************";
     echo "$cmd"
     (cd ..; $cmd) || die "Failed"

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -19,6 +19,7 @@
 #include "timeinfo.h"
 #include "playout/moggy.h"
 #include "engines/replay.h"
+#include "uct/internal.h"
 #include "ownermap.h"
 
 
@@ -92,11 +93,20 @@ remove_comments(char *line)
 }
 
 static void
-board_print_test(int level, board_t *b)
+board_print_test(board_t *b)
 {
-	if (!DEBUGL(level) || board_printed)
+	if (!DEBUGL(2) || board_printed)
 		return;
 	board_print(b, stderr);
+	board_printed = true;
+}
+
+static void
+engine_board_print_test(engine_t *e, board_t *b)
+{
+	if (!DEBUGL(2) || board_printed)
+		return;
+	engine_board_print(e, b, stderr);
 	board_printed = true;
 }
 
@@ -240,7 +250,7 @@ show_title_if_needed()
 }
 
 #define PRINT_TEST(board, format, ...)	do {			   \
-	board_print_test(2, board);				   \
+	board_print_test(board);				   \
 	if (DEBUGL(1))  fprintf(stderr, format, __VA_ARGS__);	   \
 } while(0)
 
@@ -336,7 +346,6 @@ test_ladder(board_t *b, char *arg)
 	return   (rres == eres);
 }
 
-
 static bool
 test_ladder_any(board_t *b, char *arg)
 {
@@ -358,7 +367,6 @@ test_ladder_any(board_t *b, char *arg)
 	PRINT_RES();
 	return   (rres == eres);
 }
-
 
 static bool
 test_wouldbe_ladder(board_t *b, char *arg)
@@ -406,7 +414,6 @@ test_wouldbe_ladder_any(board_t *b, char *arg)
 	return   (rres == eres);
 }
 
-
 static bool
 test_useful_ladder(board_t *b, char *arg)
 {
@@ -450,7 +457,6 @@ test_can_countercap(board_t *b, char *arg)
 	return   (rres == eres);
 }
 
-
 static bool
 test_two_eyes(board_t *b, char *arg)
 {
@@ -471,6 +477,48 @@ test_two_eyes(board_t *b, char *arg)
 }
 
 
+/* syntax: pass_is_safe color expected_result */
+static bool
+test_pass_is_safe(board_t *b, char *arg)
+{
+	next_arg(arg);
+	enum stone color = str2stone(arg);
+	next_arg(arg);
+	int eres = atoi(arg);
+	args_end();
+
+	DEBUG_QUIET();
+	engine_t *e = new_engine(E_UCT, "", b);
+	uct_t *u = (uct_t*)(e->data);
+	DEBUG_QUIET_END();
+
+	/* Not exactly same as game conditions as we just run some playouts
+	 * instead of full tree search, but should be good enough for testing. */
+
+	// show board with ownermap
+	engine_ownermap(e, b);
+	engine_board_print_test(e, b);
+	PRINT_TEST(b, "pass_is_safe %s ?\n", stone2str(color));
+	
+	char *msg;
+	move_queue_t dead;
+	int rres = uct_pass_is_safe(u, b, color, false, &dead, &msg, DEBUGL(2));
+
+	if (DEBUGL(2) && rres)  {
+		fprintf(stderr, "-> yes: final score %s  (%s)\n", board_official_score_str(b, &dead), rules2str(b->rules));
+		board_print_official_ownermap(b, &dead);
+	}
+	if (DEBUGL(2) && !rres)  // show reason
+		fprintf(stderr, "-> no:  %s\n", msg);
+	
+	PRINT_TEST(b, "pass_is_safe %s %d...\t", stone2str(color), eres);
+
+	engine_done(e);
+	
+	PRINT_RES();
+	return   (rres == eres);
+}
+
 /* Sample moves played by moggy in a given position.
  * Board last move matters quite a lot and must be set.
  * 
@@ -483,7 +531,7 @@ test_moggy_moves(board_t *b, char *arg)
 
 	args_end();
 	if (!tunit_over_gtp) assert(last_move_set);
-	board_print_test(2, b);
+	board_print_test(b);
 
 	char e_arg[128];  sprintf(e_arg, "runs=%i", runs);
 	engine_t e;  engine_init(&e, E_REPLAY, e_arg, b);
@@ -577,7 +625,7 @@ test_moggy_status(board_t *b, char *arg)
 	if (!tunit_over_gtp) assert(last_move_set);
 	
 	enum stone color = board_to_play(b);
-	board_print_test(2, b);
+	board_print_test(b);
 	if (DEBUGL(2)) {
 		fprintf(stderr, "moggy status ");
 		for (int i = 0; i < n; i++) {
@@ -648,6 +696,7 @@ static t_unit_cmd commands[] = {
 	{ "moggy moves",            test_moggy_moves,           },
 	{ "moggy status",           test_moggy_status,          },
 	{ "false_eye_seki",         test_false_eye_seki,        },
+	{ "pass_is_safe",           test_pass_is_safe,          },
 #ifdef BOARD_TESTS
 	{ "board_undo_stress_test", board_undo_stress_test,     },
 	{ "board_regtest",          board_regression_test,      },
@@ -722,7 +771,7 @@ unit_test(char *filename)
 		if (str_prefix("rules ", line))     {  init_arg(line); set_rules(b, next); continue;  }
 		if (str_prefix("komi ", line))      {  init_arg(line); set_komi(b, next); continue;  }
 		if (str_prefix("ko ", line))	    {  init_arg(line); set_ko(b, next); continue;  }
-
+		
 		if (optional)  {  total_opt++;  passed_opt += unit_test_cmd(b, line); }
 		else           {  total++;      passed     += unit_test_cmd(b, line); }
 	}

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -160,7 +160,7 @@ typedef struct uct {
 
 #define UDEBUGL(n) DEBUGL_(u->debug_level, n)
 
-bool uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, char **msg);
+bool uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, move_queue_t *dead, char **msg, bool log);
 void uct_prepare_move(uct_t *u, board_t *b, enum stone color);
 void uct_genmove_setup(uct_t *u, board_t *b, enum stone color);
 void uct_pondering_stop(uct_t *u);

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -138,6 +138,7 @@ typedef struct uct {
 	double mcts_time;
 
 	/* Game state - maintained by setup_state(), reset_state(). */
+	board_t *main_board;
 	tree_t *t;
 	bool tree_ready;
 } uct_t;

--- a/uct/policy/generic.c
+++ b/uct/policy/generic.c
@@ -39,8 +39,9 @@ uctp_generic_choose(uct_policy_t *p, tree_node_t *node, board_t *b, enum stone c
 	 * (endgame situation that can't be clarified ...)
 	 * Call expensive uct_pass_is_safe() only if pass is indeed the best move. */
 	char *msg;
+	move_queue_t dead;
 	if (is_pass(node_coord(nbest)) &&
-	    !uct_pass_is_safe(p->uct, b, color, p->uct->pass_all_alive, &msg) &&
+	    !uct_pass_is_safe(p->uct, b, color, p->uct->pass_all_alive, &dead, &msg, false) &&
 	    nbest2 && !board_is_one_point_eye(b, node_coord(nbest2), color))
 		return nbest2;
 	return nbest;

--- a/uct/search.c
+++ b/uct/search.c
@@ -724,18 +724,19 @@ uct_search_check_stop(uct_t *u, board_t *b, enum stone color,
 	return false;
 }
 
-/* uct_pass_is_safe() also called by uct policy, beware.  */
+/* Check pass is safe and save dead groups for later, must use
+ * same dead groups at scoring time or we might lose the game.
+ * Do this here, uct_pass_is_safe() also called by uct policy */
 static bool
 uct_search_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, char **msg)
 {
-	bool res = uct_pass_is_safe(u, b, color, pass_all_alive, msg);
+	move_queue_t dead;
+	bool res = uct_pass_is_safe(u, b, color, pass_all_alive, &dead, msg, true);
 
 	/* Save dead groups for final_status_list dead. */
 	if (res) {
-		move_queue_t unclear;
-		move_queue_t *dead = &u->dead_groups;
+		u->dead_groups = dead;
 		u->pass_moveno = b->moves + 1;
-		ownermap_dead_groups(b, &u->ownermap, dead, &unclear);
 	}
 	return res;
 }

--- a/uct/search.c
+++ b/uct/search.c
@@ -743,8 +743,10 @@ uct_search_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_al
 static bool
 uct_pass_first(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, coord_t coord)
 {	
-	/* For kgs: must not pass first in main game phase when playing chinese. */
-	bool can_pass_first = (!pachi_nopassfirst(b) || pass_all_alive);
+	/* For kgs: when playing chinese must not pass first
+	 * in main game phase or cleanup phase can be abused. */
+	bool pachi_nopassfirst = (pachi_options()->nopassfirst && b->rules == RULES_CHINESE);
+	bool can_pass_first = (!pachi_nopassfirst || pass_all_alive);
 	if (!can_pass_first)  return false;
 
 	if (is_pass(coord) || is_pass(last_move(b).coord))  return false;

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -8,6 +8,7 @@
 #define DEBUG
 
 #include "debug.h"
+#include "pachi.h"
 #include "board.h"
 #include "gtp.h"
 #include "chat.h"
@@ -103,51 +104,148 @@ uct_prepare_move(uct_t *u, board_t *b, enum stone color)
 #endif
 }
 
-/* Does the board look like a final position ?
- * And do we win counting, considering that given groups are dead ?
- * (if allow_losing_pass wasn't set) */
+static bool pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, char **msg, bool log,
+			 move_queue_t *dead, move_queue_t *dead_extra, move_queue_t *unclear,
+			 bool unclear_kludge, char *label);
+static bool pass_is_safe_(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, char **msg,
+			  move_queue_t *dead, move_queue_t *unclear, bool unclear_kludge);
+
+/* Does the board look like a final position, and do we win counting ?
+ * (if allow_losing_pass was set we don't care about score)
+ * If true, returns dead groups used to evaluate position in @dead
+ * (possibly guessed if there are unclear groups). */
 bool
-uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, char **msg)
+uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive,
+		 move_queue_t *dead, char **msg, bool log)
 {
+	mq_init(dead);
+	
 	/* Check this early, no need to go through the whole thing otherwise. */
 	*msg = "too early to pass";
 	if (b->moves < board_earliest_pass(b))
 		return false;
 	
 	/* Make sure enough playouts are simulated to get a reasonable dead group list. */
-	move_queue_t dead, unclear;	
+	move_queue_t dead_orig;
+	move_queue_t unclear_orig;
 	uct_mcowner_playouts(u, b, color);
-	ownermap_dead_groups(b, &u->ownermap, &dead, &unclear);
+	ownermap_dead_groups(b, &u->ownermap, &dead_orig, &unclear_orig);
 
+#define init_pass_is_safe_groups()  do {	\
+		unclear = unclear_orig;		\
+		*dead = dead_orig;		\
+		mq_init(&dead_extra);		\
+	} while (0)
+
+	move_queue_t unclear;
+	move_queue_t dead_extra;
+	init_pass_is_safe_groups();
+	
+	if (DEBUGL(2) && log && unclear.moves)  mq_print_line("unclear groups: ", &unclear);
+
+	/* Guess unclear groups ?
+	 * By default Pachi is fairly pedantic at the end of the game and will 
+	 * refuse to pass until everything is nice and clear to him. This can 
+	 * take some moves depending on the situation if there are unclear
+	 * groups. Guessing allows more user-friendly behavior, passing earlier
+	 * without having to clarify everything. Under japanese rules this can
+	 * also prevent him from losing the game if clarifying would cost too
+	 * many points.
+	 * Even though Pachi will only guess won positions there is a possibility
+	 * of getting dead group status wrong, so only ok if game setup asks
+	 * players for dead stones and game can resume in case of disagreement
+	 * (auto-scored games like on ogs for example are definitely not ok).
+	 * -> Only enabled if user asked for it or playing japanese on kgs
+	 * (for chinese don't risk screwing up and ending up in cleanup phase) */
+	bool guess_unclear_ok = pachi_options()->guess_unclear_groups;
+	if (pachi_options()->kgs)
+		guess_unclear_ok = (b->rules == RULES_JAPANESE);
+
+	/* smart pass: try worst-case scenario first:
+	 * own unclear groups are dead and opponent's are alive.
+	 * If we still win this way for sure it's ok. */
+	if (guess_unclear_ok && unclear.moves) {
+		for (unsigned int i = 0; i < unclear.moves; i++)
+			if (board_at(b, unclear.move[i]) == color)
+				mq_add(&dead_extra, unclear.move[i], 0);    /* own groups -> dead */
+		unclear.moves = 0;                                          /* opponent's groups -> alive */
+		if (pass_is_safe(u, b, color, pass_all_alive, msg, log,
+				 dead, &dead_extra, &unclear, true, "(worst-case)"))
+			return true;
+		init_pass_is_safe_groups();  /* revert changes */
+	}
+
+	/* Strict mode then: don't pass until everything is clarified. */
+	return pass_is_safe(u, b, color, pass_all_alive, msg, log,
+			    dead, &dead_extra, &unclear, false, "");
+}
+
+static bool
+pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, char **msg, bool log,
+	     move_queue_t *dead, move_queue_t *dead_extra, move_queue_t *unclear,
+	     bool unclear_kludge, char *label)
+{
+	move_queue_t guessed;  guessed = *dead_extra;
+	mq_append(dead, dead_extra);
+	
+	bool r = pass_is_safe_(u, b, color, pass_all_alive, msg, dead, unclear, unclear_kludge);
+
+	/* smart pass: log guessed unclear groups if successful    (DEBUGL(2)) */
+	if (unclear_kludge && log && r && DEBUGL(2) && !DEBUGL(3)) {
+		mq_print("pass ok assuming dead: ", &guessed);
+		fprintf(stderr, "%s\n", label);
+	}
+
+	/* smart pass: log failed attempts as well                 (DEBUGL(3)) */
+	if (unclear_kludge && log && DEBUGL(3)) { /* log everything */
+		fprintf(stderr, "  pass %s ", (r ? "ok" : "no"));
+		int n = 0;
+		n += mq_print("assuming dead: ", &guessed);
+		fprintf(stderr, "%*s -> %-7s %s %s\n", abs(50-n), "",
+			board_official_score_str(b, dead), (r ? "" : *msg), label);
+	}
+	
+	return r;
+}
+
+static bool
+pass_is_safe_(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, char **msg,
+	      move_queue_t *dead, move_queue_t *unclear, bool unclear_kludge)
+{
 	bool check_score = !u->allow_losing_pass;
 
-	if (pass_all_alive) {
+	if (pass_all_alive) {  /* kgs chinese rules cleanup phase */
 		*msg = "need to remove opponent dead groups first";
-		for (unsigned int i = 0; i < dead.moves; i++)
-			if (board_at(b, dead.move[i]) == stone_other(color))
+		for (unsigned int i = 0; i < dead->moves; i++)
+			if (board_at(b, dead->move[i]) == stone_other(color))
 				return false;
-		dead.moves = 0; // our dead stones are alive when pass_all_alive is true
+		dead->moves = 0; // our dead stones are alive when pass_all_alive is true
 
-		float final_score = board_official_score_color(b, &dead, color);
+		float final_score = board_official_score_color(b, dead, color);
 		*msg = "losing on official score";
 		return (check_score ? final_score >= 0 : true);
 	}
-
-	/* Check score estimate first, official score is off if position is not final */
-	*msg = "losing on score estimate";
-	floating_t score_est = ownermap_score_est_color(b, &u->ownermap, color);
-	if (check_score && score_est < 0)  return false;
 	
 	int final_ownermap[board_max_coords(b)];
 	int dame, seki;
-	floating_t final_score = board_official_score_details(b, &dead, &dame, &seki, final_ownermap, &u->ownermap);
+	floating_t final_score = board_official_score_details(b, dead, &dame, &seki, final_ownermap, &u->ownermap);
 	if (color == S_BLACK)  final_score = -final_score;
+
+	floating_t score_est;
+	if (unclear_kludge)
+		score_est = final_score;   /* unclear groups, can't trust score est ... */
+	else {
+		/* Check score estimate first, official score is off if position is not final */
+		*msg = "losing on score estimate";
+		score_est = ownermap_score_est_color(b, &u->ownermap, color);
+		if (check_score && score_est < 0)  return false;
+	}
 	
 	/* Don't go to counting if position is not final. */
-	if (!board_position_final_full(b, &u->ownermap, &dead, &unclear, score_est,
+	if (!board_position_final_full(b, &u->ownermap, dead, unclear, score_est,
 				       final_ownermap, dame, final_score, msg))
 		return false;
-	
+
 	*msg = "losing on official score";
 	return (check_score ? final_score >= 0 : true);
 }
@@ -291,7 +389,7 @@ uct_dead_groups(engine_t *e, board_t *b, move_queue_t *dead)
 
 	/* Normally last genmove was a pass and we've already figured out dead groups.
 	 * Don't recompute dead groups here, result could be different this time and
-	 * lead to wrong list. */
+	 * lead to bad result ! */
 	if (u->pass_moveno == b->moves || u->pass_moveno == b->moves - 1) {
 		memcpy(dead, &u->dead_groups, sizeof(*dead));
 		return;

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -48,6 +48,7 @@ setup_state(uct_t *u, board_t *b, enum stone color)
 {
 	size_t size = u->tree_size;
 	if (DEBUGL(3)) fprintf(stderr, "allocating %i Mb for search tree\n", (int)(size / (1024*1024)));
+	u->main_board = b;
 	u->t = tree_init(color, size, stats_hbits(u));
 	if (u->initial_extra_komi)
 		u->t->extra_komi = u->initial_extra_komi;
@@ -71,6 +72,7 @@ reset_state(uct_t *u)
 	assert(u->t);
 	tree_done(u->t);
 	u->t = NULL;
+	u->main_board = NULL;
 }
 
 static void
@@ -124,6 +126,14 @@ uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive,
 	*msg = "too early to pass";
 	if (b->moves < board_earliest_pass(b))
 		return false;
+
+	/* Must be thread-safe inasmuch as this also gets called from the main thread
+	 * through uct policy choose() (uct_progress_status(), uct_search_check_stop())
+	 * and main board may not be changed even for a split second without risking
+	 * having another thread grab it in an invalid state.
+	 * board_position_final() uses with_move() so copy board first. */
+	board_t b2;
+	if (b == u->main_board) {  board_copy(&b2, b);  b = &b2;  }
 	
 	/* Make sure enough playouts are simulated to get a reasonable dead group list. */
 	move_queue_t dead_orig;


### PR DESCRIPTION
Guess unclear groups for more user-friendly pass behavior :

By default Pachi is fairly pedantic at the end of the game and will refuse to pass until everything is nice and clear to him. This can take some moves depending on the situation if there are unclear groups. Guessing allows more user-friendly behavior, passing earlier without having to clarify everything. Under japanese rules this can also prevent him from losing the game if clarifying would cost too many points. 

Even though Pachi will only guess won positions there is a possibility of getting dead group status wrong, so only ok if game setup asks players for dead stones and game can resume in case of disagreement (auto-scored games like on ogs for example are definitely not ok). 

Basically:
- Direct interactive play           : ok 
- Any kind of automated / online play : no ! 
- Except online play on kgs         : ok   (enabled automatically) 
 
So off by default except when playing japanese on kgs. 

Some `uct_pass_is_safe()` / `board_position_final()` fixes as well.
