### PR TITLE
UCB1 Policy Fix

### DIFF
--- a/uct/internal.h
+++ b/uct/internal.h
@@ -166,40 +166,4 @@ void uct_mcowner_playouts(uct_t *u, board_t *b, enum stone color);
 void uct_tree_size_init(uct_t *u, size_t tree_size);
 
 
-/* This is the state used for descending the tree; we use this wrapper
- * structure in order to be able to easily descend in multiple trees
- * in parallel (e.g. main tree and local tree) or compute cummulative
- * "path value" throughout the tree descent. */
-typedef struct {
-	/* Active tree nodes: */
-	tree_node_t *node; /* Main tree. */
-	/* Value of main tree node (with all value factors, but unbiased
-	 * - without exploration factor), from black's perspective. */
-	move_stats_t value;
-} uct_descent_t;
-
-#define uct_descent(node)  { node }
-
-typedef tree_node_t *(*uctp_choose)(uct_policy_t *p, tree_node_t *node, board_t *b, enum stone color, coord_t exclude);
-typedef floating_t (*uctp_evaluate)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity);
-typedef void (*uctp_descend)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity, bool allow_pass);
-typedef void (*uctp_winner)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent);
-typedef void (*uctp_prior)(uct_policy_t *p, tree_t *tree, tree_node_t *node, board_t *b, enum stone color, int parity);
-typedef void (*uctp_update)(uct_policy_t *p, tree_t *tree, tree_node_t *node, enum stone node_color, enum stone player_color, playout_amafmap_t *amaf, board_t *final_board, floating_t result);
-typedef void (*uctp_done)(uct_policy_t *p);
-
-struct uct_policy {
-	uct_t *uct;
-	uctp_choose choose;
-	uctp_winner winner;
-	uctp_evaluate evaluate;
-	uctp_descend descend;
-	uctp_update update;
-	uctp_prior prior;
-	uctp_done done;
-	bool wants_amaf;
-	void *data;
-};
-
-
 #endif

--- a/uct/policy.h
+++ b/uct/policy.h
@@ -1,0 +1,41 @@
+#ifndef PACHI_UCT_POLICY_H
+#define PACHI_UCT_POLICY_H
+
+
+/* This is the state used for descending the tree; we use this wrapper
+ * structure in order to be able to easily descend in multiple trees
+ * in parallel (e.g. main tree and local tree) or compute cummulative
+ * "path value" throughout the tree descent. */
+typedef struct {
+	/* Active tree nodes: */
+	tree_node_t *node; /* Main tree. */
+	/* Value of main tree node (with all value factors, but unbiased
+	 * - without exploration factor), from black's perspective. */
+	move_stats_t value;
+} uct_descent_t;
+
+#define uct_descent(node)  { node }
+
+typedef tree_node_t *(*uctp_choose)(uct_policy_t *p, tree_node_t *node, board_t *b, enum stone color, coord_t exclude);
+typedef floating_t (*uctp_evaluate)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity);
+typedef void (*uctp_descend)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity, bool allow_pass);
+typedef void (*uctp_winner)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent);
+typedef void (*uctp_prior)(uct_policy_t *p, tree_t *tree, tree_node_t *node, board_t *b, enum stone color, int parity);
+typedef void (*uctp_update)(uct_policy_t *p, tree_t *tree, tree_node_t *node, enum stone node_color, enum stone player_color, playout_amafmap_t *amaf, board_t *final_board, floating_t result);
+typedef void (*uctp_done)(uct_policy_t *p);
+
+typedef struct uct_policy {
+	uct_t *uct;
+	uctp_choose choose;
+	uctp_winner winner;
+	uctp_evaluate evaluate;
+	uctp_descend descend;
+	uctp_update update;
+	uctp_prior prior;
+	uctp_done done;
+	bool wants_amaf;
+	void *data;
+} uct_policy_t;
+
+
+#endif

--- a/uct/policy.h
+++ b/uct/policy.h
@@ -2,27 +2,13 @@
 #define PACHI_UCT_POLICY_H
 
 
