### PR TITLE
Josekifix Rewrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ DCNN_DARKFOREST=1
 
 # BOARD_SIZE=19
 
-# Build josekifix module ?
+# Build josekifix module ?	 (DCNN must be enabled as well)
 # Provides fixes for joseki lines that dcnn plays poorly, and more varied
 # fusekis when playing as black.
 
@@ -151,6 +151,23 @@ double:
 
 
 #######################################################################
+# Sanity checks
+
+ifeq ($(DCNN), 1)
+ifndef JOSEKIFIX
+$(error JOSEKIFIX must be enabled for DCNN build)
+endif
+endif
+
+ifeq ($(JOSEKIFIX), 1)
+ifndef DCNN
+$(error DCNN must be enabled for JOSEKIFIX build)
+endif
+endif
+
+
+#######################################################################
+# Variables
 
 MAKEFLAGS += --no-print-directory
 ARCH = $(shell uname -m)

--- a/Makefile
+++ b/Makefile
@@ -153,12 +153,6 @@ double:
 #######################################################################
 # Sanity checks
 
-ifeq ($(DCNN), 1)
-ifndef JOSEKIFIX
-$(error JOSEKIFIX must be enabled for DCNN build)
-endif
-endif
-
 ifeq ($(JOSEKIFIX), 1)
 ifndef DCNN
 $(error DCNN must be enabled for JOSEKIFIX build)
@@ -254,7 +248,6 @@ endif
 
 ifeq ($(JOSEKIFIX), 1)
 	COMMON_FLAGS    += -DJOSEKIFIX
-	EXTRA_SUBDIRS   += josekifix
 	EXTRA_DATAFILES += josekifix.gtp
 endif
 
@@ -295,7 +288,7 @@ OBJS = $(EXTRA_OBJS) \
        playout.o random.o stone.o timeinfo.o fbook.o chat.o util.o
 
 # Low-level dependencies last
-SUBDIRS   = $(EXTRA_SUBDIRS) pattern joseki uct uct/policy t-unit t-predict engines playout tactics
+SUBDIRS   = $(EXTRA_SUBDIRS) engines joseki josekifix pattern playout tactics t-predict t-unit uct uct/policy
 DATAFILES = $(EXTRA_DATAFILES) detlef54.prototxt detlef54.trained joseki19.gtp opening.dat patterns_mm.gamma patterns_mm.spat 
 
 

--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,9 @@ test_moggy: FORCE
 test_spatial: FORCE
 	+@make -C t-unit test_spatial
 
+test_external_engine: FORCE
+	+@make -C t-unit test_external_engine
+
 # Regression tests
 regtest: FORCE
 	+@make -C t-regress regtest

--- a/dcnn/blunder.c
+++ b/dcnn/blunder.c
@@ -120,7 +120,8 @@ dcnn_44_reduce_33_blunder(board_t *b, move_t *m, move_t *redirect)
 		if (m->coord != rb3 && m->coord != rc1)  continue;
 		
 		coord_t c = check_override_rot(b, &override, rot, 0);
