### PR TITLE
GTP cleanup

### DIFF
--- a/board.c
+++ b/board.c
@@ -405,7 +405,7 @@ board_handicap_stone(board_t *board, int x, int y, move_queue_t *q)
 void
 board_handicap(board_t *board, int stones, move_queue_t *q)
 {
-	assert(stones <= 9);
+	assert(stones >= 0 && stones <= 9);
 	int margin = 3 + (board_rsize(board) >= 13);
 	int min = margin;
 	int mid = board_stride(board) / 2;

--- a/engine.h
+++ b/engine.h
@@ -78,7 +78,8 @@ struct engine {
 
 	options_t options;
 
-	bool keep_on_clear;			    /* If set, do not reset the engine state on clear_board. */
+	bool keep_on_clear;			    /* Do not reset engine on clear_board. */
+	bool keep_on_undo;			    /* Do not reset engine after undo. */
 
 	engine_setoption_t       setoption;	    /* Set/change engine option. Don't call directly.
 						     * @optname/@optval: option name/value. @optval may be changed by engine.

--- a/engine.h
+++ b/engine.h
@@ -75,6 +75,7 @@ struct engine {
 	int   id;
 	char *name;
 	char *comment;
+	char *version;				    /* Replaces default gtp answer if present. */
 
 	options_t options;
 

--- a/engine.h
+++ b/engine.h
@@ -115,6 +115,15 @@ struct engine {
 };
 
 
+/* Initial sanity checks. */
+void engine_init_checks(void);
+
+/* Convert engine name to id. */
+enum engine_id engine_name_to_id(const char *name);
+
+/* List supported engines (show_all: show/hide internal engines). */
+char* supported_engines(bool show_all);
+
 /* Initialize engine. Call engine_done() later when finished with it. */
 void engine_init(engine_t *e, int id, const char *e_arg, board_t *b);
 

--- a/gogui.c
+++ b/gogui.c
@@ -557,8 +557,8 @@ cmd_gogui_joseki_moves(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 enum parse_code
 cmd_gogui_joseki_show_pattern(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	char *arg;  gtp_arg(arg);
-	coord_t coord = str2coord(arg);
+	coord_t coord;
+	gtp_arg_coord(coord);
 
 	gtp_printf(gtp, "");  /* gtp prefix */
 	gogui_show_pattern(b, coord, JOSEKI_PATTERN_DIST);
@@ -671,8 +671,9 @@ josekifix_gogui_show_patterns(struct board *b)
 enum parse_code
 cmd_gogui_josekifix_set_coord(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	char *arg;  gtp_arg(arg);
-	coord_t coord = str2coord(arg);
+	coord_t coord;
+	gtp_arg_coord(coord);
+	
 	josekifix_set_coord(coord);
 	return cmd_gogui_josekifix_show_pattern(b, e, ti, gtp);
 }
@@ -759,9 +760,9 @@ enum parse_code
 cmd_gogui_pattern_features(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	enum stone color = board_to_play(b);
-	
-	char *arg;  gtp_arg(arg);
-	coord_t coord = str2coord(arg);
+	coord_t coord;
+	gtp_arg_coord(coord);
+
 	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...");  return P_OK;  }
 	
 	pattern_t p;
@@ -787,9 +788,10 @@ cmd_gogui_pattern_features(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 enum parse_code
 cmd_gogui_pattern_gammas(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	enum stone color = board_to_play(b);	
-	char *arg;  gtp_arg(arg);
-	coord_t coord = str2coord(arg);
+	enum stone color = board_to_play(b);
+	coord_t coord;
+	gtp_arg_coord(coord);
+	
 	if (board_at(b, coord) != S_NONE)  {  gtp_reply(gtp, "TEXT Must be empty spot ...");  return P_OK;  }
 
 	pattern_t p;
@@ -814,8 +816,8 @@ cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (!pattern_engine)   init_pattern_engine(b);
 	pattern_config_t *pc = pattern_engine_get_pc(pattern_engine);
 
-	char *arg;  gtp_arg(arg);
-	coord_t coord = str2coord(arg);
+	coord_t coord;
+	gtp_arg_coord(coord);
 
 	gtp_printf(gtp, "");   /* gtp prefix */
 	gogui_show_pattern(b, coord, spatial_dist);
@@ -836,11 +838,14 @@ cmd_gogui_show_spatial(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 enum parse_code
 cmd_gogui_spatial_size(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	char *arg;  gtp_arg_optional(arg);
-	/* Return current value */
-	if (!*arg) {  gtp_printf(gtp, "%i\n", spatial_dist);  return P_OK;  }
+	/* No argument: Return current value */
+	if (!*gtp->next) {
+		gtp_printf(gtp, "%i\n", spatial_dist);
+		return P_OK;
+	}
 
-	int d = atoi(arg);
+	int d;
+	gtp_arg_number(d);
 	if (d < 3 || d > 10) {  gtp_error(gtp, "Between 3 and 10 please");  return P_OK;  }
 	spatial_dist = d;
 	return P_OK;

--- a/gtp.c
+++ b/gtp.c
@@ -99,11 +99,14 @@ gtp_error(gtp_t *gtp, const char *str)
 {
 	gtp->error = true;
 	
-	/* errors never quiet */
+	/* Errors never quiet */
 	gtp_prefix(gtp, '?');
 	fputs(str, stdout);
 	putchar('\n');
 	gtp_flush(gtp);  /* flush errors right away */
+
+	if (gtp->fatal)
+		die("Command '%s' failed, aborting: %s\n", gtp->cmd, str);
 }
 
 /* Output anything (no \n added). */
@@ -134,6 +137,12 @@ gtp_error_printf(gtp_t *gtp, const char *format, ...)
 	vprintf(format, ap);
 	gtp_flush(gtp);   /* flush errors right away */
 
+	if (gtp->fatal) {
+		fprintf(stderr, "Command '%s' failed, aborting: ", gtp->cmd);
+		vfprintf(stderr, format, ap);
+		exit(EXIT_FAILURE);
+	}
+	
 	va_end(ap);	
 }
 

--- a/gtp.c
+++ b/gtp.c
@@ -166,7 +166,6 @@ known_commands(gtp_t *gtp)
 		sbprintf(buf, "%s\n", commands[i].cmd);
 	}
 	
-	sbprintf(buf, "gogui-analyze_commands\n");
 	return buf->str;
 }
 
@@ -1073,82 +1072,81 @@ cmd_kgs_time_settings(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 
 
 static gtp_command_t gtp_commands[] =
-{
-	{ "protocol_version",       cmd_protocol_version },
-	{ "name",                   cmd_name },
-	{ "echo",                   cmd_echo },
-	{ "version",                cmd_version },
-	{ "list_commands",          cmd_list_commands },
-	{ "known_command",          cmd_known_command },
-	{ "quit",                   cmd_quit },
+{								/* Core GTP commands */
 	{ "boardsize",              cmd_boardsize },
 	{ "clear_board",            cmd_clear_board },
-	{ "komi",                   cmd_komi },
-	{ "play",                   cmd_play },
-	{ "genmove",                cmd_genmove },
-	{ "time_left",              cmd_time_left },
-	{ "time_settings",          cmd_kgs_time_settings },
-	{ "set_free_handicap",      cmd_set_free_handicap },
-	{ "place_free_handicap",    cmd_fixed_handicap },
-	{ "fixed_handicap",         cmd_fixed_handicap },
+	{ "echo",                   cmd_echo },
 	{ "final_score",            cmd_final_score },
 	{ "final_status_list",      cmd_final_status_list },
+	{ "fixed_handicap",         cmd_fixed_handicap },
+	{ "genmove",                cmd_genmove },
+	{ "known_command",          cmd_known_command },
+	{ "komi",                   cmd_komi },
+	{ "list_commands",          cmd_list_commands },
+	{ "name",                   cmd_name },
+	{ "place_free_handicap",    cmd_fixed_handicap },
+	{ "play",                   cmd_play },
+	{ "protocol_version",       cmd_protocol_version },
+	{ "quit",                   cmd_quit },
+	{ "set_free_handicap",      cmd_set_free_handicap },
+	{ "showboard",              cmd_showboard },
+	{ "time_left",              cmd_time_left },
 	{ "undo",                   cmd_undo },
-	{ "showboard",              cmd_showboard },   	/* ogs */
-
-	{ "kgs-game_over",          cmd_kgs_game_over },
-	{ "kgs-rules",              cmd_kgs_rules },
-	{ "kgs-genmove_cleanup",    cmd_genmove },
-	{ "kgs-time_settings",      cmd_kgs_time_settings },
-	{ "kgs-chat",               cmd_kgs_chat },
-
-	{ "pachi-predict",          cmd_pachi_predict },
-	{ "pachi-tunit",            cmd_pachi_tunit },
-	{ "pachi-genmoves",         cmd_pachi_genmoves },
-	{ "pachi-genmoves_cleanup", cmd_pachi_genmoves },
-	{ "pachi-gentbook",         cmd_pachi_gentbook },
-	{ "pachi-dumptbook",        cmd_pachi_dumptbook },
-	{ "pachi-evaluate",         cmd_pachi_evaluate },
-	{ "pachi-result",           cmd_pachi_result },
-	{ "pachi-score_est",        cmd_pachi_score_est },
-	{ "pachi-setoption",	    cmd_pachi_setoption },  /* Set/change engine option */
-	{ "pachi-getoption",	    cmd_pachi_getoption },  /* Get engine option(s) */
-
-	{ "lz-analyze",             cmd_lz_analyze },         /* Lizzie, Sabaki, etc */
-	{ "lz-genmove_analyze",     cmd_lz_genmove_analyze },
-
-	/* Short aliases */
+	{ "version",                cmd_version },
+								/* Aliases */
 	{ "predict",                cmd_pachi_predict },
-	{ "tunit",		    cmd_pachi_tunit },
 	{ "score_est",              cmd_pachi_score_est },
-
+	{ "time_settings",          cmd_kgs_time_settings },
+	{ "tunit",		    cmd_pachi_tunit },
+								/* GoGui commands */
 	{ "gogui-analyze_commands", cmd_gogui_analyze_commands },
-	{ "gogui-livegfx",          cmd_gogui_livegfx },
-	{ "gogui-influence",        cmd_gogui_influence },
-	{ "gogui-score_est",        cmd_gogui_score_est },
-	{ "gogui-final_score",      cmd_gogui_final_score },
 	{ "gogui-best_moves",       cmd_gogui_best_moves },
-	{ "gogui-winrates",         cmd_gogui_winrates },
-	{ "gogui-joseki_moves",     cmd_gogui_joseki_moves },
-	{ "gogui-joseki_show_pattern", cmd_gogui_joseki_show_pattern },
+	{ "gogui-color_palette",    cmd_gogui_color_palette },
 #ifdef DCNN
 	{ "gogui-dcnn_best",        cmd_gogui_dcnn_best },
 	{ "gogui-dcnn_colors",      cmd_gogui_dcnn_colors },
 	{ "gogui-dcnn_rating",      cmd_gogui_dcnn_rating },
-#endif /* DCNN */
-	{ "gogui-pattern_best",     cmd_gogui_pattern_best },
-	{ "gogui-pattern_colors",   cmd_gogui_pattern_colors },
-	{ "gogui-pattern_rating",   cmd_gogui_pattern_rating },
-	{ "gogui-pattern_features", cmd_gogui_pattern_features },
-	{ "gogui-pattern_gammas",   cmd_gogui_pattern_gammas },
-	{ "gogui-show_spatial",     cmd_gogui_show_spatial },
-	{ "gogui-spatial_size",     cmd_gogui_spatial_size },
-	{ "gogui-color_palette",    cmd_gogui_color_palette },
+#endif
+	{ "gogui-final_score",      cmd_gogui_final_score },
+	{ "gogui-influence",        cmd_gogui_influence },
+	{ "gogui-joseki_moves",     cmd_gogui_joseki_moves },
+	{ "gogui-joseki_show_pattern", cmd_gogui_joseki_show_pattern },
 #ifdef JOSEKIFIX
+	{ "gogui-josekifix_dump_templates", cmd_gogui_josekifix_dump_templates },
 	{ "gogui-josekifix_set_coord",    cmd_gogui_josekifix_set_coord },
 	{ "gogui-josekifix_show_pattern", cmd_gogui_josekifix_show_pattern },
-	{ "gogui-josekifix_dump_templates", cmd_gogui_josekifix_dump_templates },
 #endif
+	{ "gogui-livegfx",          cmd_gogui_livegfx },
+	{ "gogui-pattern_best",     cmd_gogui_pattern_best },
+	{ "gogui-pattern_colors",   cmd_gogui_pattern_colors },
+	{ "gogui-pattern_features", cmd_gogui_pattern_features },
+	{ "gogui-pattern_gammas",   cmd_gogui_pattern_gammas },
+	{ "gogui-pattern_rating",   cmd_gogui_pattern_rating },
+	{ "gogui-score_est",        cmd_gogui_score_est },
+	{ "gogui-show_spatial",     cmd_gogui_show_spatial },
+	{ "gogui-spatial_size",     cmd_gogui_spatial_size },
+	{ "gogui-winrates",         cmd_gogui_winrates },
+								/* KGS commands */
+	{ "kgs-chat",               cmd_kgs_chat },
+	{ "kgs-game_over",          cmd_kgs_game_over },
+	{ "kgs-genmove_cleanup",    cmd_genmove },
+	{ "kgs-rules",              cmd_kgs_rules },
+	{ "kgs-time_settings",      cmd_kgs_time_settings },
+								/* Lizzie, Sabaki, etc */
+	{ "lz-analyze",             cmd_lz_analyze },
+	{ "lz-genmove_analyze",     cmd_lz_genmove_analyze },
+								/* Pachi */
+	{ "pachi-dumptbook",        cmd_pachi_dumptbook },
+	{ "pachi-evaluate",         cmd_pachi_evaluate },
+	{ "pachi-genmoves",         cmd_pachi_genmoves },
+	{ "pachi-genmoves_cleanup", cmd_pachi_genmoves },
+	{ "pachi-gentbook",         cmd_pachi_gentbook },
+	{ "pachi-getoption",	    cmd_pachi_getoption },	/* Get engine option(s) */
+	{ "pachi-predict",          cmd_pachi_predict },
+	{ "pachi-result",           cmd_pachi_result },
+	{ "pachi-score_est",        cmd_pachi_score_est },
+	{ "pachi-setoption",	    cmd_pachi_setoption },	/* Set engine option */	
+	{ "pachi-tunit",            cmd_pachi_tunit },
 
 	{ 0, 0 }
 };

--- a/gtp.c
+++ b/gtp.c
@@ -233,7 +233,10 @@ cmd_echo(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 static enum parse_code
 cmd_version(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
-	gtp_printf(gtp, "%s", PACHI_VERSION);
+	if (e->version)
+		gtp_printf(gtp, "%s", e->version);
+	else
+		gtp_printf(gtp, "%s", PACHI_VERSION);
 
 	/* Show josekifix status */
  	if (!get_josekifix_enabled() && e->id == E_UCT)

--- a/gtp.c
+++ b/gtp.c
@@ -292,7 +292,8 @@ cmd_boardsize(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	}
 	board_resize(b, size);
 	board_clear(b);
-	return P_ENGINE_RESET;
+
+	return (e->keep_on_clear ? P_OK : P_ENGINE_RESET);
 }
 
 static enum parse_code
@@ -303,7 +304,7 @@ cmd_clear_board(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	if (DEBUGL(3) && debug_boardprint)
 		board_print(b, stderr);
 
-	return P_ENGINE_RESET;
+	return (e->keep_on_clear ? P_OK : P_ENGINE_RESET);
 }
 
 static enum parse_code

--- a/gtp.c
+++ b/gtp.c
@@ -1006,6 +1006,25 @@ cmd_pachi_tunit(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 	return P_OK;
 }
 
+/* Let gtp check correct engine is running (but not change it).
+ * For unit testing. Abort if wrong engine is being used.
+ * Usage: pachi-engine <engine_name>  */
+static enum parse_code
+cmd_pachi_engine(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
+{
+	char *arg;
+	gtp_arg(arg);
+
+	int id = engine_name_to_id(arg);
+	if (id == E_MAX)
+		gtp_error_printf(gtp, "bad engine '%s'\n", arg);
+	else if (id != e->id)
+		die("GTP expects engine '%s', aborting.\n"
+		    "Try running 'pachi -e %s'\n", arg, arg);
+	
+	return P_OK;
+}
+
 static enum parse_code
 cmd_kgs_chat(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
@@ -1149,6 +1168,7 @@ static gtp_command_t gtp_commands[] =
 	{ "lz-genmove_analyze",     cmd_lz_genmove_analyze },
 								/* Pachi */
 	{ "pachi-dumptbook",        cmd_pachi_dumptbook },
+	{ "pachi-engine",	    cmd_pachi_engine },
 	{ "pachi-evaluate",         cmd_pachi_evaluate },
 	{ "pachi-genmoves",         cmd_pachi_genmoves },
 	{ "pachi-genmoves_cleanup", cmd_pachi_genmoves },

--- a/gtp.h
+++ b/gtp.h
@@ -23,6 +23,7 @@ typedef struct
 	bool		noundo;			/* undo only allowed for pass */
 	bool		kgs;			/* kgs mode */
 	bool		kgs_chat;		/* enable kgs-chat command ? */
+	bool		fatal;			/* abort on gtp error */
 	char*		custom_name;
 	char*		banner;			/* kgs game start message */
 	

--- a/gtp.h
+++ b/gtp.h
@@ -65,6 +65,51 @@ typedef struct
 	gtp_arg_next(gtp); \
 } while(0)
 
+#define gtp_arg_number(n)   do {  \
+	char *arg_;  \
+	gtp_arg(arg_);  \
+	if (!valid_number(arg_)) {	 \
+	        if (DEBUGL(0)) fprintf(stderr, "Invalid numeric value '%s'\n", arg_);  \
+		gtp_error(gtp, "numeric value expected"); \
+		return P_OK; \
+	} \
+	(n) = atoi(arg_);  \
+} while(0)
+
+#define gtp_arg_float(x)   do {  \
+	char *arg_;  \
+	gtp_arg(arg_);  \
+	if (!valid_float(arg_)) {  \
+	        if (DEBUGL(0)) fprintf(stderr, "Invalid numeric value '%s'\n", arg_);  \
+		gtp_error(gtp, "numeric value expected"); \
+		return P_OK; \
+	} \
+	float *px = &(x);  \
+	sscanf(arg_, "%f", px);  \
+} while(0)
+
+#define gtp_arg_color(color)   do {  \
+	char *arg_;  \
+	gtp_arg(arg_);  \
+	if (!valid_color(arg_)) {  \
+		if (DEBUGL(0)) fprintf(stderr, "Invalid color '%s'\n", arg_);  \
+		gtp_error(gtp, "invalid coord");	\
+		return P_OK; \
+	} \
+	(color) = str2stone(arg_);  \
+} while(0)
+
+#define gtp_arg_coord(c)   do {  \
+	char *arg_;  \
+	gtp_arg(arg_);  \
+	if (!valid_coord(arg_)) {  \
+		if (DEBUGL(0)) fprintf(stderr, "Invalid coord '%s'\n", arg_);  \
+		gtp_error(gtp, "invalid coord");	\
+		return P_OK; \
+	} \
+	(c) = str2coord(arg_);  \
+} while(0)
+
 
 void gtp_init(gtp_t *gtp, board_t *b);
 void gtp_done(gtp_t *gtp);

--- a/josekifix/josekifix.c
+++ b/josekifix/josekifix.c
@@ -854,7 +854,7 @@ ladder_sanity_check(board_t *board, ladder_check_t *check, override_t *override)
 
 	/* Check coords are valid */
 	
-	if (!valid_str_coord(check->coord)) {
+	if (!valid_coord(check->coord)) {
 		board_print(board, stderr);	/* orig board, without setup stones */
 		die("josekifix: \"%s\": invalid ladder coord '%s', aborting. (run with -d5 to see previous moves)\n",
 		    override->name, check->coord);
@@ -862,14 +862,14 @@ ladder_sanity_check(board_t *board, ladder_check_t *check, override_t *override)
 	
 	int n = JOSEKIFIX_LADDER_SETUP_MAX;
 	for (int i = 0; i < n && check->setup_own[i]; i++)
-		if (!valid_str_coord(check->setup_own[i])) {
+		if (!valid_coord(check->setup_own[i])) {
 			board_print(board, stderr);
 			die("josekifix: \"%s\": invalid ladder setup_own coord '%s', aborting. (run with -d5 to see previous moves)\n",
 			    override->name, check->setup_own[i]);
 		}
 
 	for (int i = 0; i < n && check->setup_other[i]; i++)
-		if (!valid_str_coord(check->setup_other[i])) {
+		if (!valid_coord(check->setup_other[i])) {
 			board_print(board, stderr);
 			die("josekifix: \"%s\": invalid ladder setup_other coord '%s', aborting. (run with -d5 to see previous moves)\n",
 			    override->name, check->setup_other[i]);
@@ -913,13 +913,13 @@ common_sanity_checks(board_t *b, override_t *override)
 		die("josekifix: this override has no name, aborting. (run with -d5 to see previous moves)\n");
 	}
 
-	if (!valid_str_coord(override->prev) && strcmp(override->prev, "pass")) {
+	if (!valid_coord(override->prev) && strcmp(override->prev, "pass")) {
 		board_print(b, stderr);
 		die("josekifix: \"%s\": invalid prev move '%s', aborting. (run with -d5 to see previous moves)\n",
 		    override->name, override->prev);
 	}
 
-	if (!valid_str_coord(override->next) && strcmp(override->next, "pass")) {
+	if (!valid_coord(override->next) && strcmp(override->next, "pass")) {
 		board_print(b, stderr);
 		die("josekifix: \"%s\": invalid next move '%s', aborting. (run with -d5 to see previous moves)\n",
 		    override->name, override->next);
@@ -931,7 +931,7 @@ common_sanity_checks(board_t *b, override_t *override)
 	if (override->coord_other)	around_str = override->coord_other;
 	if (override->coord_empty)	around_str = override->coord_empty;
 	
-	if (around_str && !valid_str_coord(around_str)) {
+	if (around_str && !valid_coord(around_str)) {
 		board_print(b, stderr);
 		die("josekifix: \"%s\": invalid around coord '%s', aborting. (run with -d5 to see previous moves)\n",
 		    override->name, around_str);

--- a/josekifix/josekifixload.c
+++ b/josekifix/josekifixload.c
@@ -181,7 +181,7 @@ parse_external_engine_moves(board_t *b, override_t *override, external_engine_se
 static void
 joseki_override_set_around(override_t *override, board_t *b, char *value)
 {	
-	assert(valid_str_coord(value));
+	assert(valid_coord(value));
 
 	enum stone own_color = board_to_play(b);
 	enum stone other_color = stone_other(own_color);
@@ -241,7 +241,7 @@ add_override(board_t *b, move_t *m, char *move_str)
 		/* around = coord		match pattern origin.
 		 * around = last		(use last move) */
 		else if (!strcmp(name, "around")) {
-			if (strcmp(value, "last") && !valid_str_coord(value)) {
+			if (strcmp(value, "last") && !valid_coord(value)) {
 				board_print(b, stderr);
 				die("josekifix: \"%s\": invalid around coord '%s', aborting. (run with -d5 to see previous moves)\n",
 				    override_name, value);
@@ -255,7 +255,7 @@ add_override(board_t *b, move_t *m, char *move_str)
 
 		/* around2 = coord		also check pattern at this location */
 		else if (!strcmp(name, "around2")) {	// second area check
-			if (strcmp(value, "last") && !valid_str_coord(value)) {
+			if (strcmp(value, "last") && !valid_coord(value)) {
 				board_print(b, stderr);
 				die("josekifix: \"%s\": invalid around2 coord '%s', aborting. (run with -d5 to see previous moves)\n",
 				    override_name, value);

--- a/move.c
+++ b/move.c
@@ -7,6 +7,37 @@
 #include "move.h"
 
 
+/* Check @s is valid coord for given board size. */
+static bool
+valid_coord_for(char *s, int size)
+{
+	if (!s || !s[0])
+		return false;
+
+	if (!strcasecmp(s, "pass") || !strcasecmp(s, "resign"))
+		return true;
+
+	char c1 = tolower(s[0]);
+	char c2 = s[1];
+	int  x  = (c1 - 'a') + 1 - (c1 > 'i');
+	int  y  = atoi(s + 1);
+	int  digits = (y > 9 ? 2 : 1);
+	char endc = (s + 1)[digits];
+	assert(size <= 25);				// 'z' last letter
+	
+	return (c1 != 'i' && isdigit(c2) && (isspace(endc) || endc == 0) &&
+		x >= 1    && x <= size   &&
+		y >= 1    && y <= size);
+}
+
+/* Check @s is valid coord for current board size. */
+bool
+valid_coord(char *s)
+{
+	return valid_coord_for(s, the_board_rsize());
+}
+
+
 /* The S_OFFBOARD margin is not addressable by coordinates. */
 
 static char asdf[] = "abcdefghjklmnopqrstuvwxyz";
@@ -42,16 +73,21 @@ coord2sstr(coord_t c)
 	return coord2bstr(b, c);
 }
 
-/* No sanity checking */
+/* Aborts if coord is invalid. */
 coord_t
 str2coord_for(char *str, int size)
 {
 	if (!strcasecmp(str, "pass"))    return pass;
 	if (!strcasecmp(str, "resign"))	 return resign;
-	
+
+	assert(valid_coord_for(str, size));
+
+	int  stride = size + 2;
 	char xc = tolower(str[0]);
-	int stride = size + 2;
-	return xc - 'a' - (xc > 'i') + 1 + atoi(str + 1) * stride;
+	int  x = (xc - 'a') + 1 - (xc > 'i');
+	int  y = atoi(str + 1);
+	
+	return (y * stride + x);
 }
 
 coord_t
@@ -59,21 +95,6 @@ str2coord(char *str)
 {
 	return str2coord_for(str, the_board_rsize());
 }
-
-bool
-valid_str_coord(char *s)
-{
-	if (!s || !s[0])
-		return false;
-
-	char c1 = toupper(s[0]);
-	char c2 = s[1];
-	int n = atoi(s + 1);
-	return (c1 >= 'A' && c1 <= 'T' &&
-		c2 >= '0' && c2 <= '9' &&
-		n >= 1 && n <= 19);
-}
-
 
 /* Must match rotations in pthashes_init() */
 coord_t

--- a/move.h
+++ b/move.h
@@ -37,8 +37,8 @@ coord_t str2coord(char *str);
 coord_t str2coord_for(char *str, int size);
 /* Rotate coordinate according to rot: [0-7] for 8 board symmetries. */
 coord_t rotate_coord(coord_t c, int rot);
-/* Check string coord is valid */
-bool valid_str_coord(char *s);
+/* Check string coord is valid for current board. */
+bool valid_coord(char *s);
 
 typedef struct {
 	coord_t coord;

--- a/pachi.c
+++ b/pachi.c
@@ -186,6 +186,7 @@ usage(char *arg)
 		"  -s, --seed RANDOM_SEED            set random seed \n"
 		"  -u, --unit-test FILE              run unit tests \n"
 		"      --tunit-fatal                 abort on failed unit test \n"
+		"      --gtp-fatal                   abort on gtp error \n"
 		" \n"
 		"Engine components: \n"
 		"      --dcnn,     --nodcnn          dcnn required / disabled \n"
@@ -263,6 +264,7 @@ usage(char *arg)
 #define OPT_NODCNN_BLUNDER    277
 #define OPT_TUNIT_FATAL	      278
 #define OPT_BANNER            279
+#define OPT_GTP_FATAL         280
 
 
 static struct option longopts[] = {
@@ -278,6 +280,7 @@ static struct option longopts[] = {
 	{ "fbook",                  required_argument, 0, 'f' },
 	{ "fuseki-time",            required_argument, 0, OPT_FUSEKI_TIME },
 	{ "fuseki",                 required_argument, 0, OPT_FUSEKI },
+	{ "gtp-fatal",		    no_argument,       0, OPT_GTP_FATAL },
 #ifdef NETWORK
 	{ "gtp-port",               required_argument, 0, 'g' },
 	{ "log-port",               required_argument, 0, 'l' },
@@ -387,6 +390,9 @@ int main(int argc, char *argv[])
 #endif
 			case 'f':
 				fbookfile = strdup(optarg);
+				break;
+			case OPT_GTP_FATAL:
+				gtp->fatal = true;
 				break;
 #ifdef NETWORK
 			case 'g':

--- a/pachi.c
+++ b/pachi.c
@@ -97,8 +97,7 @@ main_loop(gtp_t *gtp, board_t *b, engine_t *e, time_info_t *ti, time_info_t *ti_
 		if (c == P_ENGINE_RESET) {
 			ti[S_BLACK] = *ti_default;
 			ti[S_WHITE] = *ti_default;
-			if (!e->keep_on_clear)
-				engine_reset(e, b);
+			engine_reset(e, b);
 		}
 	}
 }

--- a/pachi.h
+++ b/pachi.h
@@ -20,9 +20,6 @@ typedef struct {
 /* Free globals */
 void pachi_done();
 
-/* Init engines */
-void pachi_engine_init(struct engine *e, int id, struct board *b);
-
 /* Get global options */
 const pachi_options_t *pachi_options();
 

--- a/spudfrog
+++ b/spudfrog
@@ -5,9 +5,12 @@ die() {  echo "spudfrog: $@"; exit 1;  }
 max() {  [ $1 -gt $2 ] && echo $1 || echo $2;  }
 [ -n "$OPT" ] || die "i need to be called from Makefile"
 
+# set color 237 = gray  (256 color term)
+echo "]4;237;rgb:3a/3a/3a\\"
+
 red="[31;1m";     green="[32;1m";  yellow="[33;1m";  blue="[34;1m"
 purple="[35;1m";  cyan="[36;1m";   end="[0m"
-ngreen="[32m";    white="[37;1m"   gray="[30;1m"
+ngreen="[32m";    white="[37;1m"   gray="[38;5;237m"
 
 cc1=$( $CC $CFLAGS -E -v - </dev/null 2>&1 | grep cc1 | head -1 | tr -d '\\"' )
 
@@ -46,6 +49,6 @@ printf "%s            (.)~(.)                                         $end\n" $s
 printf "%s           (-------)                                        $end\n" $spud
 printf "%s   .------%sooO%s-----%sOoo%s------------------------------.$end\n" $gray $spud $gray $spud $gray
 printf "%s  | ${end} %*s%s%*s $gray |$end\n"                                  $gray  $n1 ""  "$status"  $n2 ""
-printf "%s   ᛫-----------------------------------------------᛫$end\n" $gray
+printf "%s   ˙-----------------------------------------------˙$end\n" $gray
 printf "%s           ( )   ( )                                        $end  \n" $spud
 printf "\n"

--- a/stone.c
+++ b/stone.c
@@ -1,6 +1,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include "stone.h"
 
@@ -20,6 +21,13 @@ str2stone(char *str)
 	switch (tolower(*str)) {
 		case 'b': return S_BLACK;
 		case 'w': return S_WHITE;
-		default: return S_NONE;
+		default:  assert(0);
 	}
+}
+
+bool
+valid_color(char *str)
+{
+	char c = tolower(*str);
+	return (c == 'b' || c == 'w');
 }

--- a/stone.h
+++ b/stone.h
@@ -1,6 +1,8 @@
 #ifndef PACHI_STONE_H
 #define PACHI_STONE_H
 
+#include <assert.h>
+
 enum stone {
 	S_NONE,
 	S_BLACK,
@@ -11,6 +13,7 @@ enum stone {
 
 static char stone2char(enum stone s);
 static enum stone char2stone(char s);
+bool valid_color(char *s);
 char *stone2str(enum stone s); /* static string */
 enum stone str2stone(char *str);
 

--- a/t-unit/gtp_test.gtp
+++ b/t-unit/gtp_test.gtp
@@ -28,6 +28,7 @@ predict b a1
 clear_board
 pachi-predict b a1
 
+boardsize 19
 clear_board
 set_free_handicap d4 q16
 

--- a/t-unit/gtp_test.gtp
+++ b/t-unit/gtp_test.gtp
@@ -27,6 +27,7 @@ clear_board
 predict b a1
 clear_board
 pachi-predict b a1
+pachi-engine uct
 
 boardsize 19
 clear_board

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -809,8 +809,6 @@ test_genmove(board_t *b, char *arg)
 
 	/* Sanity checks */
 	board_t *tmp = board_new(19, NULL);
-	assert(using_dcnn(tmp));
-	assert(using_patterns());
 	board_delete(&tmp);
 
 	static time_info_t ti = { 0, };

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -790,7 +790,7 @@ test_genmove(board_t *b, char *arg)
 		if (*arg == '!')  arg++;
 		if (!strcmp(arg, "pass"))   {  mq_add(q, pass, 0);    next_arg_opt(arg);  continue;  }
 		if (!strcmp(arg, "resign")) {  mq_add(q, resign, 0);  next_arg_opt(arg);  continue;  }
-		if (!valid_str_coord(arg))  die("Invalid move: '%s'\n", arg);
+		if (!valid_coord(arg))  die("Invalid move: '%s'\n", arg);
 		mq_add(q, str2coord(arg), 0);
 		next_arg_opt(arg);
 	}
@@ -884,7 +884,7 @@ test_dcnn_blunder(board_t *b, char *arg)
 		move_queue_t *q = (*arg == '!' ? &unwanted : &wanted);
 		if (*arg == '!')  arg++;
 		if (!strcmp(arg, "pass") || !strcmp(arg, "resign"))  die("Can't have pass or resign here.\n");
-		if (!valid_str_coord(arg))  die("Invalid move: '%s'\n", arg);
+		if (!valid_coord(arg))  die("Invalid move: '%s'\n", arg);
 		mq_add(q, str2coord(arg), 0);
 		next_arg_opt(arg);
 	}

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -162,11 +162,9 @@ typedef struct uct {
 #define UDEBUGL(n) DEBUGL_(u->debug_level, n)
 
 bool uct_pass_is_safe(uct_t *u, board_t *b, enum stone color, bool pass_all_alive, move_queue_t *dead, char **msg, bool log);
-void uct_prepare_move(uct_t *u, board_t *b, enum stone color);
 void uct_genmove_setup(uct_t *u, board_t *b, enum stone color);
 void uct_pondering_stop(uct_t *u);
 void uct_get_best_moves(uct_t *u, coord_t *best_c, float *best_r, int nbest, bool winrates, int min_playouts);
-void uct_get_best_moves_at(uct_t *u, tree_node_t *n, coord_t *best_c, float *best_r, int nbest, bool winrates, int min_playouts);
 void uct_mcowner_playouts(uct_t *u, board_t *b, enum stone color);
 void uct_tree_size_init(uct_t *u, size_t tree_size);
 

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -40,6 +40,8 @@ uct_policy_t *policy_ucb1amaf_init(uct_t *u, char *arg, board_t *board);
 static void uct_pondering_start(uct_t *u, board_t *b0, tree_t *t, enum stone color, coord_t our_move, int flags);
 static void uct_genmove_pondering_save_replies(uct_t *u, board_t *b, enum stone color, coord_t next_move);
 static void uct_genmove_pondering_start(uct_t *u, board_t *b, enum stone color, coord_t our_move);
+static void uct_get_best_moves_at(uct_t *u, tree_node_t *parent, coord_t *best_c, float *best_r, int nbest,bool winrates, int min_playouts);
+
 
 /* Maximal simulation length. */
 #define MC_GAMELEN	MAX_GAMELEN
@@ -85,7 +87,7 @@ setup_dynkomi(uct_t *u, board_t *b, enum stone to_play)
 		u->t->extra_komi = 0;
 }
 
-void
+static void
 uct_prepare_move(uct_t *u, board_t *b, enum stone color)
 {
 	if (u->t) {  /* Verify that we have sane state. */
@@ -816,7 +818,7 @@ uct_analyze(engine_t *e, board_t *b, enum stone color, int start)
 /* Same as uct_get_best_moves() for node @parent.
  * XXX pass can be a valid move in which case you need best_n to check. 
  *     have another function which exposes best_n ? */
-void
+static void
 uct_get_best_moves_at(uct_t *u, tree_node_t *parent, coord_t *best_c, float *best_r, int nbest,
 		      bool winrates, int min_playouts)
 {
@@ -893,7 +895,7 @@ uct_dumptbook(engine_t *e, board_t *b, enum stone color)
 }
 
 
-floating_t
+static floating_t
 uct_evaluate_one(engine_t *e, board_t *b, time_info_t *ti, coord_t c, enum stone color)
 {
 	uct_t *u = (uct_t*)e->data;
@@ -924,7 +926,7 @@ uct_evaluate_one(engine_t *e, board_t *b, time_info_t *ti, coord_t c, enum stone
 	return isnan(bestval) ? NAN : 1.0f - bestval;
 }
 
-void
+static void
 uct_evaluate(engine_t *e, board_t *b, time_info_t *ti, floating_t *vals, enum stone color)
 {
 	for (int i = 0; i < b->flen; i++) {
@@ -942,7 +944,7 @@ log_nthreads(uct_t *u)
 	if (DEBUGL(0) && !logged++)  fprintf(stderr, "Threads: %i\n", u->threads);
 }
 
-size_t
+static size_t
 uct_default_tree_size()
 {
 	/* Double it on 64-bit, tree takes up twice as much memory ... */
@@ -1513,7 +1515,7 @@ uct_setoption(engine_t *e, board_t *b, const char *optname, char *optval,
 	return true;  /* successful */
 }
 
-uct_t *
+static uct_t *
 uct_state_init(engine_t *e, board_t *b)
 {
 	options_t *options = &e->options;

--- a/uct/uct.h
+++ b/uct/uct.h
@@ -7,6 +7,5 @@ void   uct_engine_init(engine_t *e, board_t *b);
 
 bool   uct_gentbook(engine_t *e, board_t *b, time_info_t *ti, enum stone color);
 void   uct_dumptbook(engine_t *e, board_t *b, enum stone color);
-size_t uct_default_tree_size(void);
 
 #endif

--- a/util.c
+++ b/util.c
@@ -108,6 +108,29 @@ str_prefix(char *prefix, char *str)
 	return (!strncmp(prefix, str, strlen(prefix)));
 }
 
+bool
+valid_number(char *str)
+{
+	char c = *str++;
+	if (c != '-' && !isdigit(c))
+		return false;
+	
+	while (isdigit(*str))
+		str++;
+	return (!*str || isspace(*str));
+}
+
+bool
+valid_float(char *str)
+{
+	char c = *str++;
+	if (c != '-' && c != '.' && !isdigit(c))
+		return false;
+
+	while (isdigit(*str) || *str == '.')
+		str++;
+	return (!*str || isspace(*str));
+}
 
 static void
 vwarning(const char *format, va_list ap)

--- a/util.h
+++ b/util.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 #undef MIN
 #undef MAX
@@ -21,6 +22,10 @@
 
 /* Returns true if @str starts with @prefix */
 int str_prefix(char *prefix, char *str);
+
+/* Argument parsing helpers */
+bool valid_number(char *str);
+bool valid_float(char *str);
 
 /* Warn user (popup on windows) */
 void warning(const char *format, ...)

--- a/util.h
+++ b/util.h
@@ -180,14 +180,14 @@ strbuf_t *strbuf_init_alloc(strbuf_t *buf, int size);
 strbuf_t *new_strbuf(int size);
 
 /* Create string buffer for use within current function (stack-allocated). */
-#define strbuf(buf, size)  \
-	char buffer_[(size)];  strbuf_t strbuf_; \
-	strbuf_t *buf = strbuf_init(&strbuf_, buffer_, sizeof(buffer_));
+#define strbuf(name, size)  \
+	char buffer_ ## name [(size)];  strbuf_t strbuf_ ## name; \
+	strbuf_t *name = strbuf_init(&strbuf_ ## name, buffer_ ## name, sizeof(buffer_ ## name));
 
 /* Create static string buffer: can return buf->str (but not buf). */
-#define static_strbuf(buf, size)  \
-	static char buffer_[(size)];  strbuf_t strbuf_; \
-	strbuf_t *buf = strbuf_init(&strbuf_, buffer_, sizeof(buffer_));
+#define static_strbuf(name, size)  \
+	static char buffer_ ## name [(size)];  strbuf_t strbuf_ ## name; \
+	strbuf_t *name = strbuf_init(&strbuf_ ## name, buffer_ ## name, sizeof(buffer_ ## name));
 
 /* String buffer version of printf():
  * Use sbprintf(buf, format, ...) to accumulate output. */


### PR DESCRIPTION
GTP layer quality of life changes:
- Validate GTP input
  Long overdue, work in progress but should be mostly done (color, coord, number, float)
- Clean engine `keep_on_clear` handling:
  GTP layer checks engine flags, caller just checks `P_ENGINE_RESET`.
- Added engine `keep_on_undo`:
  Makes persistent engines a lot easier to write, like distributed engine which can use this instead of fighting / duplicating GTP layer.
- Added `pachi-engine` command:
  For testing: ensure expected engine is running.
- Added `--gtp-fatal` option for catching errors in tests (abort on gtp error).
- `version`: Let engines override default version.

Some main() cleanup:
- Moved engine init to engine.c
- Move all wrap-up code to pachi_done()