-/* This is the state used for descending the tree; we use this wrapper
- * structure in order to be able to easily descend in multiple trees
- * in parallel (e.g. main tree and local tree) or compute cummulative
- * "path value" throughout the tree descent. */
-typedef struct {
-	/* Active tree nodes: */
-	tree_node_t *node; /* Main tree. */
-	/* Value of main tree node (with all value factors, but unbiased
-	 * - without exploration factor), from black's perspective. */
-	move_stats_t value;
-} uct_descent_t;
-
-#define uct_descent(node)  { node }
-
-typedef tree_node_t *(*uctp_choose)(uct_policy_t *p, tree_node_t *node, board_t *b, enum stone color, coord_t exclude);
-typedef floating_t (*uctp_evaluate)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity);
-typedef void (*uctp_descend)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent, int parity, bool allow_pass);
-typedef void (*uctp_winner)(uct_policy_t *p, tree_t *tree, uct_descent_t *descent);
-typedef void (*uctp_prior)(uct_policy_t *p, tree_t *tree, tree_node_t *node, board_t *b, enum stone color, int parity);
-typedef void (*uctp_update)(uct_policy_t *p, tree_t *tree, tree_node_t *node, enum stone node_color, enum stone player_color, playout_amafmap_t *amaf, board_t *final_board, floating_t result);
-typedef void (*uctp_done)(uct_policy_t *p);
+typedef tree_node_t* (*uctp_choose)(uct_policy_t *p, tree_node_t *node, board_t *b, enum stone color, coord_t exclude);
+typedef floating_t   (*uctp_evaluate)(uct_policy_t *p, tree_t *tree, tree_node_t *node, int parity);
+typedef tree_node_t* (*uctp_descend)(uct_policy_t *p, tree_t *tree, tree_node_t *node, int parity, bool allow_pass);
+typedef tree_node_t* (*uctp_winner)(uct_policy_t *p, tree_t *tree, tree_node_t *node);
+typedef void         (*uctp_prior)(uct_policy_t *p, tree_t *tree, tree_node_t *node, board_t *b, enum stone color, int parity);
+typedef void         (*uctp_update)(uct_policy_t *p, tree_t *tree, tree_node_t *node, enum stone node_color, enum stone player_color, playout_amafmap_t *amaf, board_t *final_board, floating_t result);
+typedef void         (*uctp_done)(uct_policy_t *p);
 
 typedef struct uct_policy {
 	uct_t *uct;

--- a/uct/policy/generic.c
+++ b/uct/policy/generic.c
@@ -10,6 +10,7 @@
 #include "random.h"
 #include "uct/internal.h"
 #include "uct/tree.h"
+#include "uct/policy.h"
 #include "uct/policy/generic.h"
 
 tree_node_t *

--- a/uct/policy/generic.c
+++ b/uct/policy/generic.c
@@ -52,17 +52,15 @@ uctp_generic_choose(uct_policy_t *p, tree_node_t *node, board_t *b, enum stone c
  * value (using prior and possibly rave), because the raw value is meaningless for
  * nodes evaluated rarely.
  * This function is called while the tree is updated by other threads */
-void
-uctp_generic_winner(uct_policy_t *p, tree_t *tree, uct_descent_t *descent)
+tree_node_t *
+uctp_generic_winner(uct_policy_t *p, tree_t *tree, tree_node_t *node)
 {
-	if (!p->evaluate)
-		return;
 	bool allow_pass = false; /* At worst forces some extra playouts at the end */
-	int parity = tree_node_parity(tree, descent->node);
+	int parity = tree_node_parity(tree, node);
 
-	uctd_try_node_children(tree, descent, allow_pass, parity, p->uct->tenuki_d, di, urgency) {
-		urgency = p->evaluate(p, tree, &di, parity);
-	} uctd_set_best_child(di, urgency);
+	uctd_try_node_children(tree, node, allow_pass, parity, p->uct->tenuki_d, ni, urgency) {
+		urgency = p->evaluate(p, tree, ni, parity);
+	} uctd_set_best_child(ni, urgency);
 
-	uctd_get_best_child(descent);
+	return uctd_get_best_child(node);
 }

--- a/uct/policy/generic.h
+++ b/uct/policy/generic.h
@@ -11,7 +11,7 @@ struct board;
 struct tree_node;
 
 tree_node_t *uctp_generic_choose(uct_policy_t *p, tree_node_t *node, board_t *b, enum stone color, coord_t exclude);
-void uctp_generic_winner(uct_policy_t *p, tree_t *tree, uct_descent_t *descent);
+tree_node_t *uctp_generic_winner(uct_policy_t *p, tree_t *tree, tree_node_t *node);
 
 
 /* Some generic stitching for tree descent. */
@@ -22,46 +22,48 @@ void uctp_generic_winner(uct_policy_t *p, tree_t *tree, uct_descent_t *descent);
 #define uctd_debug(fmt...)
 #endif
 
-#define uctd_try_node_children(tree, descent, allow_pass, parity, tenuki_d, di, urgency) \
-	/* Information abound best children. */ \
-	/* XXX: We assume board <=25x25. */ \
-	uct_descent_t dbest[BOARD_MAX_MOVES + 1] = { uct_descent(descent->node->children) }; int dbests = 1; \
-	floating_t best_urgency = -9999; \
-	/* Descent children iterator. */ \
-	uct_descent_t dci = uct_descent(descent->node->children); \
-	\
-	for (; dci.node; dci.node = dci.node->sibling) { \
-		floating_t urgency; \
-		/* Do not consider passing early. */ \
-		if (unlikely((!allow_pass && is_pass(node_coord(dci.node))) || (dci.node->hints & TREE_HINT_INVALID))) \
-			continue; \
-		/* Set up descent-further iterator. This is the public-accessible
-		 * one, and usually is similar to dci. However, in case of local
-		 * trees, we may keep next-candidate pointer in dci while storing
-		 * actual-specimen in di. */ \
-		uct_descent_t di = dci; \
+/* Compute urgency for each child of @node.
+ * Following urgency code is called for each child with @ni as 
+ * current child node and stores its result in @urgency.  */
+#define uctd_try_node_children(tree, node, allow_pass, parity, tenuki_d, ni, urgency)				\
+	/* Information abound best children. */									\
+	/* XXX: We assume board <=25x25. */									\
+	tree_node_t *dbest[BOARD_MAX_MOVES + 1] = { node->children };						\
+	int dbests = 1;												\
+	floating_t best_urgency = -9999;									\
+														\
+	/* Descent children iterator. */									\
+	for (tree_node_t *dci = node->children; dci; dci = dci->sibling) {					\
+		floating_t urgency;										\
+		/* Do not consider passing early. */								\
+		if (unlikely((!allow_pass && is_pass(node_coord(dci))) || (dci->hints & TREE_HINT_INVALID)))	\
+			continue;										\
+		/* Set up descent-further iterator. This is the public-accessible one. */			\
+		tree_node_t *ni = dci;										\
 
 		/* ...your urgency computation code goes here... */
 
-#define uctd_set_best_child(di, urgency) \
-		uctd_debug("(%s) %f\n", coord2sstr(node_coord(di.node), tree->board), urgency); \
-		if (urgency - best_urgency > __FLT_EPSILON__) { /* urgency > best_urgency */ \
-			uctd_debug("new best\n"); \
-			best_urgency = urgency; dbests = 0; \
-		} \
-		if (urgency - best_urgency > -__FLT_EPSILON__) { /* urgency >= best_urgency */ \
-			uctd_debug("another best\n"); \
-			/* We want to always choose something else than a pass \
-			 * in case of a tie. pass causes degenerative behaviour. */ \
-			if (dbests == 1 && is_pass(node_coord(dbest[0].node))) { \
-				dbests--; \
-			} \
-			uct_descent_t db = di; \
-			dbest[dbests++] = db; \
-		} \
+
+/* Keep track of children with highest urgency. */
+#define uctd_set_best_child(ni, urgency)									\
+		uctd_debug("(%s) %f\n", coord2sstr(node_coord(ni), tree->board), urgency);			\
+		if (urgency - best_urgency > __FLT_EPSILON__) { /* urgency > best_urgency */			\
+			uctd_debug("new best\n");								\
+			best_urgency = urgency; dbests = 0;							\
+		}												\
+		if (urgency - best_urgency > -__FLT_EPSILON__) { /* urgency >= best_urgency */			\
+			uctd_debug("another best\n");								\
+			/* We want to always choose something else than a pass					\
+			 * in case of a tie. pass causes degenerative behaviour. */				\
+			if (dbests == 1 && is_pass(node_coord(dbest[0]))) {					\
+				dbests--;									\
+			}											\
+			dbest[dbests++] = ni;									\
+		}												\
 	}
 
-#define uctd_get_best_child(descent) *(descent) = dbest[fast_random(dbests)];
+/* Select best child for descent */
+#define uctd_get_best_child(node)	(dbest[fast_random(dbests)])
 
 
 #endif

--- a/uct/policy/ucb1.c
+++ b/uct/policy/ucb1.c
@@ -17,7 +17,7 @@
 
 typedef struct {
 	/* This is what the Modification of UCT with Patterns in Monte Carlo Go
-	 * paper calls 'p'. Original UCB has this on 2, but this seems to
+	 * paper calls 'p'. Original UCB has this on sqrt(2), but this seems to
 	 * produce way too wide searches; reduce this to get deeper and
 	 * narrower readouts - try 0.2. */
 	floating_t explore_p;

--- a/uct/policy/ucb1.c
+++ b/uct/policy/ucb1.c
@@ -65,15 +65,9 @@ ucb1_update(uct_policy_t *p, tree_t *tree, tree_node_t *node, enum stone node_co
 	 * update all the preceding positions properly since
 	 * they had to all occur in all branches, only in
 	 * different order. */
-	enum stone winner_color = result > 0.5 ? S_BLACK : S_WHITE;
 
 	for (; node; node = node->parent) {
 		stats_add_result(&node->u, result, 1);
-
-		if (!is_pass(node_coord(node))) {
-			stats_add_result(&node->winner_owner, board_at(final_board, node_coord(node)) == winner_color ? 1.0 : 0.0, 1);
-			stats_add_result(&node->black_owner, board_at(final_board, node_coord(node)) == S_BLACK ? 1.0 : 0.0, 1);
-		}
 	}
 }
 

--- a/uct/policy/ucb1.c
+++ b/uct/policy/ucb1.c
@@ -9,6 +9,7 @@
 #include "move.h"
 #include "random.h"
 #include "uct/internal.h"
+#include "uct/policy.h"
 #include "uct/tree.h"
 #include "uct/policy/generic.h"
 

--- a/uct/policy/ucb1.c
+++ b/uct/policy/ucb1.c
@@ -45,10 +45,9 @@ ucb1_descend(uct_policy_t *p, tree_t *tree, tree_node_t *node, int parity, bool 
 		/* xxx: we don't take local-tree information into account. */
 
 		if (uct_playouts) {
-			urgency = (ni->u.playouts * tree_node_get_value(tree, parity, ni->u.value)
-				   + ni->prior.playouts * tree_node_get_value(tree, parity, ni->prior.value))
-				   + (parity > 0 ? 0 : ni->descents)
-				  / uct_playouts;
+			urgency = (ni->u.playouts     * tree_node_get_value(tree, parity, ni->u.value) +
+				   ni->prior.playouts * tree_node_get_value(tree, parity, ni->prior.value) +
+				   (parity > 0 ? 0 : ni->descents)) / uct_playouts;
 			urgency += b->explore_p * sqrt(xpl / uct_playouts);
 		} else {
 			urgency = b->fpu;

--- a/uct/policy/ucb1amaf.c
+++ b/uct/policy/ucb1amaf.c
@@ -13,6 +13,7 @@
 #include "random.h"
 #include "tactics/util.h"
 #include "uct/internal.h"
+#include "uct/policy.h"
 #include "uct/tree.h"
 #include "uct/policy/generic.h"
 

--- a/uct/policy/ucb1amaf.c
+++ b/uct/policy/ucb1amaf.c
@@ -21,7 +21,7 @@
 
 typedef struct {
 	/* This is what the Modification of UCT with Patterns in Monte Carlo Go
-	 * paper calls 'p'. Original UCB has this on 2, but this seems to
+	 * paper calls 'p'. Original UCB has this on sqrt(2), but this seems to
 	 * produce way too wide searches; reduce this to get deeper and
 	 * narrower readouts - try 0.2. */
 	floating_t explore_p;

--- a/uct/search.c
+++ b/uct/search.c
@@ -25,6 +25,7 @@
 #include "uct/walk.h"
 #include "uct/prior.h"
 #include "uct/dynkomi.h"
+#include "uct/policy.h"
 #include "dcnn/dcnn.h"
 #include "pachi.h"
 

--- a/uct/search.c
+++ b/uct/search.c
@@ -747,11 +747,8 @@ uct_search_check_stop(uct_t *u, board_t *b, enum stone color,
 	/* We want to stop simulating, but are willing to keep trying
 	 * if we aren't completely sure about the winner yet. */
 	if (desired_done) {
-		if (u->policy->winner && u->policy->evaluate) {
-			uct_descent_t descent = uct_descent(ctx->t->root);
-			u->policy->winner(u->policy, ctx->t, &descent);
-			winner = descent.node;
-		}
+		if (u->policy->winner && u->policy->evaluate)
+			winner = u->policy->winner(u->policy, ctx->t, ctx->t->root);
 		if (best)
 			bestr = u->policy->choose(u->policy, best, b, stone_other(color), resign);
 		if (!uct_search_keep_looking(u, ctx->t, b, ti, &s->stop, best, best2, bestr, winner, i))

--- a/uct/uct.c
+++ b/uct/uct.c
@@ -27,6 +27,7 @@
 #include "uct/search.h"
 #include "uct/tree.h"
 #include "uct/dynkomi.h"
+#include "uct/policy.h"
 #include "uct/uct.h"
 #include "uct/walk.h"
 #include "dcnn/dcnn.h"

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -306,14 +306,14 @@ static int
 uct_leaf_node(uct_t *u, board_t *b, enum stone player_color,
               playout_amafmap_t *amaf,
               tree_t *t, tree_node_t *n, enum stone node_color,
-	      char *spaces)
+	      int spaces)
 {
 	enum stone next_color = stone_other(node_color);
 	int parity = (next_color == player_color ? 1 : -1);
 
 	if (UDEBUGL(7))
-		fprintf(stderr, "%s*-- UCT playout #%d start [%s] %f\n",
-			spaces, n->u.playouts, coord2sstr(node_coord(n)),
+		fprintf(stderr, "%*s*-- UCT playout #%d start [%s] %f\n",
+			spaces, "", n->u.playouts, coord2sstr(node_coord(n)),
 			tree_node_get_value(t, -parity, n->u.value));
 
 	playout_setup_t ps = playout_setup(u->gamelen, u->mercymin);
@@ -325,8 +325,8 @@ uct_leaf_node(uct_t *u, board_t *b, enum stone player_color,
 		result = - result;
 	}
 	if (UDEBUGL(7))
-		fprintf(stderr, "%s -- [%d..%d] %s random playout result %d\n",
-		        spaces, player_color, next_color, coord2sstr(node_coord(n)), result);
+		fprintf(stderr, "%*s -- [%d..%d] %s random playout result %d\n",
+		        spaces, "", player_color, next_color, coord2sstr(node_coord(n)), result);
 
 	return result;
 }
@@ -387,7 +387,6 @@ uct_playout_descent(uct_t *u, board_t *b, enum stone player_color, tree_t *t, in
 	/* Tree descent */
 	/* XXX: This is somewhat messy since @n and descent.node are redundant. */
 	uct_descent_t descent;  descent.node = n;
-	int dlen = 1;
 	/* The last "significant" node along the descent (i.e. node
 	 * with higher than configured number of playouts). For black
 	 * and white. */
@@ -399,15 +398,12 @@ uct_playout_descent(uct_t *u, board_t *b, enum stone player_color, tree_t *t, in
 	int passes = is_pass(last_move(b).coord) && b->moves > 0;
 
 	/* debug */
-	static char spaces[] = "\0                                                      ";
+	int spaces = 0;
 	/* /debug */
 	if (UDEBUGL(8))
 		fprintf(stderr, "--- (#%d) UCT walk with color %d\n", t->root->u.playouts, player_color);
 
 	while (!tree_leaf_node(n) && passes < 2) {
-		spaces[dlen - 1] = ' '; spaces[dlen] = 0;
-
-
 		/*** Choose a node to descend to: */
 
 		/* Parity is chosen already according to the child color, since
@@ -427,11 +423,11 @@ uct_playout_descent(uct_t *u, board_t *b, enum stone player_color, tree_t *t, in
 			significant[node_color - 1] = descent.node;
 
 		n = descent.node;
-		dlen++;
+		spaces++;
 		assert(n == t->root || n->parent);
 		if (UDEBUGL(7))
-			fprintf(stderr, "%s+-- UCT sent us to [%s:%d] %d,%f\n",
-			        spaces, coord2sstr(node_coord(n)),
+			fprintf(stderr, "%*s+-- UCT sent us to [%s:%d] %d,%f\n",
+			        spaces, "", coord2sstr(node_coord(n)),
 				node_coord(n), n->u.playouts,
 				tree_node_get_value(t, parity, n->u.value));
 

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -21,6 +21,7 @@
 #include "uct/uct.h"
 #include "uct/walk.h"
 #include "uct/prior.h"
+#include "uct/policy.h"
 #include "gogui.h"
 
 

--- a/uct/walk.c
+++ b/uct/walk.c
@@ -386,8 +386,7 @@ uct_playout_descent(uct_t *u, board_t *b, enum stone player_color, tree_t *t, in
 		tree_expand_node(t, n, b, player_color, u, 1);
 	
 	/* Tree descent */
-	/* XXX: This is somewhat messy since @n and descent.node are redundant. */
-	uct_descent_t descent;  descent.node = n;
+	
 	/* The last "significant" node along the descent (i.e. node
 	 * with higher than configured number of playouts). For black
 	 * and white. */
@@ -413,17 +412,15 @@ uct_playout_descent(uct_t *u, board_t *b, enum stone player_color, tree_t *t, in
 		int parity = (node_color == player_color ? 1 : -1);
 
 		if (!u->random_policy_chance || fast_random(u->random_policy_chance))
-			u->policy->descend(u->policy, t, &descent, parity, u->allow_pass);
+			n = u->policy->descend(u->policy, t, n, parity, u->allow_pass);
 		else
-			u->random_policy->descend(u->random_policy, t, &descent, parity, u->allow_pass);
-
+			n = u->random_policy->descend(u->random_policy, t, n, parity, u->allow_pass);
 
 		/*** Perform the descent: */
 
-		if (descent.node->u.playouts >= u->significant_threshold)
-			significant[node_color - 1] = descent.node;
+		if (n->u.playouts >= u->significant_threshold)
+			significant[node_color - 1] = n;
 
-		n = descent.node;
 		spaces++;
 		assert(n == t->root || n->parent);
 		if (UDEBUGL(7))


### PR DESCRIPTION
Fixed crashes with UCB1 policy (not default). Looks like it's been broken for a long time.
Also fixed urgency calculation, looks like it's working now.

Rewrote UCB1 prior handling to keep with spirit of the original formula:
Using parent prior playouts seems dubious here.
We want log(total playouts) in the formula. For real playouts it works:
```
  node->u.playouts = total playouts going through this node
                   = sum(playouts) for all children
```

But `node->prior.playouts` has no relation to children prior playouts.
If we treat prior as added playouts we should sum over children prior playouts.

Also clean up unused descent data structures.