-		if (!is_pass(c)) {		/* Would rather just clobber since w doesn't want to play B2 right away, */
+		if (!is_pass(c) && sane_override_move(b, c, "4-4 reduce 3-3 blunder", "dcnn_blunder")) {
+						/* Would rather just clobber since w doesn't want to play B2 right away, */
 			redirect->coord = c;	/* but mcts ends up playing B3 anyway sometimes in this case ! */
 			return true;		/* So redirect, if it had a big prior will play B2 right away, */
 		}				/* no big deal. */

--- a/dcnn/blunder.c
+++ b/dcnn/blunder.c
@@ -104,8 +104,8 @@ static bool
 dcnn_44_reduce_33_blunder(board_t *b, move_t *m, move_t *redirect)
 {
 	/* B3 not blunder if w has a stone at B6, make sure override covers that area. */
-	override_t override = { .coord_empty = "B1", .prev = "pass", "B2", "4-4 reduce 3-3", { 0x104718b6711a28d0, 0xdcd0e566177a90e8, 0xb1256f54939c1c48, 0xce86cd889eb98e38,
-											       0xd39f04865100718, 0x8dfd49f239c658, 0xa84411bdaafa8a10, 0xbd0cd1b2a8ace9b8 } };
+	override_t override = { .coord = "B1", .prev = "pass", "B2", "4-4 reduce 3-3", { 0x104718b6711a28d0, 0xdcd0e566177a90e8, 0xb1256f54939c1c48, 0xce86cd889eb98e38,
+											 0xd39f04865100718, 0x8dfd49f239c658, 0xa84411bdaafa8a10, 0xbd0cd1b2a8ace9b8 } };
 	int dist = coord_edge_distance(m->coord);
 	if (dist != 1 && dist != 0)  return false;
 

--- a/dcnn/blunder.c
+++ b/dcnn/blunder.c
@@ -11,7 +11,7 @@
 #include "tactics/2lib.h"
 #include "tactics/selfatari.h"
 #include "board_undo.h"
-#include "josekifix/josekifix.h"
+#include "josekifix/override.h"
 
 
 static bool dcnn_blunder_enabled = true;

--- a/engine.c
+++ b/engine.c
@@ -20,6 +20,7 @@
 #include "joseki/josekiload.h"
 #include "josekifix/josekifix_engine.h"
 #include "josekifix/josekifixload.h"
+#include "josekifix/josekifixscan.h"
 
 
 /**************************************************************************************************/
@@ -50,6 +51,9 @@ engine_map_t engines[] = {
 #ifdef JOSEKIFIX
 	{ E_JOSEKIFIX,		"josekifix",	  josekifix_engine_init,      0 },
 	{ E_JOSEKIFIXLOAD,	"josekifixload",  josekifixload_engine_init,  0 },
+#ifdef EXTRA_ENGINES
+	{ E_JOSEKIFIXSCAN,	"josekifixscan",  josekifixscan_engine_init,  0 },
+#endif
 #endif	
 	{ E_RANDOM,		"random",         random_engine_init,         1 },
 	{ E_REPLAY,		"replay",         replay_engine_init,         1 },

--- a/engine.c
+++ b/engine.c
@@ -18,6 +18,7 @@
 #include "pattern/pattern_engine.h"
 #include "joseki/joseki_engine.h"
 #include "joseki/josekiload.h"
+#include "josekifix/josekifix_engine.h"
 #include "josekifix/josekifixload.h"
 
 
@@ -47,6 +48,7 @@ engine_map_t engines[] = {
 	{ E_JOSEKI,		"joseki",         joseki_engine_init,         1 },
 	{ E_JOSEKILOAD,		"josekiload",     josekiload_engine_init,     0 },
 #ifdef JOSEKIFIX
+	{ E_JOSEKIFIX,		"josekifix",	  josekifix_engine_init,      0 },
 	{ E_JOSEKIFIXLOAD,	"josekifixload",  josekifixload_engine_init,  0 },
 #endif	
 	{ E_RANDOM,		"random",         random_engine_init,         1 },
@@ -136,7 +138,7 @@ engine_options_free(options_t *options)
 }
 
 /* Add option, overwriting previous value if any. */
-static void
+void
 engine_options_add(options_t *options, const char *name, const char *val)
 {
 	/* Overwrite existing option ? */

--- a/engine.h
+++ b/engine.h
@@ -32,6 +32,7 @@ enum engine_id {
 	E_JOSEKI,
 	E_JOSEKILOAD,
 #ifdef JOSEKIFIX
+	E_JOSEKIFIX,
 	E_JOSEKIFIXLOAD,
 #endif
 	E_RANDOM,
@@ -172,6 +173,7 @@ int  best_moves_print(board_t *b, char *str, coord_t *best_c, int nbest);
 void      engine_options_print(options_t *options);
 option_t *engine_options_lookup(options_t *options, const char *name);
 void      engine_options_concat(strbuf_t *buf, options_t *options);
+void	  engine_options_add(options_t *options, const char *name, const char *val);
 
 /* For options which need to be set at engine setup time: */
 #define ENGINE_SETOPTION_NEED_RESET  \

--- a/engine.h
+++ b/engine.h
@@ -34,6 +34,9 @@ enum engine_id {
 #ifdef JOSEKIFIX
 	E_JOSEKIFIX,
 	E_JOSEKIFIXLOAD,
+#ifdef EXTRA_ENGINES
+	E_JOSEKIFIXSCAN,
+#endif
 #endif
 	E_RANDOM,
 	E_REPLAY,

--- a/engine.h
+++ b/engine.h
@@ -52,6 +52,7 @@ typedef struct engine engine_t;
 typedef void (*engine_init_t)(engine_t *e, board_t *b);
 typedef bool (*engine_setoption_t)(engine_t *e, board_t *b, const char *optname, char *optval, char **err, bool setup, bool *reset);
 typedef enum parse_code (*engine_notify_t)(engine_t *e, board_t *b, int id, char *cmd, char *args, gtp_t *gtp);
+typedef void (*engine_notify_after_t)(engine_t *e, board_t *b, int id, char *cmd, gtp_t *gtp);
 typedef void (*engine_board_print_t)(engine_t *e, board_t *b, FILE *f);
 typedef char *(*engine_notify_play_t)(engine_t *e, board_t *b, move_t *m, char *enginearg, bool *print_board);
 typedef char *(*engine_chat_t)(engine_t *e, board_t *b, bool in_game, char *from, char *cmd);
@@ -88,10 +89,11 @@ struct engine {
 						     * @setup: true if called during engine setup.
 						     * @reset: set by engine if option can only be set at setup time. */
 
-	engine_notify_t          notify;
-	engine_board_print_t     board_print;
-	engine_notify_play_t     notify_play;
-	engine_chat_t            chat;
+	engine_notify_play_t     notify_play;	    /* Notify engine of play commands received. */
+	engine_notify_t          notify;            /* Notify engine of all gtp commands received. */
+	engine_notify_after_t    notify_after;      /* Like notify() but called after running default handler. */
+	engine_board_print_t     board_print;	    /* Engine-specific board_print() function. */
+	engine_chat_t            chat;		    /* Answer kgs chat commands. */
 
 	engine_genmove_t         genmove;           /* Generate a move. If pass_all_alive is true, <pass> shall be generated only */
 	engine_genmove_t         genmove_analyze;   /* if all stones on the board can be considered alive, without regard to "dead" */
@@ -107,13 +109,13 @@ struct engine {
 
 	engine_dead_groups_t     dead_groups;       /* One dead group per queued move (coord_t is (ab)used as group_t). */
 	engine_ownermap_t        ownermap;	    /* Return current ownermap, if engine supports it. */
-	engine_result_t          result;
+	engine_result_t          result;	    /* More detailed output of last genmove. */
 
 	engine_stop_t            stop;		    /* Pause any background thinking being done, but do not tear down
 						     * any data structures yet. */
 	engine_done_t            done;		    /* e->data and e will be free()d by caller afterwards. */
 
-	void *data;
+	void *data;				    /* Pointer to engine-specific data structure. */
 };
 
 

--- a/engines/external.h
+++ b/engines/external.h
@@ -5,7 +5,9 @@
 
 void external_engine_init(engine_t *e, board_t *b);
 bool external_engine_started(engine_t *e);
-int  external_engine_send_cmd(engine_t *e, char *cmd, char **reply, char **error);
+
+void external_engine_undo(engine_t *e);
+void external_engine_play(engine_t *e, coord_t c, enum stone color);
 
 
 #endif

--- a/gogui.c
+++ b/gogui.c
@@ -56,18 +56,18 @@ cmd_gogui_analyze_commands(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 		//printf("plist/Final Status List Black/final_status_list black_territory\n");
 		//printf("plist/Final Status List White/final_status_list white_territory\n");
 	}
-	if (!strcmp(e->name, "UCT") && using_joseki(b)) {
+	if (str_prefix("UCT", e->name) && using_joseki(b)) {
 		printf("gfx/Joseki Moves/gogui-joseki_moves\n");
 		printf("gfx/Joseki Range/gogui-joseki_show_pattern %%p\n");
 	}
 #ifdef DCNN                            /* board check fake since we're called once on startup ... */
-	if (!strcmp(e->name, "UCT") && using_dcnn(b)) {
+	if (str_prefix("UCT", e->name) && using_dcnn(b)) {
 		printf("gfx/DCNN Best Moves/gogui-dcnn_best\n");
 		printf("gfx/DCNN Color Map/gogui-dcnn_colors\n");
 		printf("gfx/DCNN Ratings/gogui-dcnn_rating\n");
 	}
 #endif
-	if (!strcmp(e->name, "UCT") && using_patterns()) {
+	if (str_prefix("UCT", e->name) && using_patterns()) {
 		printf("gfx/Pattern Best Moves/gogui-pattern_best\n");
 		printf("gfx/Pattern Color Map/gogui-pattern_colors\n");
 		printf("gfx/Pattern Ratings/gogui-pattern_rating\n");
@@ -76,7 +76,7 @@ cmd_gogui_analyze_commands(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 		printf("gfx/Set Spatial Size/gogui-spatial_size %%o\n");
 		printf("gfx/Show Spatial/gogui-show_spatial %%p\n");
 	}
-	if (!strcmp(e->name, "UCT")) {
+	if (str_prefix("UCT", e->name)) {
 		printf("gfx/Live gfx = Best Moves/gogui-livegfx best_moves\n");
 		printf("gfx/Live gfx = Best Sequence/gogui-livegfx best_seq\n");
 		printf("gfx/Live gfx = Winrates/gogui-livegfx winrates\n");

--- a/gogui.c
+++ b/gogui.c
@@ -6,7 +6,6 @@
 #include "timeinfo.h"
 #include "gtp.h"
 #include "gogui.h"
-#include "josekifix/josekifix.h"
 #include "ownermap.h"
 #include "joseki/joseki.h"
 #include "uct/uct.h"

--- a/gtp.c
+++ b/gtp.c
@@ -214,7 +214,7 @@ static enum parse_code
 cmd_name(board_t *b, engine_t *e, time_info_t *ti, gtp_t *gtp)
 {
 	char *name = "Pachi %s";
-	if (!strcmp(e->name, "UCT"))  name = "Pachi";
+	if (str_prefix("UCT", e->name))  name = "Pachi";
 	if (gtp->custom_name)         name = gtp->custom_name;
 	gtp_printf(gtp, name, e->name);
 	gtp_printf(gtp, "\n");

--- a/gtp.c
+++ b/gtp.c
@@ -1203,8 +1203,9 @@ gtp_run_handler(gtp_t *gtp, board_t *b, engine_t *e, time_info_t *ti, char *buf)
 	}
 	
 	/* Run engine notify() handler */
+	enum parse_code c;
 	if (e->notify) {
-		enum parse_code c = e->notify(e, b, gtp->id, gtp->cmd, gtp->next, gtp);
+		c = e->notify(e, b, gtp->id, gtp->cmd, gtp->next, gtp);
 		
 		if (gtp->error)  return P_OK;		      /* error, don't run default handler */
 
@@ -1217,7 +1218,13 @@ gtp_run_handler(gtp_t *gtp, board_t *b, engine_t *e, time_info_t *ti, char *buf)
 	}
 
 	/* Run default handler */
-	return handler(b, e, ti, gtp);
+	c = handler(b, e, ti, gtp);
+
+	/* Run engine notify_after() handler */
+	if (e->notify_after)
+		e->notify_after(e, b, gtp->id, gtp->cmd, gtp);
+	
+	return c;
 }
 
 enum parse_code

--- a/gtp.c
+++ b/gtp.c
@@ -652,7 +652,7 @@ cmd_fixed_handicap(board_t *b, engine_t *engine, time_info_t *ti, gtp_t *gtp)
 	move_queue_t q;  mq_init(&q);
 	board_handicap(b, stones, &q);
 	
-	if (DEBUGL(1) && debug_boardprint)
+	if (DEBUGL(3) && debug_boardprint)
 		board_print(b, stderr);
 
 	for (int i = 0; i < q.moves; i++) {

--- a/joseki/joseki.h
+++ b/joseki/joseki.h
@@ -7,8 +7,8 @@
 
 #define JOSEKI_PATTERN_DIST	     9
 
-#define joseki_spatial_hash(b, coord, color)         (outer_spatial_hash_from_board_rot_d((b), (coord), (enum stone)(color), 0, JOSEKI_PATTERN_DIST))
-#define joseki_3x3_spatial_hash(b, coord, color)     (outer_spatial_hash_from_board_rot_d((b), (coord), (enum stone)(color), 0, 3))
+#define joseki_spatial_hash(b, coord, color)         (joseki_spatial_hash_d((b), (coord), (enum stone)(color), JOSEKI_PATTERN_DIST))
+#define joseki_3x3_spatial_hash(b, coord, color)     (joseki_spatial_hash_d((b), (coord), (enum stone)(color), 3))
 
 #define JOSEKI_FLAGS_IGNORE  (1 << 0)
 #define JOSEKI_FLAGS_3X3     (1 << 1)
@@ -57,6 +57,9 @@ void get_joseki_best_moves(board_t *b, coord_t *coords, float *ratings, int matc
 void print_joseki_best_moves(board_t *b, coord_t *best_c, float *best_r, int nbest);
 void print_joseki_moves(joseki_dict_t *jd, board_t *b, enum stone color);
 
+
+/* Low-level functions */
+hash_t joseki_spatial_hash_d(board_t *b, coord_t coord, enum stone color, unsigned int d);
 
 
 /* Iterate over all dictionary patterns. */

--- a/josekifix/Makefile
+++ b/josekifix/Makefile
@@ -1,6 +1,6 @@
 INCLUDES=-I..
 
-OBJS = fuseki.o josekifix.o josekifixload.o special_checks.o
+OBJS = fuseki.o josekifix.o josekifix_engine.o josekifixload.o special_checks.o
 SGF  = josekifix.sgf fusekifix.sgf
 
 # don't build data by default, trips automated build systems

--- a/josekifix/Makefile
+++ b/josekifix/Makefile
@@ -5,6 +5,10 @@ SGF  = josekifix.sgf fusekifix.sgf
 
 ifeq ($(JOSEKIFIX), 1)
 	OBJS += fuseki.o joseki_override.o josekifix_engine.o josekifixload.o special_checks.o
+
+ifeq ($(EXTRA_ENGINES), 1)
+	OBJS += josekifixscan.o
+endif
 endif
 
 

--- a/josekifix/Makefile
+++ b/josekifix/Makefile
@@ -1,7 +1,12 @@
 INCLUDES=-I..
 
-OBJS = fuseki.o josekifix.o josekifix_engine.o josekifixload.o special_checks.o
+OBJS = override.o
 SGF  = josekifix.sgf fusekifix.sgf
+
+ifeq ($(JOSEKIFIX), 1)
+	OBJS += fuseki.o joseki_override.o josekifix_engine.o josekifixload.o special_checks.o
+endif
+
 
 # don't build data by default, trips automated build systems
 all: lib.a

--- a/josekifix/fuseki.c
+++ b/josekifix/fuseki.c
@@ -3,7 +3,8 @@
 
 #include "engine.h"
 #include "pattern/spatial.h"
-#include "josekifix/josekifix.h"
+#include "josekifix/override.h"
+#include "josekifix/joseki_override.h"
 #include "tactics/util.h"
 
 typedef coord_t (*override_hook_t)(struct board *b, hash_t lasth);
@@ -131,7 +132,7 @@ double_takamoku_fuseki(struct board *b, hash_t lasth)
 		{ NULL, NULL, NULL }
 	};
 
-	return check_overrides(b, overrides, lasth);
+	return check_overrides(b, overrides, lasth, "fuseki_override");
 }
 
 #if 0
@@ -174,7 +175,7 @@ large_keima_fuseki(struct board *b, hash_t lasth)
 		case 2: if (hash_empty("Q5")  == 0x4ff209de037e7964)  return coord("R4");
 			if (hash_empty("D15") == 0xf38ceba436dc80e4)  return coord("D17");
 			return pass;
-		case 4: return check_override(b, &override, NULL, lasth);
+		case 4: return check_override(b, &override, NULL, lasth, "fuseki_override");
 		default: return pass;
 	}
 }
@@ -263,7 +264,7 @@ check_special_fuseki(struct board *b, hash_t lasth) {
 	if (!fuseki)  return pass;
 	
 	coord_t c = fuseki->override(b, lasth);
-	if (is_pass(c) || !josekifix_sane_override(b, c, fuseki->name, -1)) {
+	if (is_pass(c) || !sane_override_move(b, c, fuseki->name, "fuseki_override")) {
 		reset_fuseki_handler();
 		return pass;
 	}

--- a/josekifix/fuseki.c
+++ b/josekifix/fuseki.c
@@ -20,9 +20,7 @@ typedef struct {
 
 #define coord(str)  (str2coord(str))
 #define empty(str)  (board_at(b, coord(str)) == S_NONE)
-#define white(str)  (board_at(b, coord(str)) == S_WHITE)
-#define hash_empty(str)  (empty(str) ? outer_spatial_hash_from_board(b, coord(str), last_move(b).color) : 0)
-#define hash_white(str)  (white(str) ? outer_spatial_hash_from_board(b, coord(str), last_move(b).color) : 0)
+#define spatial_hash(str)  (josekifix_spatial_hash(b, coord(str), last_move(b).color))
 
 #define random_coord(...)  get_random_coord(b, __VA_ARGS__, NULL)
 
@@ -59,10 +57,10 @@ great_wall_fuseki(struct board *b, hash_t lasth)
 {
 	switch (b->moves) {
 		case 0:  return coord("K10");  // Tengen
-		case 2:  return (hash_empty("K18") == 0xaf1ca7d9bc6ee27b ? coord("K16") : pass);
-		case 4:  return (hash_empty("K2")  == 0x4a56cdcaed2d35eb ? coord("K4")  : pass);
-		case 6:  return (hash_empty("K12") == 0xd696c67a8e541c9f ? coord("L13") : pass);
-		case 8:  return (hash_empty("K8")  == 0xf389fa404333ddc7 ? coord("J7")  : pass);
+		case 2:  return (spatial_hash("K18") == 0xaf1ca7d9bc6ee27b ? coord("K16") : pass);
+		case 4:  return (spatial_hash("K2")  == 0x4a56cdcaed2d35eb ? coord("K4")  : pass);
+		case 6:  return (spatial_hash("K12") == 0xd696c67a8e541c9f ? coord("L13") : pass);
+		case 8:  return (spatial_hash("K8")  == 0xf389fa404333ddc7 ? coord("J7")  : pass);
 		default: return pass;
 	}
 }
@@ -72,11 +70,11 @@ great_cross_fuseki(struct board *b, hash_t lasth)
 {
 	switch (b->moves) {
 		case 0:  return coord("K10");  // Tengen
-		case 2:  return (hash_empty("K15") == 0x52940f053f7d41d8 ? coord("K16") : pass);
-		case 4:  return (hash_empty("K5")  == 0xd3041f9087051224 ? coord("K4")  : pass);
+		case 2:  return (spatial_hash("K15") == 0x52940f053f7d41d8 ? coord("K16") : pass);
+		case 4:  return (spatial_hash("K5")  == 0xd3041f9087051224 ? coord("K4")  : pass);
 
-		case 6:  return (hash_empty("E10") == 0x4b3a2de37f1672b0 ? coord("D10") : pass);
-		case 8:  return (hash_empty("P10") == 0x1a311a3e8d8dc68c ? coord("Q10") : pass);
+		case 6:  return (spatial_hash("E10") == 0x4b3a2de37f1672b0 ? coord("D10") : pass);
+		case 8:  return (spatial_hash("P10") == 0x1a311a3e8d8dc68c ? coord("Q10") : pass);
 		default: return pass;
 	}
 }
@@ -86,11 +84,11 @@ tengen_sanrensei_fuseki(struct board *b, hash_t lasth)
 {
 	switch (b->moves) {
 		case 0: return coord("Q16");
-		case 2: if (hash_empty("Q5")  == 0x4ff209de037e7964)  return coord("Q4");
-			if (hash_empty("D15") == 0xf38ceba436dc80e4)  return coord("D16");
+		case 2: if (spatial_hash("Q5")  == 0x4ff209de037e7964)  return coord("Q4");
+			if (spatial_hash("D15") == 0xf38ceba436dc80e4)  return coord("D16");
 			return pass;
 		case 4:
-			if (hash_empty("K10") == 0x4e62eb7437da8b53)  return coord("K10");
+			if (spatial_hash("K10") == 0x4e62eb7437da8b53)  return coord("K10");
 			return pass;
 		default: return pass;
 	}
@@ -102,11 +100,11 @@ five_five_fuseki(struct board *b, hash_t lasth)
 {
 	switch (b->moves) {
 		case 0: return coord("P15");
-		case 2: if (hash_empty("Q5")  == 0x4ff209de037e7964)  return coord("P5");
-			if (hash_empty("D15") == 0xf38ceba436dc80e4)  return coord("E15");
+		case 2: if (spatial_hash("Q5")  == 0x4ff209de037e7964)  return coord("P5");
+			if (spatial_hash("D15") == 0xf38ceba436dc80e4)  return coord("E15");
 			return pass;
-		case 4:
-			if (hash_white("D4") == 0xfbbb40c10212374b)
+		case 4:			
+			if (spatial_hash("D4") == 0xaed991de623d0bc6)	/* White stone at D4 */
 				return random_coord("F3", "F3", "F4", "G3", "K4");
 			return pass;
 		default: return pass;
@@ -120,15 +118,15 @@ double_takamoku_fuseki(struct board *b, hash_t lasth)
 {
 	switch (b->moves) {
 		case 0: return coord("Q15");
-		case 2: if (hash_empty("Q5")  == 0x4ff209de037e7964)  return coord("P4");
-			if (hash_empty("D15") == 0xf38ceba436dc80e4)  return coord("E16");
+		case 2: if (spatial_hash("Q5")  == 0x4ff209de037e7964)  return coord("P4");
+			if (spatial_hash("D15") == 0xf38ceba436dc80e4)  return coord("E16");
 			return pass;
 	}
 
 	/* Cover invasion, otherwise no fun ... */
 	override_t overrides[] = {
-		{ .coord_empty = "Q5", .prev = "R4", "Q6", "",  { 0xb40892614d827e6, 0xbb42499bcc8ef68a, 0x7f3874ee2d7548a2, 0xfc3dfb8271de3b66,
-								  0xa5f0ba7f0edf4c02, 0x613a14799996cc56, 0xed437c981690dc16, 0x1a8e9d4f0524feea } },
+		{ .coord = "Q5", .prev = "R4", "Q6", "",  { 0xb40892614d827e6, 0xbb42499bcc8ef68a, 0x7f3874ee2d7548a2, 0xfc3dfb8271de3b66,
+							    0xa5f0ba7f0edf4c02, 0x613a14799996cc56, 0xed437c981690dc16, 0x1a8e9d4f0524feea } },
 		{ NULL, NULL, NULL }
 	};
 
@@ -142,8 +140,8 @@ christmas_island_fuseki(struct board *b, hash_t lasth)
 {
 	switch (b->moves) {
 		case 0: return coord("R14");
-		case 2: if (hash_empty("D15") == 0xf38ceba436dc80e4)  return coord("F17");
-			if (hash_empty("Q5")  == 0x4ff209de037e7964)  return coord("O3");
+		case 2: if (spatial_hash("D15") == 0xf38ceba436dc80e4)  return coord("F17");
+			if (spatial_hash("Q5")  == 0x4ff209de037e7964)  return coord("O3");
 			return pass;
 		default: return pass;
 	}
@@ -167,13 +165,13 @@ static fuseki_t wild_fusekis[] = {
 static coord_t
 large_keima_fuseki(struct board *b, hash_t lasth)
 {
-	override_t override = { .coord_empty = "P4", .prev = "", "O3", "",  { 0x77980cd3dd9328ef, 0x746b3bf60920fbc7, 0x66dfa042cb1f17cf, 0x652c97671facc4e7,
-									       0x32c2c9f9bfa6523f, 0x42e8884f4f56b037, 0x21066ae947c2613f, 0x512c2b5fb7328337 } };
+	override_t override = { .coord = "P4", .prev = "", "O3", "",  { 0x77980cd3dd9328ef, 0x746b3bf60920fbc7, 0x66dfa042cb1f17cf, 0x652c97671facc4e7,
+									0x32c2c9f9bfa6523f, 0x42e8884f4f56b037, 0x21066ae947c2613f, 0x512c2b5fb7328337 } };
 
 	switch (b->moves) {
 		case 0: return coord("Q16");
-		case 2: if (hash_empty("Q5")  == 0x4ff209de037e7964)  return coord("R4");
-			if (hash_empty("D15") == 0xf38ceba436dc80e4)  return coord("D17");
+		case 2: if (spatial_hash("Q5")  == 0x4ff209de037e7964)  return coord("R4");
+			if (spatial_hash("D15") == 0xf38ceba436dc80e4)  return coord("D17");
 			return pass;
 		case 4: return check_override(b, &override, NULL, lasth, "fuseki_override");
 		default: return pass;
@@ -185,13 +183,13 @@ sanrensei_fuseki(struct board *b, hash_t lasth)
 {
 	switch (b->moves) {
 		case 0: return coord("Q16");
-		case 2: if (hash_empty("Q5")  == 0x4ff209de037e7964)  return coord("Q4");
-			if (hash_empty("D15") == 0xf38ceba436dc80e4)  return coord("D16");
+		case 2: if (spatial_hash("Q5")  == 0x4ff209de037e7964)  return coord("Q4");
+			if (spatial_hash("D15") == 0xf38ceba436dc80e4)  return coord("D16");
 			return pass;
 		case 4: if (last_move2(b).coord == coord("Q4"))
-				return (hash_empty("P10") == 0x6824b58429db8cde ? coord("Q10") : pass);
+				return (spatial_hash("P10") == 0x6824b58429db8cde ? coord("Q10") : pass);
 			if (last_move2(b).coord == coord("D16"))
-				return (hash_empty("K15") == 0x1f77eaacf1573066 ? coord("K16") : pass);
+				return (spatial_hash("K15") == 0x1f77eaacf1573066 ? coord("K16") : pass);
 		default: return pass;
 	}
 }
@@ -201,13 +199,13 @@ chinese_fuseki(struct board *b, hash_t lasth)
 {
 	switch (b->moves) {
 		case 0: return coord("Q16");
-		case 2: if (hash_empty("Q5")  == 0x4ff209de037e7964)  return coord("Q3");
-			if (hash_empty("D15") == 0xf38ceba436dc80e4)  return coord("C16");
+		case 2: if (spatial_hash("Q5")  == 0x4ff209de037e7964)  return coord("Q3");
+			if (spatial_hash("D15") == 0xf38ceba436dc80e4)  return coord("C16");
 			return pass;
 		case 4: if (last_move2(b).coord == coord("Q3"))
-				return (hash_empty("P10") == 0x6824b58429db8cde ? random_coord("R9", "Q9") : pass);
+				return (spatial_hash("P10") == 0x6824b58429db8cde ? random_coord("R9", "Q9") : pass);
 			if (last_move2(b).coord == coord("C16"))
-				return (hash_empty("K15") == 0x1f77eaacf1573066 ? random_coord("J17", "J16") : pass);
+				return (spatial_hash("K15") == 0x1f77eaacf1573066 ? random_coord("J17", "J16") : pass);
 		default: return pass;
 	}
 }
@@ -277,6 +275,9 @@ check_special_fuseki(struct board *b, hash_t lasth) {
 coord_t
 josekifix_initial_fuseki(struct board *b, strbuf_t *log, hash_t lasth)
 {
+	/* All hashes are computed with dist 10 here. */
+	assert(MAX_PATTERN_DIST == 10);
+	
 	coord_t c = pass;
 	
 	/* Special fuseki ? */
@@ -293,5 +294,3 @@ josekifix_initial_fuseki(struct board *b, strbuf_t *log, hash_t lasth)
 
 	return pass;
 }
-
-

--- a/josekifix/joseki_override.c
+++ b/josekifix/joseki_override.c
@@ -355,9 +355,12 @@ sane_joseki_override_move(struct board *b, coord_t c, char *name, int n)
 	enum stone color = stone_other(last_move(b).color);
 	if (is_pass(c))  return true;
 	if (!board_is_valid_play_no_suicide(b, color, c)) {
-		josekifix_log("joseki_override: %s (%s", coord2sstr(c), name);
-		if (n > 1)  josekifix_log(", %i", n);
-		josekifix_log(")  WARNING invalid move !!\n");
+		/* Override or external engine returned an invalid move.
+		 * This should never happen, something very wrong is going on.
+		 * Log now (not through josekifix_log() which will get silenced). */
+		fprintf(stderr, "joseki_override: %s (%s", coord2sstr(c), name);
+		if (n > 1)  fprintf(stderr, ", %i", n);
+		fprintf(stderr, (")  WARNING invalid move !!\n");
 		return false;
 	}
 	return true;

--- a/josekifix/joseki_override.c
+++ b/josekifix/joseki_override.c
@@ -43,10 +43,6 @@ josekifix_init(board_t *b)
 /**********************************************************************************************************/
 /* External engine */
 
-
-/* For each quadrant, whether to enable external engine mode (value specifies number of moves)  */
-static int  wanted_external_engine_mode[4] = { 0, };
-
 static bool external_engine_overrides_enabled = true;
 
 #define EXTERNAL_ENGINE_MOVE -3
@@ -102,33 +98,38 @@ set_external_engine_mode_all_quadrants(board_t *b, int moves)
 }
 #endif
 
+/* For each quadrant, whether to enable external engine mode (value = number of moves)  */
+typedef struct {
+	char moves[4];
+} external_engine_mode_t;
+
 static void
-clear_wanted_external_engine_mode(void)
+clear_wanted_external_engine_mode(external_engine_mode_t *mode)
 {
 	for (int q = 0; q < 4; q++)
-		wanted_external_engine_mode[q] = 0;
+		mode->moves[q] = 0;
 }
 
 static void
-set_wanted_external_engine_mode(board_t *b, joseki_override_t *override, coord_t next, int rot)
+set_wanted_external_engine_mode(external_engine_mode_t *mode, board_t *b, joseki_override_t *override, coord_t next, int rot)
 {
 	bool have = false;
 	for (int q = 0; q < 4; q++)
 		if (override->external_engine_mode[q]) {
 			have = true;
-			wanted_external_engine_mode[rotate_quadrant(q, rot)] = override->external_engine_mode[q];
+			mode->moves[rotate_quadrant(q, rot)] = override->external_engine_mode[q];
 		}
 	if (have)  return;	/* explicit setting takes precedence if set */
 
 	if (is_pass(next))	/* pass as next move = enable external engine mode in last quadrant */
-		wanted_external_engine_mode[last_quadrant(b)] = DEFAULT_EXTERNAL_ENGINE_MOVES;
+		mode->moves[last_quadrant(b)] = DEFAULT_EXTERNAL_ENGINE_MOVES;
 }
 
 static void
-commit_wanted_external_engine_mode(board_t *b)
+commit_wanted_external_engine_mode(external_engine_mode_t *mode, board_t *b)
 {
 	for (int q = 0; q < 4; q++) {
-		int moves = wanted_external_engine_mode[q];
+		int moves = mode->moves[q];
 		
 		if (moves) {	/* enable external joseki engine mode in this quadrant */
 			set_external_engine_mode_quad(b, q, moves);
@@ -272,9 +273,11 @@ str2coord_safe(char *str)
 	return str2coord(str);
 }
 
-/* Check override at given location (single rotation) */
+/* Check override at given location (single rotation)
+ * If matches return next move and set wanted external engine @mode. */
 static coord_t
-check_joseki_override_at_rot(struct board *b, joseki_override_t *override, int rot, char* coordstr)
+check_joseki_override_at_rot(struct board *b, joseki_override_t *override, external_engine_mode_t *mode,
+			     int rot, char* coordstr)
 {
 	assert(override->next[0] && override->next[0] != 'X');
 	assert(coordstr[0] && coordstr[0] != 'X');
@@ -290,7 +293,7 @@ check_joseki_override_at_rot(struct board *b, joseki_override_t *override, int r
 	hash_t h = josekifix_spatial_hash(b, rcoord, last_move(b).color); /* hash with last move color */
 	if (h == override->hashes[rot] &&
 	    check_override_ladder(b, override, rot)) {
-		set_wanted_external_engine_mode(b, override, next, rot);
+		set_wanted_external_engine_mode(mode, b, override, next, rot);
 		if (is_pass(next))
 			return EXTERNAL_ENGINE_MOVE;
 		return rotate_coord(next, rot);
@@ -300,10 +303,10 @@ check_joseki_override_at_rot(struct board *b, joseki_override_t *override, int r
 
 /* Check override at given location (all rotations) */
 static coord_t
-check_joseki_override_at(struct board *b, joseki_override_t *override, char* coordstr)
+check_joseki_override_at(struct board *b, joseki_override_t *override, external_engine_mode_t *mode, char* coordstr)
 {
 	for (int rot = 0; rot < 8; rot++) {
-		coord_t c = check_joseki_override_at_rot(b, override, rot, coordstr);
+		coord_t c = check_joseki_override_at_rot(b, override, mode, rot, coordstr);
 		if (!is_pass(c))
 			return c;
 	}
@@ -313,7 +316,7 @@ check_joseki_override_at(struct board *b, joseki_override_t *override, char* coo
 
 /* Check override around last move (single rotation) */
 static coord_t
-check_joseki_override_last_rot(struct board *b, joseki_override_t *override, int rot, hash_t lasth)
+check_joseki_override_last_rot(struct board *b, joseki_override_t *override, external_engine_mode_t *mode, int rot, hash_t lasth)
 {
 	assert(override->prev[0] && override->prev[0] != 'X');
 	assert(override->next[0] && override->next[0] != 'X');
@@ -326,7 +329,7 @@ check_joseki_override_last_rot(struct board *b, joseki_override_t *override, int
 	
 	if (lasth == override->hashes[rot] &&
 	    check_override_ladder(b, override, rot)) {
-		set_wanted_external_engine_mode(b, override, next, rot);
+		set_wanted_external_engine_mode(mode, b, override, next, rot);
 		if (is_pass(next))
 			return EXTERNAL_ENGINE_MOVE;
 		return rotate_coord(next, rot);
@@ -336,12 +339,12 @@ check_joseki_override_last_rot(struct board *b, joseki_override_t *override, int
 
 /* Check override around last move (all rotations) */
 static coord_t
-check_joseki_override_last(struct board *b, joseki_override_t *override, hash_t lasth)
+check_joseki_override_last(struct board *b, joseki_override_t *override, external_engine_mode_t *mode, hash_t lasth)
 {
 	for (int rot = 0; rot < 8; rot++) {
-	    coord_t c = check_joseki_override_last_rot(b, override, rot, lasth);
-	    if (!is_pass(c))
-		    return c;
+		coord_t c = check_joseki_override_last_rot(b, override, mode, rot, lasth);
+		if (!is_pass(c))
+			return c;
 	}
 	
 	return pass;
@@ -367,19 +370,19 @@ sane_joseki_override_move(struct board *b, coord_t c, char *name, int n)
 }
 
 static coord_t
-check_joseki_override_rot(struct board *b, joseki_override_t *override, int rot, hash_t lasth)
+check_joseki_override_rot(struct board *b, joseki_override_t *override, external_engine_mode_t *mode, int rot, hash_t lasth)
 {
 	if (override->coord)
-		return check_joseki_override_at_rot(b, override, rot, override->coord);
-	return check_joseki_override_last_rot(b, override, rot, lasth);
+		return check_joseki_override_at_rot(b, override, mode, rot, override->coord);
+	return check_joseki_override_last_rot(b, override, mode, rot, lasth);
 }
 
 static coord_t
-check_joseki_override_(struct board *b, joseki_override_t *override, hash_t lasth)
+check_joseki_override_(struct board *b, joseki_override_t *override, external_engine_mode_t *mode, hash_t lasth)
 {
 	if (override->coord)
-		return check_joseki_override_at(b, override, override->coord);
-	return check_joseki_override_last(b, override, lasth);
+		return check_joseki_override_at(b, override, mode, override->coord);
+	return check_joseki_override_last(b, override, mode, lasth);
 }
 
 
@@ -388,9 +391,9 @@ check_joseki_override_(struct board *b, joseki_override_t *override, hash_t last
 
 /* Check single override, making sure returned move is sane. */
 static coord_t
-check_joseki_override(struct board *b, joseki_override_t *override, hash_t lasth)
+check_joseki_override(struct board *b, joseki_override_t *override, external_engine_mode_t *mode, hash_t lasth)
 {
-	coord_t c = check_joseki_override_(b, override, lasth);
+	coord_t c = check_joseki_override_(b, override, mode, lasth);
 
 	/* Get external engine move now if needed */
 	if (c == EXTERNAL_ENGINE_MOVE)
@@ -408,18 +411,18 @@ check_joseki_override(struct board *b, joseki_override_t *override, hash_t lasth
  * All overrides must match (in the same rotation) for this to match.
  * Returns last entry's next move. */
 static coord_t
-check_joseki_overrides_and(struct board *b, joseki_override_t *overrides, hash_t lasth)
+check_joseki_overrides_and(struct board *b, joseki_override_t *overrides, external_engine_mode_t *mode, hash_t lasth)
 {
 	for (int rot = 0; rot < 8; rot++) {
-		clear_wanted_external_engine_mode();	/* Cleanup in case of partial match */
+		clear_wanted_external_engine_mode(mode);	/* Cleanup in case of partial match */
 
 		/* Check if first override matches ... */
-		coord_t c = check_joseki_override_rot(b, &overrides[0], rot, lasth);
+		coord_t c = check_joseki_override_rot(b, &overrides[0], mode, rot, lasth);
 		if (is_pass(c))  continue;
 
 		/* And all other overrides match in same rotation.  */
 		for (int i = 1; overrides[i].name && !is_pass(c); i++)
-			c = check_joseki_override_rot(b, &overrides[i], rot, lasth);
+			c = check_joseki_override_rot(b, &overrides[i], mode, rot, lasth);
 		if (is_pass(c))  continue;
 
 		/* Passes all checks, get external engine move now if needed */
@@ -433,7 +436,7 @@ check_joseki_overrides_and(struct board *b, joseki_override_t *overrides, hash_t
 		return c;
 	}
 
-	clear_wanted_external_engine_mode();	/* Cleanup in case of partial match */
+	clear_wanted_external_engine_mode(mode);	/* Cleanup in case of partial match */
 	return pass;
 }
 
@@ -441,52 +444,103 @@ check_joseki_overrides_and(struct board *b, joseki_override_t *overrides, hash_t
 /**********************************************************************************************************/
 /* Batch override checking */
 
-/* Check overrides, return first match's next move (pass if none).
- * Matching needs not be optimized at all (few entries, running once
- * at the end of genmove). So we just run through the whole list, see
- * if there's any match (we have hashes for all rotations). */
+/* Check overrides, return best match's move (pass if none) and wanted external engine mode.
+ * Matching needs not be optimized at all (few entries, running once at the end of genmove).
+ * So run through the whole list, see if there's any match (we have hashes for all rotations). */
 static coord_t
-check_joseki_overrides_list(struct board *b, joseki_override_t overrides[], hash_t lasth, char *title)
+check_joseki_overrides_list(struct board *b, joseki_override_t overrides[], external_engine_mode_t *wanted,
+			    hash_t lasth, char *title)
 {
 	if (!overrides)  return pass;
+
+	joseki_override_t *best_match = NULL;
+	coord_t best_coord = pass;
+	int warned_no_prio = 0;
 	
 	for (int i = 0; overrides[i].name; i++) {
 		joseki_override_t *override = &overrides[i];
-		coord_t c = check_joseki_override(b, override, lasth);
-		if (!is_pass(c)) {
-			if (title) {  /* log */
-				int n = override_entry_number(overrides, override);
-				josekifix_log("%s (move %i): %s (%s", title, b->moves, coord2sstr(c), override->name);
-				if (n != 1)  josekifix_log(", %i", n);
-				josekifix_log(")\n");
-			}
-			return c;
+		external_engine_mode_t mode;
+		clear_wanted_external_engine_mode(&mode);
+		coord_t c = check_joseki_override(b, override, &mode, lasth);
+		if (is_pass(c))
+			continue;
+		
+		if (title) {  /* Log */		
+			int n = override_entry_number(overrides, override);
+			josekifix_log("%s (move %i): %s (%s", title, b->moves, coord2sstr(c), override->name);
+			if (n != 1)  josekifix_log(", %i", n);
+			josekifix_log(")");
+			if (override->priority)
+				josekifix_log("  (prio %i)", override->priority);
+			josekifix_log("\n");
 		}
+
+		/* Warn if we have multiple matches with same priority. */
+		if (best_match && override->priority == best_match->priority) {
+			if (!override->priority && !warned_no_prio++)
+				josekifix_log("%s (move %i): WARNING multiple matches with no priority set...\n", title, b->moves);
+			if (override->priority)
+				josekifix_log("%s (move %i): WARNING multiple matches with same priority (%i)\n", title, b->moves, override->priority);
+ 		}
+
+		/* Keep best match */
+		if (!best_match || override->priority > best_match->priority) {
+			best_match = override;
+			best_coord = c;
+			*wanted = mode;
+ 		}
 	}
-	return pass;
+	
+	return best_coord;
 }
 
 /* Same for overrides <and> checks (joseki_override2_t) */
 static coord_t
-check_joseki_overrides2_list(struct board *b, joseki_override2_t overrides[], hash_t lasth, char *title)
+check_joseki_overrides2_list(struct board *b, joseki_override2_t overrides[], external_engine_mode_t *wanted,
+			     hash_t lasth, char *title)
 {
 	if (!overrides)  return pass;
+
+	joseki_override_t *best_match = NULL;
+	coord_t     best_coord = pass;
+	int warned_no_prio = 0;
 	
 	for (int i = 0; overrides[i].override1.name; i++) {
 		joseki_override2_t *override = &overrides[i];
 		joseki_override_t  *override1 = &override->override1;
-		coord_t c = check_joseki_overrides_and(b, override1, lasth);
-		if (!is_pass(c)) {
-			if (title) {  /* log */
+		external_engine_mode_t mode;
+		clear_wanted_external_engine_mode(&mode);
+		coord_t c = check_joseki_overrides_and(b, override1, &mode, lasth);
+		if (is_pass(c))
+			continue;
+		
+		if (title) {  /* Log */
 				int n = override2_entry_number(overrides, override);
 				josekifix_log("%s (move %i): %s (%s", title, b->moves, coord2sstr(c), override1->name);
 				if (n != 1)  josekifix_log(", %i", n);
-				josekifix_log(")\n");
-			}
-			return c;
+				josekifix_log(")");
+				if (override1->priority)
+					josekifix_log("  (prio %i)", override1->priority);
+				josekifix_log("\n");
+		}
+		
+		/* Warn if we have multiple matches with same priority. */
+		if (best_match && override1->priority == best_match->priority) {
+			if (!override1->priority && !warned_no_prio++)
+				josekifix_log("%s (move %i): WARNING multiple matches with no priority set...\n", title, b->moves);
+			if (override1->priority)
+				josekifix_log("%s (move %i): WARNING multiple matches with same priority (%i)\n", title, b->moves, override1->priority);
+ 		}
+		
+		/* Keep best match */
+		if (!best_match || override1->priority > best_match->priority) {
+			best_match = override1;
+			best_coord = c;
+			*wanted = mode;
 		}
 	}
-	return pass;
+
+	return best_coord;	
 }
 
 
@@ -495,16 +549,16 @@ check_joseki_overrides2_list(struct board *b, joseki_override2_t overrides[], ha
 
 /* Check overrides, return first match's next move */
 static coord_t
-check_joseki_overrides(struct board *b, hash_t lasth)
+check_joseki_overrides(struct board *b, hash_t lasth, external_engine_mode_t *mode)
 {
 	coord_t c = pass;
 	
 	/* <and> checks first */
-	c = check_joseki_overrides2_list(b, joseki_overrides2, lasth, "joseki_override");
+	c = check_joseki_overrides2_list(b, joseki_overrides2, mode, lasth, "joseki_override");
 	if (!is_pass(c))  return c;
 
 	/* regular overrides */
-	c = check_joseki_overrides_list(b, joseki_overrides, lasth, "joseki_override");
+	c = check_joseki_overrides_list(b, joseki_overrides, mode, lasth, "joseki_override");
 	if (!is_pass(c))  return c;
 
 	return pass;
@@ -514,20 +568,21 @@ check_joseki_overrides(struct board *b, hash_t lasth)
 static void
 check_logged_variations(struct board *b, hash_t lasth)
 {
-	/* <and> checks first */	
-	check_joseki_overrides2_list(b, logged_variations2, lasth, "joseki_variation");
-	check_joseki_overrides_list(b, logged_variations, lasth, "joseki_variation");
+	/* <and> checks first */
+	external_engine_mode_t mode;  /* Dummy */
+	check_joseki_overrides2_list(b, logged_variations2, &mode, lasth, "joseki_variation");
+	check_joseki_overrides_list(b, logged_variations, &mode, lasth, "joseki_variation");
 }
 
 static coord_t
-joseki_override_(struct board *b, strbuf_t *log,
+joseki_override_(struct board *b, strbuf_t *log, external_engine_mode_t *mode,
 		 struct ownermap *prev_ownermap, struct ownermap *ownermap,
 		 bool external_engine_enabled)
 {
 	/* Shouldn't reach here if module disabled */
 	assert(josekifix_enabled);
 
-	clear_wanted_external_engine_mode();
+	clear_wanted_external_engine_mode(mode);
 	external_engine_overrides_enabled = external_engine_enabled;
 	log_buf = log;
     
@@ -543,7 +598,7 @@ joseki_override_(struct board *b, strbuf_t *log,
 
 	/* Joseki overrides */
 	check_logged_variations(b, lasth);
-	c = check_joseki_overrides(b, lasth);
+	c = check_joseki_overrides(b, lasth, mode);
 	if (!is_pass(c))  return c;
 	
 	/* Kill 3-3 invasion */
@@ -560,7 +615,7 @@ joseki_override_(struct board *b, strbuf_t *log,
 		c = external_joseki_engine_genmove(b);
 		if (!b->influence_fuseki_by_quadrant[last_quadrant(b)]++)
 			josekifix_log("joseki_override (move %i): %s (influence fuseki)\n", b->moves, coord2sstr(c));
-		wanted_external_engine_mode[last_quadrant(b)] = DEFAULT_EXTERNAL_ENGINE_MOVES;
+		mode->moves[last_quadrant(b)] = DEFAULT_EXTERNAL_ENGINE_MOVES;
 		return c;
 	}
 
@@ -583,13 +638,14 @@ joseki_override_external_engine_only(board_t *b)
 	assert(josekifix_enabled);
 	external_joseki_engine_genmoved = false;
 	strbuf(log, 4096);
-	coord_t c = joseki_override_(b, log, NULL, NULL, true);
+	external_engine_mode_t mode;
+	coord_t c = joseki_override_(b, log, &mode, NULL, NULL, true);
 	
 	if (!is_pass(c) && external_joseki_engine_genmoved) {
 		/* display log, we have a match */
 		if (DEBUGL(2))  fprintf(stderr, "%s", log->str);
 		
-		commit_wanted_external_engine_mode(b);
+		commit_wanted_external_engine_mode(&mode, b);
 		return c;
 	}
 	return pass;
@@ -602,11 +658,12 @@ coord_t
 joseki_override_no_external_engine(struct board *b, struct ownermap *prev_ownermap, struct ownermap *ownermap)
 {
 	assert(josekifix_enabled);
-	strbuf(log, 4096);    
-	coord_t c = joseki_override_(b, log, prev_ownermap, ownermap, false);
+	strbuf(log, 4096);
+	external_engine_mode_t mode;
+	coord_t c = joseki_override_(b, log, &mode, prev_ownermap, ownermap, false);
 	if (DEBUGL(2))  fprintf(stderr, "%s", log->str);	/* display log */
 
-	commit_wanted_external_engine_mode(b);
+	commit_wanted_external_engine_mode(&mode, b);
 	return c;
 }
 
@@ -617,10 +674,11 @@ joseki_override(struct board *b)
 	assert(josekifix_enabled);
 	external_joseki_engine_genmoved = false;
 	strbuf(log, 4096);
-	coord_t c = joseki_override_(b, log, NULL, NULL, true);
+	external_engine_mode_t mode;
+	coord_t c = joseki_override_(b, log, &mode, NULL, NULL, true);
 	if (DEBUGL(2))  fprintf(stderr, "%s", log->str);	/* display log */
 
-	commit_wanted_external_engine_mode(b);
+	commit_wanted_external_engine_mode(&mode, b);
 	return c;
 }
 

--- a/josekifix/joseki_override.c
+++ b/josekifix/joseki_override.c
@@ -8,6 +8,7 @@
 #include "tactics/util.h"
 #include "tactics/2lib.h"
 #include "tactics/ladder.h"
+#include "josekifix/override.h"
 #include "josekifix/joseki_override.h"
 #include "josekifix/josekifixload.h"
 #include "josekifix/josekifix_engine.h"
@@ -273,8 +274,7 @@ str2coord_safe(char *str)
 
 /* Check override at given location (single rotation) */
 static coord_t
-check_joseki_override_at_rot(struct board *b, joseki_override_t *override, int rot,
-			     char* coordstr, enum stone stone_color)
+check_joseki_override_at_rot(struct board *b, joseki_override_t *override, int rot, char* coordstr)
 {
 	assert(override->next[0] && override->next[0] != 'X');
 	assert(coordstr[0] && coordstr[0] != 'X');
@@ -287,26 +287,23 @@ check_joseki_override_at_rot(struct board *b, joseki_override_t *override, int r
 	if (is_pass(next) && !external_engine_overrides_enabled)	      return pass;
 		
 	coord_t rcoord = rotate_coord(coord, rot);
-	if (board_at(b, rcoord) == stone_color) {
-		hash_t h = outer_spatial_hash_from_board(b, rcoord, last_move(b).color); /* hash with last move color */
-		if (h == override->hashes[rot] &&
-		    check_override_ladder(b, override, rot)) {
-			set_wanted_external_engine_mode(b, override, next, rot);
-			if (is_pass(next))
-				return EXTERNAL_ENGINE_MOVE;
-			return rotate_coord(next, rot);
-		}
+	hash_t h = josekifix_spatial_hash(b, rcoord, last_move(b).color); /* hash with last move color */
+	if (h == override->hashes[rot] &&
+	    check_override_ladder(b, override, rot)) {
+		set_wanted_external_engine_mode(b, override, next, rot);
+		if (is_pass(next))
+			return EXTERNAL_ENGINE_MOVE;
+		return rotate_coord(next, rot);
 	}
 	return pass;
 }
 
 /* Check override at given location (all rotations) */
 static coord_t
-check_joseki_override_at(struct board *b, joseki_override_t *override,
-			 char* coordstr, enum stone stone_color)
+check_joseki_override_at(struct board *b, joseki_override_t *override, char* coordstr)
 {
 	for (int rot = 0; rot < 8; rot++) {
-		coord_t c = check_joseki_override_at_rot(b, override, rot, coordstr, stone_color);
+		coord_t c = check_joseki_override_at_rot(b, override, rot, coordstr);
 		if (!is_pass(c))
 			return c;
 	}
@@ -369,20 +366,16 @@ sane_joseki_override_move(struct board *b, coord_t c, char *name, int n)
 static coord_t
 check_joseki_override_rot(struct board *b, joseki_override_t *override, int rot, hash_t lasth)
 {
-	enum stone color = last_move(b).color;
-	if (override->coord_other)  return check_joseki_override_at_rot(b, override, rot, override->coord_other, color);
-	if (override->coord_own)    return check_joseki_override_at_rot(b, override, rot, override->coord_own, stone_other(color));
-	if (override->coord_empty)  return check_joseki_override_at_rot(b, override, rot, override->coord_empty, S_NONE);
+	if (override->coord)
+		return check_joseki_override_at_rot(b, override, rot, override->coord);
 	return check_joseki_override_last_rot(b, override, rot, lasth);
 }
 
 static coord_t
 check_joseki_override_(struct board *b, joseki_override_t *override, hash_t lasth)
 {
-	enum stone color = last_move(b).color;
-	if (override->coord_other)  return check_joseki_override_at(b, override, override->coord_other, color);
-	if (override->coord_own)    return check_joseki_override_at(b, override, override->coord_own, stone_other(color));
-	if (override->coord_empty)  return check_joseki_override_at(b, override, override->coord_empty, S_NONE);
+	if (override->coord)
+		return check_joseki_override_at(b, override, override->coord);
 	return check_joseki_override_last(b, override, lasth);
 }
 
@@ -535,11 +528,10 @@ joseki_override_(struct board *b, strbuf_t *log,
 	external_engine_overrides_enabled = external_engine_enabled;
 	log_buf = log;
     
-	assert(MAX_PATTERN_DIST == JOSEKIFIX_OVERRIDE_DIST);
 	if (board_rsize(b) != 19)            return pass;
 	
 	coord_t last = last_move(b).coord;
-	hash_t lasth = outer_spatial_hash_from_board(b, last, last_move(b).color);
+	hash_t lasth = josekifix_spatial_hash(b, last, last_move(b).color);
 	coord_t c = pass;
 
 	

--- a/josekifix/joseki_override.c
+++ b/josekifix/joseki_override.c
@@ -218,7 +218,7 @@ ladder_check(board_t *board, joseki_override_t *override, int rot, ladder_check_
 	
 	//board_print(b, stderr);
 	bool result = (check->works ? ladder : !ladder);
-	josekifix_log("joseki_override:      %s:  %s ladder at %s = %i  (%s)\n", override->name,
+	josekifix_log("joseki_override (move %i):      %s:  %s ladder at %s = %i  (%s)\n", board->moves, override->name,
 		      stone2str(ladder_color), coord2sstr(c), ladder, (result ? "ok" : "bad"));
 	return result;
 }
@@ -358,9 +358,9 @@ sane_joseki_override_move(struct board *b, coord_t c, char *name, int n)
 		/* Override or external engine returned an invalid move.
 		 * This should never happen, something very wrong is going on.
 		 * Log now (not through josekifix_log() which will get silenced). */
-		fprintf(stderr, "joseki_override: %s (%s", coord2sstr(c), name);
+		fprintf(stderr, "joseki_override (move %i): %s (%s", b->moves, coord2sstr(c), name);
 		if (n > 1)  fprintf(stderr, ", %i", n);
-		fprintf(stderr, (")  WARNING invalid move !!\n");
+		fprintf(stderr, ")  WARNING invalid move !!\n");
 		return false;
 	}
 	return true;
@@ -456,7 +456,7 @@ check_joseki_overrides_list(struct board *b, joseki_override_t overrides[], hash
 		if (!is_pass(c)) {
 			if (title) {  /* log */
 				int n = override_entry_number(overrides, override);
-				josekifix_log("%s: %s (%s", title, coord2sstr(c), override->name);
+				josekifix_log("%s (move %i): %s (%s", title, b->moves, coord2sstr(c), override->name);
 				if (n != 1)  josekifix_log(", %i", n);
 				josekifix_log(")\n");
 			}
@@ -479,7 +479,7 @@ check_joseki_overrides2_list(struct board *b, joseki_override2_t overrides[], ha
 		if (!is_pass(c)) {
 			if (title) {  /* log */
 				int n = override2_entry_number(overrides, override);
-				josekifix_log("%s: %s (%s", title, coord2sstr(c), override1->name);
+				josekifix_log("%s (move %i): %s (%s", title, b->moves, coord2sstr(c), override1->name);
 				if (n != 1)  josekifix_log(", %i", n);
 				josekifix_log(")\n");
 			}
@@ -559,7 +559,7 @@ joseki_override_(struct board *b, strbuf_t *log,
 	if (playing_against_influence_fuseki(b)) {
 		c = external_joseki_engine_genmove(b);
 		if (!b->influence_fuseki_by_quadrant[last_quadrant(b)]++)
-			josekifix_log("joseki override: %s (influence fuseki)\n", coord2sstr(c));
+			josekifix_log("joseki_override (move %i): %s (influence fuseki)\n", b->moves, coord2sstr(c));
 		wanted_external_engine_mode[last_quadrant(b)] = DEFAULT_EXTERNAL_ENGINE_MOVES;
 		return c;
 	}

--- a/josekifix/joseki_override.h
+++ b/josekifix/joseki_override.h
@@ -12,10 +12,6 @@
  * to let an external joseki engine take over the following sequence in this quadrant.
  */
 
-
-/* Pattern dist used for hashes */
-#define JOSEKIFIX_OVERRIDE_DIST 10
-
 #define JOSEKIFIX_LADDER_SETUP_MAX 5
 
 
@@ -46,10 +42,7 @@ typedef struct {
 	hash_t hashes[8];       /* spatial hashes for all 8 rotations */
 	
 			/* optional fields */
-	char* coord_own;	/* match pattern around this location instead of last move. */
-	char* coord_other;      /* spatial patterns ignore center stone so we need to convey that (3 possibilities) */
-	char* coord_empty;      /* set the one corresponding to board position (own color / other color / empty) */
-
+	char* coord;			/* match pattern around this location instead of last move. */
 	ladder_check_t ladder_check;	/* ladder checks */
 	ladder_check_t ladder_check2;
 

--- a/josekifix/joseki_override.h
+++ b/josekifix/joseki_override.h
@@ -51,6 +51,7 @@ typedef struct {
 					 * value specifies number of external engine moves to play.
 					 * note: can also just set "pass" as next move instead of filling this
 					 *       (= enable for current quadrant, 15 moves)  */
+	int priority;			/* pattern priority  (in case there are multiple matches) */	
 } joseki_override_t;
 
 /* Representation of an <and> check (2 overrides).

--- a/josekifix/joseki_override.h
+++ b/josekifix/joseki_override.h
@@ -1,5 +1,5 @@
-#ifndef PACHI_JOSEKIFIX_H
-#define PACHI_JOSEKIFIX_H
+#ifndef PACHI_JOSEKI_OVERRIDE_H
+#define PACHI_JOSEKI_OVERRIDE_H
 
 #ifdef JOSEKIFIX
 
@@ -12,7 +12,6 @@
  * to let an external joseki engine take over the following sequence in this quadrant.
  */
 
-struct ownermap;
 
 /* Pattern dist used for hashes */
 #define JOSEKIFIX_OVERRIDE_DIST 10
@@ -35,7 +34,6 @@ typedef struct {
  *   - last move
  *   - spatial pattern (radius 5) around last move (or a given coord near it)
  *   - optionally ladder checks (override specifies ladder setup).
- * Custom override code also gets passed current ownermap and can use it in their checks.
  *
  * Coords are just stored as strings: we really don't care about performance here (few
  * entries, running once at the end of genmove) and makes it easy to initialize override
@@ -60,15 +58,15 @@ typedef struct {
 					 * value specifies number of external engine moves to play.
 					 * note: can also just set "pass" as next move instead of filling this
 					 *       (= enable for current quadrant, 15 moves)  */
-} override_t;
+} joseki_override_t;
 
 /* Representation of an <and> check (2 overrides).
  * Terminating null kept for convenience */
 typedef struct {
-	override_t override1;
-	override_t override2;
-	override_t null;
-} override2_t;
+	joseki_override_t override1;
+	joseki_override_t override2;
+	joseki_override_t null;
+} joseki_override2_t;
 
 
 /* global */
@@ -76,23 +74,12 @@ void disable_josekifix(void);
 void require_josekifix(void);
 bool get_josekifix_enabled(void);
 bool get_josekifix_required(void);
-
-/* loading overrides */
 bool josekifix_init(board_t *b);
 
-/* genmove */
 coord_t joseki_override(struct board *b);
 coord_t joseki_override_no_external_engine(struct board *b, struct ownermap *prev_ownermap, struct ownermap *ownermap);
 coord_t joseki_override_external_engine_only(board_t *b);
 
-
-/* low level override matching */
-coord_t check_override(struct board *b, override_t *override, int *prot, hash_t lasth);
-coord_t check_override_last(struct board *b, override_t *override, int *prot, hash_t lasth);
-coord_t check_override_rot(struct board *b, override_t *override, int rot, hash_t lasth);
-coord_t check_overrides(struct board *b, override_t overrides[], hash_t lasth);
-coord_t check_overrides_and(struct board *b, override_t *overrides, int *prot, hash_t lasth, bool log);
-bool    josekifix_sane_override(struct board *b, coord_t c, char *name, int n);
 void    josekifix_log(const char *format, ...);
 bool    josekifix_ladder_setup(board_t *b, int rot, ladder_check_t *check);
 

--- a/josekifix/josekifix.h
+++ b/josekifix/josekifix.h
@@ -67,9 +67,10 @@ typedef struct {
 void disable_josekifix(void);
 void require_josekifix(void);
 bool get_josekifix_enabled(void);
+bool get_josekifix_required(void);
 
 /* loading overrides */
-void josekifix_init(board_t *b);
+bool josekifix_init(board_t *b);
 void joseki_override_fill_hashes(override_t *override, board_t *b);
 void joseki_override_print(override_t *override, char *section);
 void josekifix_add_override(board_t *b, override_t *override);
@@ -78,9 +79,10 @@ void josekifix_add_logged_variation(board_t *b, override_t *override);
 void josekifix_add_logged_variation_and(board_t *b, override_t *log1, override_t *log2);
 
 /* genmove */
-coord_t joseki_override_before_genmove(board_t *b, enum stone color);
+coord_t joseki_override(struct board *b);
 coord_t joseki_override_no_external_engine(struct board *b, struct ownermap *prev_ownermap, struct ownermap *ownermap);
 coord_t joseki_override_external_engine_only(board_t *b);
+
 
 /* low level override matching */
 coord_t check_override(struct board *b, override_t *override, int *prot, hash_t lasth);
@@ -96,11 +98,6 @@ coord_t josekifix_initial_fuseki(struct board *b, strbuf_t *log, hash_t lasth);
 
 /* special checks */
 coord_t josekifix_kill_3_3_invasion(struct board *b, struct ownermap *prev_ownermap, hash_t lasth);
-
-extern char     *external_joseki_engine_cmd;
-extern engine_t *external_joseki_engine;
-extern int	 external_joseki_engine_genmoved;
-
 
 
 #endif /* JOSEKIFIX */

--- a/josekifix/josekifix.h
+++ b/josekifix/josekifix.h
@@ -62,6 +62,14 @@ typedef struct {
 					 *       (= enable for current quadrant, 15 moves)  */
 } override_t;
 
+/* Representation of an <and> check (2 overrides).
+ * Terminating null kept for convenience */
+typedef struct {
+	override_t override1;
+	override_t override2;
+	override_t null;
+} override2_t;
+
 
 /* global */
 void disable_josekifix(void);
@@ -71,12 +79,6 @@ bool get_josekifix_required(void);
 
 /* loading overrides */
 bool josekifix_init(board_t *b);
-void joseki_override_fill_hashes(override_t *override, board_t *b);
-void joseki_override_print(override_t *override, char *section);
-void josekifix_add_override(board_t *b, override_t *override);
-void josekifix_add_override_and(board_t *b, override_t *override1, override_t *override2);
-void josekifix_add_logged_variation(board_t *b, override_t *override);
-void josekifix_add_logged_variation_and(board_t *b, override_t *log1, override_t *log2);
 
 /* genmove */
 coord_t joseki_override(struct board *b);
@@ -92,6 +94,7 @@ coord_t check_overrides(struct board *b, override_t overrides[], hash_t lasth);
 coord_t check_overrides_and(struct board *b, override_t *overrides, int *prot, hash_t lasth, bool log);
 bool    josekifix_sane_override(struct board *b, coord_t c, char *name, int n);
 void    josekifix_log(const char *format, ...);
+bool    josekifix_ladder_setup(board_t *b, int rot, ladder_check_t *check);
 
 /* fuseki */
 coord_t josekifix_initial_fuseki(struct board *b, strbuf_t *log, hash_t lasth);

--- a/josekifix/josekifix.h
+++ b/josekifix/josekifix.h
@@ -97,11 +97,6 @@ coord_t josekifix_initial_fuseki(struct board *b, strbuf_t *log, hash_t lasth);
 /* special checks */
 coord_t josekifix_kill_3_3_invasion(struct board *b, struct ownermap *prev_ownermap, hash_t lasth);
 
-/* external joseki engine */
-void    external_joseki_engine_play(coord_t c, enum stone color);
-void    external_joseki_engine_fixed_handicap(int stones);
-void    external_joseki_engine_forward_cmd(gtp_t *gtp, char *command);
-
 extern char     *external_joseki_engine_cmd;
 extern engine_t *external_joseki_engine;
 extern int	 external_joseki_engine_genmoved;

--- a/josekifix/josekifix.sgf
+++ b/josekifix/josekifix.sgf
@@ -2128,6 +2128,13 @@ See first variation in the tree ("3-4 trick play") for example.
 
 - Optional settings:
 
+  priority = n
+
+Set override priority (default 0).
+Can be useful to resolve cases where multiple overrides match but some are
+more specific / desirable than others. Otherwise first match is kept and a warning
+is issued.
+
   external_engine
   external_engine = lower_left lower_right
 

--- a/josekifix/josekifix_engine.c
+++ b/josekifix/josekifix_engine.c
@@ -12,7 +12,7 @@
 #include "engine.h"
 #include "engines/external.h"
 #include "josekifix/josekifix_engine.h"
-#include "josekifix/josekifix.h"
+#include "josekifix/joseki_override.h"
 #include "tactics/util.h"
 #include "dcnn/dcnn.h"
 #include "uct/uct.h"

--- a/josekifix/josekifix_engine.c
+++ b/josekifix/josekifix_engine.c
@@ -1,0 +1,383 @@
+#define DEBUG
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "board.h"
+#include "debug.h"
+#include "engine.h"
+#include "engines/external.h"
+#include "josekifix/josekifix_engine.h"
+#include "josekifix/josekifix.h"
+#include "tactics/util.h"
+#include "dcnn/dcnn.h"
+#include "uct/uct.h"
+
+
+/* Engine state */
+static engine_t *uct_engine = NULL;
+static engine_t *external_joseki_engine = NULL;
+static bool      undo_pending = false;
+
+/* Globals */
+char *external_joseki_engine_cmd = "katago gtp";
+bool  external_joseki_engine_genmoved = false;
+
+
+/**********************************************************************************************************/
+/* UCT engine */
+
+static void
+reload_uct_engine(engine_t *e, board_t *board)
+{
+	move_history_t *h = board->move_history;
+	int n = h->moves;
+	board_t *b = board_new(board->rsize, NULL);
+	b->handicap = board->handicap;
+
+	if (DEBUGL(3)) fprintf(stderr, "reloading uct engine after undo(s).\n");
+	engine_reset(uct_engine, b);
+	
+	/* Replay remaining moves. */
+	for (int i = 0; i < n; i++) {
+		move_t m = h->move[i];
+		bool print;
+		uct_engine->notify_play(uct_engine, b, &m, "", &print);
+		int r = board_play(b, &m);
+		assert(r >= 0);
+	}
+	
+	board_delete(&b);
+}
+
+
+/**********************************************************************************************************/
+/* External engine */
+
+static bool
+start_external_joseki_engine(board_t *b)
+{
+	assert(!external_joseki_engine);
+ 
+	char *cmd = external_joseki_engine_cmd;
+	if (!cmd)  return false;
+
+	strbuf(buf, 1024);
+	strbuf_printf(buf, "cmd=%s", cmd);
+	engine_t *e = new_engine(E_EXTERNAL, buf->str, b);
+	
+	if (!external_engine_started(e)) {
+		delete_engine(&e);
+		return false;
+	}
+
+	external_joseki_engine = e;
+	return true;
+}
+
+coord_t
+external_joseki_engine_genmove(board_t *b)
+{
+	enum stone color = board_to_play(b);
+	coord_t c = external_joseki_engine->genmove(external_joseki_engine, b, NULL, color, false);
+	
+	external_joseki_engine_genmoved = true;
+	
+	return c;
+}
+
+
+/**********************************************************************************************************/
+/* Genmove */
+
+/* Early genmove logic:
+ * If there's an override involving external joseki engine we want to avoid spending time in
+ * both engines. So check if there's an override involving external engine:
+ * - If so get final move from it. uct genmove will be skipped.
+ * - Otherwise return pass. Override will be handled after genmove.
+ * 
+ * Also take care to apply overrides to external engine moves if in external_joseki_engine_mode,
+ * they should take precedence. If there's an override still ask it for a move even though we
+ * don't need it to keep game timing the same. */
+coord_t
+joseki_override_before_genmove(board_t *b, enum stone color)
+{
+	coord_t c = pass;
+	int quad = last_quadrant(b);
+	bool external_joseki_engine_mode_on = b->external_joseki_engine_moves_left_by_quadrant[quad];
+	
+	if (external_joseki_engine_mode_on) {
+		b->external_joseki_engine_moves_left_by_quadrant[quad]--;
+		
+		if (DEBUGL(3))  fprintf(stderr, "external joseki engine mode: quadrant %i, moves left: %i\n",
+					quad, b->external_joseki_engine_moves_left_by_quadrant[quad]);
+
+		/* First check overrides. */
+		c = joseki_override(b);
+
+		/* If genmoved, we have final move and we spent some time thinking, all good.  */
+		if (external_joseki_engine_genmoved)  return c;
+
+		/* Get move now then ... */
+		coord_t c2 = external_joseki_engine_genmove(b);
+
+		/* But let override take over if different. */
+		if (!is_pass(c) && !is_pass(c2) && c2 != c) {   /* Keep engines in sync ! */
+			c2 = c;
+			external_engine_undo(external_joseki_engine);	/* Undo external engine move, */
+			external_joseki_engine_genmoved = false;	/* caller will send play command. */
+		}
+		
+		return c2;
+	}
+	
+	if (is_pass(c))
+		c = joseki_override_external_engine_only(b);
+
+	return c;
+}
+
+/* Get move from engine, or joseki override if there is one.
+ * There are 2 joseki override hooks : one before engine genmove (this one),
+ * and another one at the end of uct genmove. Without external engine we'd
+ * need only the second one, but with 2 engines we want to avoid asking both
+ * engines as that would mean a serious delay. So this acts as a dispatch,
+ * short-cirtuiting engine genmove when we know it will be overridden by an
+ * external engine move. */
+static coord_t
+genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive, engine_genmove_t uct_genmove_func)
+{
+	external_joseki_engine_genmoved = false;
+	
+	coord_t c = joseki_override_before_genmove(b, color);
+
+	if (is_pass(c))
+		c = uct_genmove_func(uct_engine, b, ti, color, pass_all_alive);
+
+	/* Send new move to external engine if it doesn't come from it. */
+	if (!is_resign(c) && !external_joseki_engine_genmoved)
+		external_engine_play(external_joseki_engine, c, color);
+	
+	return c;
+}
+
+static coord_t
+josekifix_engine_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
+{
+	return genmove(e, b, ti, color, pass_all_alive, uct_engine->genmove);
+}
+
+static coord_t
+josekifix_engine_genmove_analyze(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
+{
+	return genmove(e, b, ti, color, pass_all_alive, uct_engine->genmove_analyze);
+}
+
+
+/**********************************************************************************************************/
+/* UCT plumbing */
+
+/* Forward setoption() calls.
+ * Not terribly efficient, the way it works right now we'll reset engine 5 times if
+ * there are 5 options that need a reset... */
+static bool
+josekifix_engine_setoption(engine_t *e, board_t *b, const char *optname, char *optval,
+	      char **err, bool setup, bool *caller_reset)
+{
+	bool reset = false;	/* Use own reset, we don't want caller to ever reset us ! */
+	if (!uct_engine->setoption(uct_engine, b, optname, optval, err, setup, &reset) &&
+	    !reset)
+		return false;
+	
+	/* Save option */
+	engine_options_add(&uct_engine->options, optname, optval);
+
+	/* Engine reset needed ? */
+	if (reset)
+		engine_reset(uct_engine, b);
+	
+	return true;
+}
+
+static void
+josekifix_engine_board_print(engine_t *e, board_t *b, FILE *f)
+{
+	uct_engine->board_print(uct_engine, b, f);
+}
+
+static char *
+josekifix_engine_chat(engine_t *e, board_t *b, bool opponent, char *from, char *cmd)
+{
+	return uct_engine->chat(uct_engine, b, opponent, from, cmd);
+}
+
+static char *
+josekifix_engine_result(engine_t *e, board_t *b)
+{
+	return uct_engine->result(uct_engine, b);
+}
+
+static void
+josekifix_engine_best_moves(engine_t *e, board_t *b, time_info_t *ti, enum stone color,
+			    coord_t *best_c, float *best_r, int nbest)
+{
+	uct_engine->best_moves(uct_engine, b, ti, color, best_c, best_r, nbest);
+}
+
+void
+josekifix_engine_evaluate(engine_t *e, board_t *b, time_info_t *ti, floating_t *vals, enum stone color)
+{
+	uct_engine->evaluate(uct_engine, b, ti, vals, color);
+}
+
+static void
+josekifix_engine_analyze(engine_t *e, board_t *b, enum stone color, int start)
+{
+	uct_engine->analyze(uct_engine, b, color, start);
+}
+
+static void
+josekifix_engine_dead_groups(engine_t *e, board_t *b, move_queue_t *dead)
+{
+	uct_engine->dead_groups(uct_engine, b, dead);
+}
+
+static void
+josekifix_engine_stop(engine_t *e)
+{
+	uct_engine->stop(uct_engine);
+}
+
+static ownermap_t*
+josekifix_engine_ownermap(engine_t *e, board_t *b)
+{
+	return uct_engine->ownermap(uct_engine, b);
+}
+
+static char*
+josekifix_engine_notify_play(engine_t *e, board_t *b, move_t *m, char *arg, bool *print_board)
+{
+	return uct_engine->notify_play(uct_engine, b, m, arg, print_board);
+}
+
+
+/**********************************************************************************************************/
+/* Notify */
+
+/* Forward commands to external/uct engines. */
+static enum parse_code
+josekifix_engine_notify(engine_t *e, board_t *b, int id, char *cmd, char *args, gtp_t *gtp)
+{
+	/* Undo handling: 
+	 * external engine takes care of itself, we just forward undo commands.
+	 * uct engine however needs to be reset after first non-undo command. */
+	if (undo_pending && strcmp(cmd, "undo")) {
+		undo_pending = false;
+		reload_uct_engine(e, b);
+	}
+	if (!strcmp(cmd, "undo"))
+		undo_pending = true;
+
+	/* Forward command to external engine. */
+	external_joseki_engine->notify(external_joseki_engine, b, id, cmd, args, gtp);
+	
+	return P_OK;
+}
+
+/* Forward commands to uct engine (after gtp handler has run). */
+static void
+josekifix_engine_notify_after(engine_t *e, board_t *b, int id, char *cmd, gtp_t *gtp)
+{
+	/* Commands that need uct_engine reset. */
+	if (!strcmp(cmd, "clear_board") || !strcmp(cmd, "boardsize"))
+		engine_reset(uct_engine, b);
+}
+
+
+/**********************************************************************************************************/
+/* Engine init */
+
+static void
+josekifix_engine_done(engine_t *e)
+{
+	delete_engine(&uct_engine);
+	delete_engine(&external_joseki_engine);
+}
+
+/* Keep in sync with uct_engine_init(). */
+void
+josekifix_engine_init(engine_t *e, board_t *b)
+{
+	e->name = "UCT+Josekifix";
+	e->comment = "Pachi UCT Monte Carlo Tree Search engine (with joseki fixes)";
+	e->keep_on_clear = true;	/* Do not reset engine on clear_board */
+	e->keep_on_undo = true;		/* Do not reset engine after undo */
+
+	e->setoption = josekifix_engine_setoption;
+	e->board_print = josekifix_engine_board_print;
+	e->notify = josekifix_engine_notify;
+	e->notify_after = josekifix_engine_notify_after;
+	e->notify_play = josekifix_engine_notify_play;
+	e->chat = josekifix_engine_chat;
+	e->result = josekifix_engine_result;
+	e->genmove = josekifix_engine_genmove;
+	e->genmove_analyze = josekifix_engine_genmove_analyze;
+	e->best_moves = josekifix_engine_best_moves;
+	e->evaluate = josekifix_engine_evaluate;
+	e->analyze = josekifix_engine_analyze;
+	e->dead_groups = josekifix_engine_dead_groups;
+	e->stop = josekifix_engine_stop;
+	e->ownermap = josekifix_engine_ownermap;
+
+	e->done = josekifix_engine_done;
+}
+
+
+/**********************************************************************************************************/
+/* Main call */
+
+/* Return main engine to use:
+ * - josekifix engine if joseki fixes are enabled
+ * - uct engine       otherwise
+ * josekifix engine acts as middle man between gtp and uct engine. */
+engine_t*
+josekifix_engine_if_needed(engine_t *uct, board_t *b)
+{
+	uct_engine = uct;
+
+	if (!using_dcnn(b)) {
+		disable_josekifix();
+		return uct_engine;
+	}
+	
+	if (!get_josekifix_enabled()) {
+		if (DEBUGL(2))  fprintf(stderr, "Joseki fixes disabled\n");
+		return uct_engine;
+	}
+
+	start_external_joseki_engine(b);
+	
+	/* While we could support a degraded mode where only self-contained overrides are supported
+	 * when external engine is missing, joseki fixes database is designed with external engine
+	 * in mind and will not play its role without it. Disable joseki fixes and let user know. */	
+	if (!external_joseki_engine) {
+		if (get_josekifix_required())  die("josekifix required but external joseki engine missing, aborting.\n");
+		if (DEBUGL(1)) fprintf(stderr, "Joseki fixes disabled: external joseki engine missing\n");
+		disable_josekifix();
+		return uct_engine;
+	}
+
+	/* Load josekifix database */
+	if (!josekifix_init(b)) {
+		delete_engine(&external_joseki_engine);
+		disable_josekifix();
+		return uct_engine;
+	}
+	
+	engine_t *josekifix_engine = new_engine(E_JOSEKIFIX, NULL, b);
+	return josekifix_engine;
+}

--- a/josekifix/josekifix_engine.c
+++ b/josekifix/josekifix_engine.c
@@ -22,6 +22,7 @@
 static engine_t  *uct_engine = NULL;
 static engine_t  *external_joseki_engine = NULL;
 static bool       undo_pending = false;
+static bool       fake_external_joseki_engine = false;
 static ownermap_t prev_ownermap;
 
 /* Globals */
@@ -68,14 +69,25 @@ start_external_joseki_engine(board_t *b)
 	return true;
 }
 
+void
+set_fake_external_joseki_engine(void)
+{
+	fake_external_joseki_engine = true;
+}
+
 coord_t
 external_joseki_engine_genmove(board_t *b)
 {
+	external_joseki_engine_genmoved = true;
+
+	if (fake_external_joseki_engine) {	/* Fake engine ? Return first move available. */
+		coord_t c = b->f[0];
+		if (DEBUGL(2))  fprintf(stderr, "external joseki engine move: %s  (fake)\n", coord2sstr(c));
+		return c;
+	}
+	
 	enum stone color = board_to_play(b);
 	coord_t c = external_joseki_engine->genmove(external_joseki_engine, b, NULL, color, false);
-	
-	external_joseki_engine_genmoved = true;
-	
 	return c;
 }
 

--- a/josekifix/josekifix_engine.c
+++ b/josekifix/josekifix_engine.c
@@ -361,7 +361,7 @@ josekifix_engine_if_needed(engine_t *uct, board_t *b)
 {
 	uct_engine = uct;
 
-	if (!using_dcnn(b)) {
+	if (!using_dcnn(b) || uct_is_slave(uct)) {
 		disable_josekifix();
 		return uct_engine;
 	}

--- a/josekifix/josekifix_engine.h
+++ b/josekifix/josekifix_engine.h
@@ -14,6 +14,8 @@ void josekifix_engine_init(engine_t *e, board_t *b);
 coord_t   external_joseki_engine_genmove(board_t *b);
 engine_t* josekifix_engine_if_needed(engine_t *uct, board_t *b);
 
+/* For josekifixscan engine */
+void set_fake_external_joseki_engine(void);
 
 #endif
 

--- a/josekifix/josekifix_engine.h
+++ b/josekifix/josekifix_engine.h
@@ -1,0 +1,20 @@
+#ifndef PACHI_JOSEKIFIX_ENGINE_H
+#define PACHI_JOSEKIFIX_ENGINE_H
+
+#ifdef JOSEKIFIX
+
+#include "engine.h"
+
+extern char *external_joseki_engine_cmd;
+extern bool  external_joseki_engine_genmoved;
+
+
+void josekifix_engine_init(engine_t *e, board_t *b);
+
+coord_t   external_joseki_engine_genmove(board_t *b);
+engine_t* josekifix_engine_if_needed(engine_t *uct, board_t *b);
+
+
+#endif
+
+#endif

--- a/josekifix/josekifixload.c
+++ b/josekifix/josekifixload.c
@@ -829,6 +829,12 @@ add_override(board_t *b, move_t *m, char *move_str)
 		/* see above */
 		else if (!strcmp(name, "external_engine_moves"))
 			parse_external_engine_moves(b, &override, &setting, value);
+
+		else if (!strcmp(name, "priority")) {
+			if (!value || !value[0])
+				die("josekifix: priority: value needed.\n");
+			override.priority = atoi(value);
+		}
 		
 		else {
 			board_print(b, stderr);

--- a/josekifix/josekifixload.h
+++ b/josekifix/josekifixload.h
@@ -1,8 +1,21 @@
 #ifndef PACHI_JOSEKIFIXLOAD_H
 #define PACHI_JOSEKIFIXLOAD_H
 
+#ifdef JOSEKIFIX
+
 #include "engine.h"
+#include "josekifix/josekifix.h"
+
+extern override_t  *joseki_overrides;
+extern override2_t *joseki_overrides2;
+extern override_t  *logged_variations;
+extern override2_t *logged_variations2;
 
 void josekifixload_engine_init(engine_t *e, board_t *b);
+
+bool josekifix_load(void);
+
+
+#endif
 
 #endif

--- a/josekifix/josekifixload.h
+++ b/josekifix/josekifixload.h
@@ -4,12 +4,12 @@
 #ifdef JOSEKIFIX
 
 #include "engine.h"
-#include "josekifix/josekifix.h"
+#include "josekifix/joseki_override.h"
 
-extern override_t  *joseki_overrides;
-extern override2_t *joseki_overrides2;
-extern override_t  *logged_variations;
-extern override2_t *logged_variations2;
+extern joseki_override_t  *joseki_overrides;
+extern joseki_override2_t *joseki_overrides2;
+extern joseki_override_t  *logged_variations;
+extern joseki_override2_t *logged_variations2;
 
 void josekifixload_engine_init(engine_t *e, board_t *b);
 

--- a/josekifix/josekifixscan.c
+++ b/josekifix/josekifixscan.c
@@ -1,0 +1,83 @@
+#define DEBUG
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "board.h"
+#include "debug.h"
+#include "engine.h"
+#include "josekifix/joseki_override.h"
+#include "josekifix/josekifixscan.h"
+#include "josekifix/josekifix_engine.h"
+
+/* Monitor play commands and check for josekifix pattern matches on all game moves.
+ * Feed it entire gamelogs as gtp stream to check all positions.  */
+
+static char *
+josekifixscan_play(engine_t *e, board_t *board, move_t *m, char *enginearg, bool *print_board)
+{
+	board_t board2;  board_copy(&board2, board);
+	board_t *b = &board2;
+
+	/* Copy history, needed for fuseki matches */
+	move_history_t history;
+	assert(board->move_history);
+	memcpy(&history, board->move_history, sizeof(history));
+	b->move_history = &history;
+	
+	if (board_play(b, m) < 0) {
+		fprintf(stderr, "! INVALID MOVE %s %s\n", stone2str(m->color), coord2sstr(m->coord));
+		board_print(b, stderr);
+		die("josekifixscan: invalid move\n");
+	}
+	
+	/* Print board on matches */
+	coord_t c = joseki_override(b);	
+	if (!is_pass(c))
+		board_print(b, stderr);
+	
+	return NULL;
+}
+
+static enum parse_code
+josekifixscan_notify(engine_t *e, board_t *b, int id, char *cmd, char *args, gtp_t *gtp)
+{
+	/* Skip final_status_list commands. */
+	if (!strcmp(cmd, "final_status_list"))
+		return P_DONE_OK;
+
+	return P_OK;
+}
+
+static coord_t
+josekifixscan_genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_all_alive)
+{
+	die("genmove command not available in josekifixscan\n");
+}
+
+void
+josekifixscan_engine_init(engine_t *e, board_t *b)
+{
+	e->name = "JosekifixScan";
+	e->comment = "You cannot play Pachi with this engine, it is for debugging purposes.";
+	e->genmove = josekifixscan_genmove;
+	e->notify_play = josekifixscan_play;
+	e->notify = josekifixscan_notify;
+	// Don't reset engine on clear_board or undo.
+	e->keep_on_clear = true;
+	e->keep_on_undo = true;
+
+	/* Sanity checks */
+	assert(b->rsize == 19);
+	require_josekifix();
+	
+	if (!get_josekifix_enabled())
+		die("Can't run josekifixscan engine with josekifix disabled.\n");
+
+	/* Fake external engine */
+	set_fake_external_joseki_engine();
+
+	/* Load josekifix database */
+	if (!josekifix_init(b))
+		die("Couldn't load josekifix data\n");
+}

--- a/josekifix/josekifixscan.h
+++ b/josekifix/josekifixscan.h
@@ -1,0 +1,8 @@
+#ifndef PACHI_DCNN_JOSEKIFIXSCAN_H
+#define PACHI_DCNN_JOSEKIFIXSCAN_H
+
+#include "engine.h"
+
+void josekifixscan_engine_init(engine_t *e, board_t *b);
+
+#endif

--- a/josekifix/override.c
+++ b/josekifix/override.c
@@ -1,0 +1,209 @@
+#include <assert.h>
+#include <stdarg.h>
+
+#define DEBUG
+#include "board.h"
+#include "debug.h"
+#include "pattern/spatial.h"
+#include "josekifix/override.h"
+#include "josekifix/joseki_override.h"
+
+
+/*****************************************************************************/
+/* board_print_pattern(): visualize pattern area */
+
+/*
+typedef struct {
+	coord_t coord;
+	unsigned int d;
+} t_print_pattern_data;
+
+static char*
+print_pattern_handler(struct board *b, coord_t c, void *pdata)
+{
+	t_print_pattern_data *data = pdata;
+	int cx = coord_x(data->coord);    int cy = coord_y(data->coord);
+	
+	for (unsigned int d = 2; d <= data->d; d++)
+	for (unsigned int j = ptind[d]; j < ptind[d + 1]; j++) {
+		ptcoords_at(x, y, cx, cy, j);
+		if (coord_xy(b, x, y) == c)
+			return "*";
+	}
+	
+	static char s[2] = { 0, };
+	s[0] = stone2char(board_at(b, c));
+	return s;
+}
+
+static void
+board_print_pattern_full(struct board *b, coord_t coord, unsigned int d)
+{
+	t_print_pattern_data data = { .coord = coord, .d = d };
+	board_hprint(b, stderr, print_pattern_handler, (void*)&data);
+}
+
+static void
+board_print_pattern(struct board *b, coord_t coord)
+{
+	board_print_pattern_full(b, coord, MAX_PATTERN_DIST);
+}
+*/
+
+
+/*****************************************************************************/
+/* Low-level override matching */
+
+static coord_t
+str2coord_safe(char *str)
+{
+	if (!str || !str[0])  return pass;
+	return str2coord(str);
+}
+
+/* Check override at given location (single rotation) */
+static coord_t
+check_override_at_rot(struct board *b, override_t *override,
+		      int rot, char* coordstr, enum stone stone_color)
+{
+	assert(override->next[0] && override->next[0] != 'X');
+	assert(coordstr[0] && coordstr[0] != 'X');
+
+	coord_t coord = str2coord(coordstr);
+	coord_t prev  = str2coord_safe(override->prev);  // optional
+	coord_t next = str2coord(override->next);
+	
+	if (!is_pass(prev) && rotate_coord(prev, rot) != last_move(b).coord)  return pass;
+	assert(!is_pass(next));
+	
+	coord_t rcoord = rotate_coord(coord, rot);
+	if (board_at(b, rcoord) == stone_color) {
+		hash_t h = outer_spatial_hash_from_board(b, rcoord, last_move(b).color); /* hash with last move color */
+		if (h == override->hashes[rot])
+			return rotate_coord(next, rot);
+	}
+	return pass;
+}
+
+/* Check override at given location (all rotations)
+ * Rotation found written to @prot in case of match. */
+static coord_t
+check_override_at(struct board *b, override_t *override,
+		  int *prot, char* coordstr, enum stone stone_color)
+{
+	for (int rot = 0; rot < 8; rot++) {
+		coord_t c = check_override_at_rot(b, override, rot, coordstr, stone_color);
+		if (!is_pass(c)) {
+			if (prot)  *prot = rot;
+			return c;
+		}
+	}
+	
+	return pass;
+}
+
+/* Check override around last move (single rotation) */
+static coord_t
+check_override_last_rot(struct board *b, override_t *override, int rot, hash_t lasth)
+{
+	assert(override->prev[0] && override->prev[0] != 'X');
+	assert(override->next[0] && override->next[0] != 'X');
+
+	coord_t prev = str2coord(override->prev);
+	coord_t next = str2coord(override->next);
+	
+	if (rotate_coord(prev, rot) != last_move(b).coord)  return pass;
+	assert(!is_pass(next));
+	
+	if (lasth == override->hashes[rot])
+		return rotate_coord(next, rot);
+	return pass;
+}
+
+/* Check override around last move (all rotations)
+ * Rotation found written to @prot in case of match */
+coord_t
+check_override_last(struct board *b, override_t *override, int *prot, hash_t lasth)
+{
+	for (int rot = 0; rot < 8; rot++) {
+	    coord_t c = check_override_last_rot(b, override, rot, lasth);
+	    if (!is_pass(c)) {
+		    if (prot)  *prot = rot;
+		    return c;
+	    }
+	}
+	
+	return pass;
+}
+
+/* Check and warn if returned move is not sane... */
+/* XXX check what happens with logging  (special fuseki bad move) */
+bool
+sane_override_move(struct board *b, coord_t c, char *name, char *title)
+{
+	enum stone color = stone_other(last_move(b).color);
+	if (is_pass(c))  return true;
+	if (!board_is_valid_play_no_suicide(b, color, c) && DEBUGL(0)) {
+		josekifix_log("%s (move %i): %s (%s)  WARNING invalid move !!\n", title, b->moves, coord2sstr(c), name);
+		return false;
+	}
+	return true;
+}
+
+coord_t
+check_override_rot(struct board *b, override_t *override, int rot, hash_t lasth)
+{
+	enum stone color = last_move(b).color;
+	if (override->coord_other)  return check_override_at_rot(b, override, rot, override->coord_other, color);
+	if (override->coord_own)    return check_override_at_rot(b, override, rot, override->coord_own, stone_other(color));
+	if (override->coord_empty)  return check_override_at_rot(b, override, rot, override->coord_empty, S_NONE);
+	return check_override_last_rot(b, override, rot, lasth);
+}
+
+static coord_t
+check_override_(struct board *b, override_t *override, int *prot, hash_t lasth)
+{
+	enum stone color = last_move(b).color;
+	if (override->coord_other)  return check_override_at(b, override, prot, override->coord_other, color);
+	if (override->coord_own)    return check_override_at(b, override, prot, override->coord_own, stone_other(color));
+	if (override->coord_empty)  return check_override_at(b, override, prot, override->coord_empty, S_NONE);
+	return check_override_last(b, override, prot, lasth);
+}
+
+/* Check single override, making sure returned move is sane. */
+coord_t
+check_override(struct board *b, override_t *override, int *prot, hash_t lasth, char *title)
+{
+	coord_t c = check_override_(b, override, prot, lasth);
+
+	/* Check move is sane... */
+	if (!sane_override_move(b, c, override->name, title))
+		return pass;
+	
+	return c;
+}
+
+/* Check overrides, return first match's move (pass if none).
+ * Matching needs not be optimized at all (few entries, running once per genmove).
+ * So we just run through the whole list checking each one (we have hashes for all rotations). */
+coord_t
+check_overrides(struct board *b, override_t overrides[], hash_t lasth, char *title)
+{
+	if (!overrides)  return pass;
+
+	for (int i = 0; overrides[i].name; i++) {
+		override_t *override = &overrides[i];
+		coord_t c = check_override(b, override, NULL, lasth, title);
+		if (is_pass(c))
+			continue;
+
+		/* No logging here. */
+
+		/* Return first match */
+		return c;
+	}
+
+	return pass;
+}
+
+

--- a/josekifix/override.c
+++ b/josekifix/override.c
@@ -6,7 +6,6 @@
 #include "debug.h"
 #include "pattern/spatial.h"
 #include "josekifix/override.h"
-#include "josekifix/joseki_override.h"
 
 
 /*****************************************************************************/
@@ -141,7 +140,10 @@ sane_override_move(struct board *b, coord_t c, char *name, char *title)
 	enum stone color = stone_other(last_move(b).color);
 	if (is_pass(c))  return true;
 	if (!board_is_valid_play_no_suicide(b, color, c) && DEBUGL(0)) {
-		josekifix_log("%s (move %i): %s (%s)  WARNING invalid move !!\n", title, b->moves, coord2sstr(c), name);
+		/* Override returned an invalid move.
+		 * This should never happen, something very wrong is going on.
+		 * Log now (not through josekifix_log() which will get silenced). */
+		fprintf(stderr, "%s: %s (%s)  WARNING invalid move !!\n", title, coord2sstr(c), name);
 		return false;
 	}
 	return true;

--- a/josekifix/override.c
+++ b/josekifix/override.c
@@ -143,7 +143,7 @@ sane_override_move(struct board *b, coord_t c, char *name, char *title)
 		/* Override returned an invalid move.
 		 * This should never happen, something very wrong is going on.
 		 * Log now (not through josekifix_log() which will get silenced). */
-		fprintf(stderr, "%s: %s (%s)  WARNING invalid move !!\n", title, coord2sstr(c), name);
+		fprintf(stderr, "%s (move %i): %s (%s)  WARNING invalid move !!\n", title, b->moves, coord2sstr(c), name);
 		return false;
 	}
 	return true;

--- a/josekifix/override.h
+++ b/josekifix/override.h
@@ -13,9 +13,6 @@
  * to let an external joseki engine take over the following sequence in this quadrant.
  */
 
-/* Pattern dist used for hashes */
-#define JOSEKIFIX_OVERRIDE_DIST 10
-
 /* Overrides are represented by this struct. 
  * matching is based on:
  *   - last move
@@ -32,10 +29,12 @@ typedef struct {
 	hash_t hashes[8];       /* spatial hashes for all 8 rotations */
 	
 			/* optional fields */
-	char* coord_own;	/* match pattern around this location instead of last move. */
-	char* coord_other;      /* spatial patterns ignore center stone so we need to convey that (3 possibilities) */
-	char* coord_empty;      /* set the one corresponding to board position (own color / other color / empty) */
+	char* coord;		/* match pattern around this location instead of last move. */
 } override_t;
+
+#define josekifix_spatial_hash(b, coord, color)			spatial_hash_from_board(b, coord, color, MAX_PATTERN_DIST)
+#define josekifix_spatial_hash_rot(b, coord, color, rot)	spatial_hash_from_board_rot(b, coord, color, rot, MAX_PATTERN_DIST)
+
 
 /* Low level override matching */
 coord_t check_override(struct board *b, override_t *override, int *prot, hash_t lasth, char *title);

--- a/josekifix/override.h
+++ b/josekifix/override.h
@@ -1,0 +1,48 @@
+#ifndef PACHI_JOSEKIFIX_OVERRIDE_H
+#define PACHI_JOSEKIFIX_OVERRIDE_H
+
+/* Simple overrides
+ *
+ * Allows to match board situation based on spatial pattern around last move to for example,
+ * detect certain joseki or fuseki sequences no matter in which corner/board orientation/color
+ * they are played.
+ *
+ * joseki_override.h has extra logic for matching joseki sequences (ladder checks etc).
+ *
+ * Overrides can either specify next move ("just override this move"), or leave it as "pass"
+ * to let an external joseki engine take over the following sequence in this quadrant.
+ */
+
+/* Pattern dist used for hashes */
+#define JOSEKIFIX_OVERRIDE_DIST 10
+
+/* Overrides are represented by this struct. 
+ * matching is based on:
+ *   - last move
+ *   - spatial pattern (radius 5) around last move (or a given coord near it)
+ *
+ * Coords are just stored as strings: we really don't care about performance here (few
+ * entries, running once at the end of genmove) and makes it easy to initialize override
+ * structs in code where special handling / experiment is called for. */
+typedef struct {
+			/* mandatory fields */	
+	char* prev;		/* last move */
+	char* next;		/* wanted next move. "pass" = external joseki engine mode (see below) */
+	char* name;		/* override name (joseki line, fuseki name ...) */
+	hash_t hashes[8];       /* spatial hashes for all 8 rotations */
+	
+			/* optional fields */
+	char* coord_own;	/* match pattern around this location instead of last move. */
+	char* coord_other;      /* spatial patterns ignore center stone so we need to convey that (3 possibilities) */
+	char* coord_empty;      /* set the one corresponding to board position (own color / other color / empty) */
+} override_t;
+
+/* Low level override matching */
+coord_t check_override(struct board *b, override_t *override, int *prot, hash_t lasth, char *title);
+coord_t check_overrides(struct board *b, override_t overrides[], hash_t lasth, char *title);
+coord_t check_override_rot(struct board *b, override_t *override, int rot, hash_t lasth);
+
+bool sane_override_move(struct board *b, coord_t c, char *name, char *title);
+
+
+#endif

--- a/josekifix/special_checks.c
+++ b/josekifix/special_checks.c
@@ -3,7 +3,8 @@
 #include "board.h"
 #include "engine.h"
 #include "pattern/spatial.h"
-#include "josekifix/josekifix.h"
+#include "josekifix/override.h"
+#include "josekifix/joseki_override.h"
 
 
 /*  6 | . . . . . . . 
@@ -22,7 +23,7 @@ josekifix_kill_3_3_invasion(struct board *b, struct ownermap *prev_ownermap,
 	override_t override = 	{ .coord_empty = "B2", .prev = "C3", "B4", "", { 0xfb50710e59804023, 0x7fefef0db770bf17, 0xef77e916af17fb33, 0x255a0304dbe9fd17, 
 										 0x41fad91638b3a0eb, 0xe04691d5dc8ef2f, 0x8e93b792ac2f9dfb, 0x79549dde6309036f } };
 	int rot;
-	coord_t c = check_override(b, &override, &rot, lasth);
+	coord_t c = check_override(b, &override, &rot, lasth, "joseki_override");
 	if (is_pass(c)) return c;
 
 	/* Corner and side owned by us in prev ownermap ?

--- a/josekifix/special_checks.c
+++ b/josekifix/special_checks.c
@@ -20,8 +20,8 @@ josekifix_kill_3_3_invasion(struct board *b, struct ownermap *prev_ownermap,
 			    hash_t lasth)
 {
 	enum stone our_color = stone_other(last_move(b).color);
-	override_t override = 	{ .coord_empty = "B2", .prev = "C3", "B4", "", { 0xfb50710e59804023, 0x7fefef0db770bf17, 0xef77e916af17fb33, 0x255a0304dbe9fd17, 
-										 0x41fad91638b3a0eb, 0xe04691d5dc8ef2f, 0x8e93b792ac2f9dfb, 0x79549dde6309036f } };
+	override_t override = 	{ .coord = "B2", .prev = "C3", "B4", "", { 0xfb50710e59804023, 0x7fefef0db770bf17, 0xef77e916af17fb33, 0x255a0304dbe9fd17, 
+									   0x41fad91638b3a0eb, 0xe04691d5dc8ef2f, 0x8e93b792ac2f9dfb, 0x79549dde6309036f } };
 	int rot;
 	coord_t c = check_override(b, &override, &rot, lasth, "joseki_override");
 	if (is_pass(c)) return c;

--- a/pachi.c
+++ b/pachi.c
@@ -52,6 +52,20 @@ pachi_init(int argc, char *argv[])
 	engine_init_checks();
 };
 
+static engine_t *
+new_main_engine(int engine_id, board_t *b, int argc, char **argv, int optind)
+{
+	/* Extra cmdline args are engine parameters */
+	strbuf(buf, 1000);
+	for (int i = optind; i < argc; i++)
+		sbprintf(buf, "%s%s", (i == optind ? "" : ","), argv[i]);
+	char *engine_args = buf->str;
+
+	engine_t *e = new_engine(engine_id, engine_args, b);
+	
+	return e;
+}
+
 static void
 log_gtp_input(char *cmd)
 {
@@ -322,11 +336,14 @@ static struct option longopts[] = {
 /**********************************************************************************************************/
 /* Main */
 
+static gtp_t	 main_gtp;
+static board_t	*main_board = NULL;
+static engine_t *main_engine;
+
 int main(int argc, char *argv[])
 {
 	pachi_options_t *options = &main_options;
 
-	gtp_t main_gtp;	
 	gtp_t *gtp = &main_gtp;
 	
 	enum engine_id engine_id = E_UCT;
@@ -342,7 +359,7 @@ int main(int argc, char *argv[])
 
 	pachi_init(argc, argv);
 
-	board_t *b = board_new(dcnn_default_board_size(), fbookfile);
+	board_t *b = main_board = board_new(dcnn_default_board_size(), fbookfile);
 	gtp_internal_init(gtp);
 	gtp_init(gtp, b);
 	gtp->banner = strdup("Have a good game !");
@@ -547,37 +564,36 @@ int main(int argc, char *argv[])
 #endif
 
 	if (testfile)		 return unit_test(testfile);
+
+	engine_t *e = main_engine = new_main_engine(engine_id, b, argc, argv, optind);
 	
-	/* Extra cmdline args are engine parameters */
-	strbuf(buf, 1000);
-	for (int i = optind; i < argc; i++)
-		sbprintf(buf, "%s%s", (i == optind ? "" : ","), argv[i]);
-	char *engine_args = buf->str;
-	
-	engine_t e;  engine_init(&e, engine_id, engine_args, b);
 	network_init(gtp_port);
 
 	while (1) {
-		main_loop(gtp, b, &e, ti, &ti_default, gtp_port);
+		main_loop(gtp, b, e, ti, &ti_default, gtp_port);
 		if (!gtp_port)  break;
 		network_init(gtp_port);
 	}
 
-	engine_done(&e);
-	board_delete(&b);
-	gtp_done(gtp);
-	chat_done();
 	free(testfile);
 	free(gtp_port);
 	free(log_port);
 	free(chatfile);
 	free(fbookfile);
+	
+	pachi_done();
+	
 	return 0;
 }
 
 void
 pachi_done()
 {
+	delete_engine(&main_engine);
+	board_delete(&main_board);
+	gtp_done(&main_gtp);
+	
+	chat_done();
 	joseki_done();
 	prob_dict_done();
 	spatial_dict_done();

--- a/pachi.c
+++ b/pachi.c
@@ -25,7 +25,7 @@
 #include "pattern/spatial.h"
 #include "pattern/prob.h"
 #include "joseki/joseki.h"
-#include "josekifix/josekifix.h"
+#include "josekifix/joseki_override.h"
 #include "josekifix/josekifix_engine.h"
 
 /* Main options */

--- a/pachi.c
+++ b/pachi.c
@@ -347,6 +347,12 @@ static gtp_t	 main_gtp;
 static board_t	*main_board = NULL;
 static engine_t *main_engine;
 
+engine_t *
+pachi_main_engine(void)
+{
+	return main_engine;
+}
+
 int main(int argc, char *argv[])
 {
 	pachi_options_t *options = &main_options;

--- a/pachi.h
+++ b/pachi.h
@@ -16,12 +16,14 @@ typedef struct {
 	enum rules forced_rules;
 } pachi_options_t;
 
+/* Get global options */
+const pachi_options_t *pachi_options();
+
+/* Get main engine */
+struct engine *pachi_main_engine(void);
 
 /* Free globals */
 void pachi_done();
-
-/* Get global options */
-const pachi_options_t *pachi_options();
 
 /* Pachi binary */
 extern char *pachi_exe;

--- a/pattern/spatial.c
+++ b/pattern/spatial.c
@@ -152,13 +152,11 @@ spatial_hash(unsigned int rotation, spatial_t *s)
 	return h;
 }
 
-/* compute spatial hash from board, ignoring center stone */
+/* Compute spatial hash from board. */
 hash_t
-outer_spatial_hash_from_board_rot_d(board_t *b, coord_t coord, enum stone color,
-				    int rot, unsigned int d)
+spatial_hash_from_board_rot(board_t *b, coord_t coord, enum stone color, int rot, unsigned int d)
 {
-	hash_t h = pthashes[0][0][S_NONE];
-	assert(d+1 < sizeof(ptind) / sizeof(*ptind));
+	assert(d <= MAX_PATTERN_DIST);
 
 	if (is_pass(coord) || is_resign(coord))  return 0;
 	
@@ -166,10 +164,11 @@ outer_spatial_hash_from_board_rot_d(board_t *b, coord_t coord, enum stone color,
 	 * reverse all colors if we are white-to-play. */
 	static enum stone bt_black[4] = { S_NONE, S_BLACK, S_WHITE, S_OFFBOARD };
 	static enum stone bt_white[4] = { S_NONE, S_WHITE, S_BLACK, S_OFFBOARD };
-	enum stone (*bt)[4] = color == S_WHITE ? &bt_white : &bt_black;
+	enum stone (*bt)[4] = (color == S_WHITE ? &bt_white : &bt_black);
 
 	int cx = coord_x(coord), cy = coord_y(coord);
-	for (unsigned int i = ptind[2]; i < ptind[d + 1]; i++) {
+	hash_t h = 0;
+	for (unsigned int i = 0; i < ptind[d + 1]; i++) {
 		ptcoords_at(x, y, cx, cy, i);
 		h ^= pthashes[rot][i][(*bt)[board_atxy(b, x, y)]];
 	}
@@ -177,15 +176,9 @@ outer_spatial_hash_from_board_rot_d(board_t *b, coord_t coord, enum stone color,
 }
 
 hash_t
-outer_spatial_hash_from_board_rot(board_t *b, coord_t coord, enum stone color, int rot)
+spatial_hash_from_board(board_t *b, coord_t coord, enum stone color, unsigned int d)
 {
-	return outer_spatial_hash_from_board_rot_d(b, coord, color, rot, MAX_PATTERN_DIST);
-}
-
-hash_t
-outer_spatial_hash_from_board(board_t *b, coord_t coord, enum stone color)
-{
-	return outer_spatial_hash_from_board_rot(b, coord, color, 0);
+	return spatial_hash_from_board_rot(b, coord, color, 0, d);
 }
 
 char *

--- a/pattern/spatial.h
+++ b/pattern/spatial.h
@@ -132,10 +132,9 @@ void spatial_from_board(pattern_config_t *pc, spatial_t *s, board_t *b, move_t *
 /* Compute hash of given spatial pattern. */
 hash_t spatial_hash(unsigned int rotation, spatial_t *s);
 
-/* Compute spatial hash from board, ignoring center stone */
-hash_t outer_spatial_hash_from_board(board_t *b, coord_t coord, enum stone color);
-hash_t outer_spatial_hash_from_board_rot(board_t *b, coord_t coord, enum stone color, int rot);
-hash_t outer_spatial_hash_from_board_rot_d(board_t *b, coord_t coord, enum stone color, int rot, unsigned int d);
+/* Compute spatial hash from board. */
+hash_t spatial_hash_from_board(board_t *b, coord_t coord, enum stone color, unsigned int d);
+hash_t spatial_hash_from_board_rot(board_t *b, coord_t coord, enum stone color, int rot, unsigned int d);
 
 /* Convert given spatial pattern to string. */
 char *spatial2str(spatial_t *s);

--- a/t-unit/Makefile
+++ b/t-unit/Makefile
@@ -15,7 +15,12 @@ test: FORCE
 		make test_moggy test_spatial test_board; \
 	fi
 
+	@if ../pachi --compile-flags | grep -q "JOSEKIFIX"; then  \
+		make test_external_engine; \
+	fi
+
 	./run_tests
+
 	@make test_gtp
 
 	@echo -n "Testing uct genmove...   "
@@ -63,6 +68,16 @@ test_gtp: FORCE
            while read f; do  if ! grep -q "^\(# *\|\)$$f" tmp.gtp  ; then \
                echo "t-unit/gtp_test.gtp: command $$f not tested, fixme !"; exit 1 ; fi; done
 	@if ./gtp_check ../pachi -t =1000 -o /dev/null < tmp.gtp;  then \
+	   echo "OK"; else  echo "FAILED"; exit 1;  fi
+
+# Test josekifix external engine sync  (needs gnugo)
+test_external_engine:
+	@gnugo --version >/dev/null 2>&1 || ( echo "gnugo missing or not in path, aborting." ; exit 1 )
+	@gnugo --version | head -1 | grep -q "GNU Go 3.8" || ( echo "need gnugo 3.8, aborting." ; exit 1 )
+	@echo -n "Testing josekifix external engine sync...   "
+	@cat external_engine.gtp | ../pachi -d4 --josekifix --external-joseki-engine 'gnugo --mode gtp' 2>&1 >/dev/null  | \
+          grep 'external engine' > external_engine.out
+	@if cmp external_engine.out external_engine.ref >/dev/null; then \
 	   echo "OK"; else  echo "FAILED"; exit 1;  fi
 
 FORCE:

--- a/t-unit/external_engine.gtp
+++ b/t-unit/external_engine.gtp
@@ -1,0 +1,40 @@
+boardsize 19
+clear_board
+komi 1.5
+fixed_handicap 4
+play W r14
+play B r15
+play W q14
+play B o16
+play W r10
+play B s14
+play W s13
+play B s16
+play W r6
+play B r5
+play W q6
+play B o4
+play W m3
+play B n3
+play W m4
+play B m2
+
+play w j10
+play b k10
+play w k11
+play b j11
+showboard
+
+undo
+undo
+undo
+undo
+showboard
+
+play W l2
+play B o2
+play W m1
+play B n2
+play W f3
+showboard
+

--- a/t-unit/external_engine.ref
+++ b/t-unit/external_engine.ref
@@ -1,0 +1,143 @@
+external engine cmd: 'gnugo --mode gtp'
+external engine: 'name'
+external engine: = GNU Go
+external engine: 'version'
+external engine: = 3.8
+external engine: 'boardsize 19'
+external engine: = 
+external engine: 'clear_board '
+external engine: = 
+external engine: 'komi 1.5'
+external engine: = 
+external engine: 'fixed_handicap 4'
+external engine: = D16 Q16 D4 Q4
+external engine: 'play W r14'
+external engine: = 
+external engine: 'play B r15'
+external engine: = 
+external engine: 'play W q14'
+external engine: = 
+external engine: 'play B o16'
+external engine: = 
+external engine: 'play W r10'
+external engine: = 
+external engine: 'play B s14'
+external engine: = 
+external engine: 'play W s13'
+external engine: = 
+external engine: 'play B s16'
+external engine: = 
+external engine: 'play W r6'
+external engine: = 
+external engine: 'play B r5'
+external engine: = 
+external engine: 'play W q6'
+external engine: = 
+external engine: 'play B o4'
+external engine: = 
+external engine: 'play W m3'
+external engine: = 
+external engine: 'play B n3'
+external engine: = 
+external engine: 'play W m4'
+external engine: = 
+external engine: 'play B m2'
+external engine: = 
+external engine: 'play w j10'
+external engine: = 
+external engine: 'play b k10'
+external engine: = 
+external engine: 'play w k11'
+external engine: = 
+external engine: 'play b j11'
+external engine: = 
+external engine: 'showboard '
+external engine: = 
+external engine:    A B C D E F G H J K L M N O P Q R S T
+external engine: 19 . . . . . . . . . . . . . . . . . . . 19
+external engine: 18 . . . . . . . . . . . . . . . . . . . 18
+external engine: 17 . . . . . . . . . . . . . . . . . . . 17
+external engine: 16 . . . X . . . . . + . . . X . X . X . 16
+external engine: 15 . . . . . . . . . . . . . . . . X . . 15
+external engine: 14 . . . . . . . . . . . . . . . O O X . 14
+external engine: 13 . . . . . . . . . . . . . . . . . O . 13
+external engine: 12 . . . . . . . . . . . . . . . . . . . 12
+external engine: 11 . . . . . . . . X O . . . . . . . . . 11     WHITE (O) has captured 0 stones
+external engine: 10 . . . + . . . . O X . . . . . + O . . 10     BLACK (X) has captured 0 stones
+external engine:  9 . . . . . . . . . . . . . . . . . . . 9
+external engine:  8 . . . . . . . . . . . . . . . . . . . 8
+external engine:  7 . . . . . . . . . . . . . . . . . . . 7
+external engine:  6 . . . . . . . . . . . . . . . O O . . 6
+external engine:  5 . . . . . . . . . . . . . . . . X . . 5
+external engine:  4 . . . X . . . . . + . O . X . X . . . 4
+external engine:  3 . . . . . . . . . . . O X . . . . . . 3
+external engine:  2 . . . . . . . . . . . X . . . . . . . 2
+external engine:  1 . . . . . . . . . . . . . . . . . . . 1
+external engine:    A B C D E F G H J K L M N O P Q R S T
+external engine: 'undo '
+external engine: = 
+external engine: 'undo '
+external engine: = 
+external engine: 'undo '
+external engine: = 
+external engine: 'undo '
+external engine: = 
+external engine: 'showboard '
+external engine: = 
+external engine:    A B C D E F G H J K L M N O P Q R S T
+external engine: 19 . . . . . . . . . . . . . . . . . . . 19
+external engine: 18 . . . . . . . . . . . . . . . . . . . 18
+external engine: 17 . . . . . . . . . . . . . . . . . . . 17
+external engine: 16 . . . X . . . . . + . . . X . X . X . 16
+external engine: 15 . . . . . . . . . . . . . . . . X . . 15
+external engine: 14 . . . . . . . . . . . . . . . O O X . 14
+external engine: 13 . . . . . . . . . . . . . . . . . O . 13
+external engine: 12 . . . . . . . . . . . . . . . . . . . 12
+external engine: 11 . . . . . . . . . . . . . . . . . . . 11     WHITE (O) has captured 0 stones
+external engine: 10 . . . + . . . . . + . . . . . + O . . 10     BLACK (X) has captured 0 stones
+external engine:  9 . . . . . . . . . . . . . . . . . . . 9
+external engine:  8 . . . . . . . . . . . . . . . . . . . 8
+external engine:  7 . . . . . . . . . . . . . . . . . . . 7
+external engine:  6 . . . . . . . . . . . . . . . O O . . 6
+external engine:  5 . . . . . . . . . . . . . . . . X . . 5
+external engine:  4 . . . X . . . . . + . O . X . X . . . 4
+external engine:  3 . . . . . . . . . . . O X . . . . . . 3
+external engine:  2 . . . . . . . . . . . X . . . . . . . 2
+external engine:  1 . . . . . . . . . . . . . . . . . . . 1
+external engine:    A B C D E F G H J K L M N O P Q R S T
+external engine: 'play W l2'
+external engine: = 
+external engine: 'play B o2'
+external engine: = 
+external engine: 'play W m1'
+external engine: = 
+external engine: 'play B n2'
+external engine: = 
+external engine: 'play W f3'
+external engine: = 
+external engine: 'showboard '
+external engine: = 
+external engine:    A B C D E F G H J K L M N O P Q R S T
+external engine: 19 . . . . . . . . . . . . . . . . . . . 19
+external engine: 18 . . . . . . . . . . . . . . . . . . . 18
+external engine: 17 . . . . . . . . . . . . . . . . . . . 17
+external engine: 16 . . . X . . . . . + . . . X . X . X . 16
+external engine: 15 . . . . . . . . . . . . . . . . X . . 15
+external engine: 14 . . . . . . . . . . . . . . . O O X . 14
+external engine: 13 . . . . . . . . . . . . . . . . . O . 13
+external engine: 12 . . . . . . . . . . . . . . . . . . . 12
+external engine: 11 . . . . . . . . . . . . . . . . . . . 11     WHITE (O) has captured 0 stones
+external engine: 10 . . . + . . . . . + . . . . . + O . . 10     BLACK (X) has captured 0 stones
+external engine:  9 . . . . . . . . . . . . . . . . . . . 9
+external engine:  8 . . . . . . . . . . . . . . . . . . . 8
+external engine:  7 . . . . . . . . . . . . . . . . . . . 7
+external engine:  6 . . . . . . . . . . . . . . . O O . . 6
+external engine:  5 . . . . . . . . . . . . . . . . X . . 5
+external engine:  4 . . . X . . . . . + . O . X . X . . . 4
+external engine:  3 . . . . . O . . . . . O X . . . . . . 3
+external engine:  2 . . . . . . . . . . O X X X . . . . . 2
+external engine:  1 . . . . . . . . . . . O . . . . . . . 1
+external engine:    A B C D E F G H J K L M N O P Q R S T
+shutting down external engine ...
+external engine: 'quit'
+external engine: = 

--- a/t-unit/test.c
+++ b/t-unit/test.c
@@ -804,8 +804,8 @@ test_genmove(board_t *b, char *arg)
 		fprintf(stderr, "%s ", args[i]);
 	fprintf(stderr, "...\n\n");
 
-	static engine_t *e = NULL;
-	if (!e)  e = new_engine(E_UCT, "", b);
+	/* Use main engine. Creating new engine messes up context which is important here. */
+	engine_t *e = pachi_main_engine();
 
 	/* Sanity checks */
 	board_t *tmp = board_new(19, NULL);

--- a/uct/internal.h
+++ b/uct/internal.h
@@ -108,9 +108,6 @@ typedef struct uct {
 
 	/* Used within frame of single genmove. */
 	ownermap_t ownermap;
-#ifdef JOSEKIFIX
-	ownermap_t prev_ownermap;
-#endif
 	int  raw_playouts_per_sec;  /* current raw playouts per second (mcowner) */
 	bool allow_pass;    /* allow pass in uct descent */
 

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -29,8 +29,8 @@
 #include "uct/dynkomi.h"
 #include "uct/uct.h"
 #include "uct/walk.h"
-#include "josekifix/josekifix.h"
 #include "dcnn/dcnn.h"
+#include "josekifix/joseki_override.h"
 
 #ifdef DISTRIBUTED
 #include "uct/slave.h"

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -961,6 +961,12 @@ uct_tree_size_init(uct_t *u, size_t tree_size)
 	u->tree_size = tree_size;
 }
 
+bool
+uct_is_slave(engine_t *e)
+{
+	uct_t *u = (uct_t*)e->data;
+	return u->slave;
+}
 
 #define NEED_RESET   ENGINE_SETOPTION_NEED_RESET
 #define option_error engine_setoption_error

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -707,21 +707,6 @@ genmove(engine_t *e, board_t *b, time_info_t *ti, enum stone color, bool pass_al
 
 	uct_progress_status(u, u->t, b, color, 0, best_coord);
 
-#ifdef JOSEKIFIX
-	/* Check joseki override */
-	if (best && get_josekifix_enabled()) {
-		coord_t c = joseki_override_no_external_engine(b, &u->prev_ownermap, uct_ownermap(e, b));
-		if (!is_pass(c)) {
-			*best_coord = c;
-			best = tree_get_node(u->t->root, c);
-			assert(best);
-		}
-	}
-
-	/* Save ownermap */
-	u->prev_ownermap = u->ownermap;
-#endif
-
 	return best;
 }
 

--- a/uct/uct.h
+++ b/uct/uct.h
@@ -7,5 +7,6 @@ void   uct_engine_init(engine_t *e, board_t *b);
 
 bool   uct_gentbook(engine_t *e, board_t *b, time_info_t *ti, enum stone color);
 void   uct_dumptbook(engine_t *e, board_t *b, enum stone color);
+bool   uct_is_slave(engine_t *e);
 
 #endif


### PR DESCRIPTION
Rewrote Josekifix layer as a separate engine so we don't have to put hacks all over the place.

If josekifix is enabled josekifix_engine replaces uct as main engine and acts as middle man between GTP layer and uct engine. It also takes care of forwarding GTP notifications to external joseki engine so it can stay in sync.
This way no need to hardcode stuff in GTP layer, as far as it's concerned it's just another engine.

Clean up underlying override API as well:

- Split josekifix.c into
  `override.c`: Simple overrides which are used by other components like dcnn_blunder, fuseki...
  `joseki_override.c`:  Full crazy josekifix logic.
- Use regular spatial hashes instead joseki-module specific hashes which don't help here.

Added josekifixscan engine: 
Scan game records for josekfix overrides (testing).

New josekifix features:
- Overrides priority (can specify in SGF file)
- Log move numbers, multiple matches
- Fixed silenced warning in case of invalid move.